### PR TITLE
[feature] Block pushes when a PR's core changes survive mutation (local pre-push --in-diff)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -20,19 +20,24 @@ status=0
 while read -r _local_ref local_sha _remote_ref remote_sha; do
   [ "$local_sha" = "$zero" ] && continue # branch deletion — nothing to mutate
   if [ "$remote_sha" = "$zero" ]; then
-    # New branch on the remote: diff against the integration branch. If it is
-    # not present locally (e.g. a fresh clone that has not fetched it) we cannot
-    # compute a base — warn and skip rather than block every push on a setup
-    # gap. CI and manual mutation (#2) still cover it.
-    if ! base="$(git merge-base "$local_sha" "$integration" 2>/dev/null)"; then
-      echo "pre-push: cannot resolve base '$integration' — skipping mutation gate." \
-        "Fetch it, or set: git config blendtutor.mutants.base <ref>" >&2
-      continue
-    fi
+    # New branch on the remote: diff against the integration branch.
+    base="$(git merge-base "$local_sha" "$integration" 2>/dev/null || true)"
   else
     # Updating an existing branch: diff only the commits being pushed.
     base="$remote_sha"
   fi
+
+  # Fail open on a base we cannot resolve — the integration branch was never
+  # fetched (new branch), or a remote sha was gc'd / force-pushed away (existing
+  # branch). A setup/sync gap is not a surviving mutant, and CI + manual mutation
+  # (#2) still cover it. Both ref kinds funnel through this one check, so the
+  # behavior is symmetric.
+  if [ -z "$base" ] || ! git rev-parse --verify --quiet "$base^{commit}" >/dev/null; then
+    echo "pre-push: cannot resolve a base to diff against — skipping mutation gate." \
+      "Fetch the integration branch, or set: git config blendtutor.mutants.base <ref>" >&2
+    continue
+  fi
+
   # </dev/null: the gate (and cargo under it) must not consume the ref lines
   # git is feeding this loop on stdin.
   "$root/scripts/check-mutants-diff.sh" "$base" </dev/null || status=1

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -20,8 +20,15 @@ status=0
 while read -r _local_ref local_sha _remote_ref remote_sha; do
   [ "$local_sha" = "$zero" ] && continue # branch deletion — nothing to mutate
   if [ "$remote_sha" = "$zero" ]; then
-    # New branch on the remote: diff against the integration branch.
-    base="$(git merge-base "$local_sha" "$integration" 2>/dev/null || echo "$integration")"
+    # New branch on the remote: diff against the integration branch. If it is
+    # not present locally (e.g. a fresh clone that has not fetched it) we cannot
+    # compute a base — warn and skip rather than block every push on a setup
+    # gap. CI and manual mutation (#2) still cover it.
+    if ! base="$(git merge-base "$local_sha" "$integration" 2>/dev/null)"; then
+      echo "pre-push: cannot resolve base '$integration' — skipping mutation gate." \
+        "Fetch it, or set: git config blendtutor.mutants.base <ref>" >&2
+      continue
+    fi
   else
     # Updating an existing branch: diff only the commits being pushed.
     base="$remote_sha"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# pre-push: block pushing core changes that leave a surviving mutant (issue #24).
+#
+# A thin shell (ADR-0002): for each ref being pushed it works out the base to
+# diff against and delegates the actual gate to scripts/check-mutants-diff.sh,
+# which runs `cargo mutants --in-diff` scoped to core. Bypass deliberately with:
+#   git push --no-verify
+#
+# git feeds "<local ref> <local sha> <remote ref> <remote sha>" lines on stdin.
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+zero="0000000000000000000000000000000000000000"
+
+# Branch to diff a brand-new (not-yet-pushed) branch against. Override per repo:
+#   git config blendtutor.mutants.base <ref>
+integration="$(git config blendtutor.mutants.base || echo origin/staging/rewrite-in-rust-lol)"
+
+status=0
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+  [ "$local_sha" = "$zero" ] && continue # branch deletion — nothing to mutate
+  if [ "$remote_sha" = "$zero" ]; then
+    # New branch on the remote: diff against the integration branch.
+    base="$(git merge-base "$local_sha" "$integration" 2>/dev/null || echo "$integration")"
+  else
+    # Updating an existing branch: diff only the commits being pushed.
+    base="$remote_sha"
+  fi
+  "$root/scripts/check-mutants-diff.sh" "$base" || status=1
+done
+
+exit "$status"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -33,7 +33,9 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
     # Updating an existing branch: diff only the commits being pushed.
     base="$remote_sha"
   fi
-  "$root/scripts/check-mutants-diff.sh" "$base" || status=1
+  # </dev/null: the gate (and cargo under it) must not consume the ref lines
+  # git is feeding this loop on stdin.
+  "$root/scripts/check-mutants-diff.sh" "$base" </dev/null || status=1
 done
 
 exit "$status"

--- a/docs/adr/0002-git-hook-mechanism.md
+++ b/docs/adr/0002-git-hook-mechanism.md
@@ -1,0 +1,57 @@
+# ADR-0002: Git hook mechanism — committed `.githooks/` linked into `.git/hooks`
+
+- Status: Accepted
+- Date: 2026-06-06
+
+## Context
+
+Issue #24 adds a blocking **pre-push** gate that runs `cargo mutants --in-diff`
+on a branch's changed `core` lines (see ADR-0001 for the `core`/`cli` split).
+For a gate to be useful it must be shared: every clone should get the same hook,
+and it should be reviewable like any other code. Git's default hook directory,
+`.git/hooks/`, is per-clone and not version-controlled, so a hook dropped there
+is invisible to the rest of the team and drifts silently.
+
+A second constraint is specific to this repo: a machine-local `post-commit` hook
+(the roborev review gate) already lives in `.git/hooks/`. The mechanism we pick
+must not disable it.
+
+## Options
+
+1. **`git config core.hooksPath .githooks`** — point git at a committed
+   directory. Simplest config. But `core.hooksPath` *replaces* `.git/hooks`
+   entirely: git then runs hooks **only** from the configured path, so the
+   existing per-developer `post-commit` (roborev) hook would silently stop
+   firing unless it too were committed into `.githooks/` — which would force
+   roborev on every contributor, who may not use it.
+2. **Committed `.githooks/` + a symlink-install script** — hook *sources* are
+   version-controlled in `.githooks/`; `scripts/install-hooks.sh` symlinks each
+   into `.git/hooks/`. The links stay live (editing the source updates the
+   active hook), and unmanaged hooks already in `.git/hooks/` (roborev's
+   `post-commit`) keep working alongside them.
+3. **Hook manager (lefthook / pre-commit / cargo-husky)** — feature-rich;
+   `cargo-husky` is Rust-native and installs hooks on first build. Adds a
+   dependency and, for cargo-husky, a build-time side effect, for a single hook.
+
+## Decision
+
+Option 2. Commit hook sources under `.githooks/`, and provide an idempotent
+`scripts/install-hooks.sh` that symlinks them into `.git/hooks/`. Setup is a
+one-time `bash scripts/install-hooks.sh` per clone, documented in the README.
+
+Rejected `core.hooksPath` because it would disable the existing roborev
+`post-commit` hook (the crux above); rejected a hook manager to avoid a
+dependency and build-time side effect for one hook.
+
+## Consequences
+
+- The roborev `post-commit` hook and the new `pre-push` hook coexist — the
+  reason to pay the symlink-install cost over the simpler `core.hooksPath`.
+- Hook logic is version-controlled and reviewed like any code; the live hook is
+  a symlink, so source edits take effect with no re-install.
+- Setup is not automatic on clone — it needs the one-time install command. CI
+  does not run it (CI gates are separate; #2). Documented in the README.
+- Symlink install assumes a platform with symlinks (macOS/Linux); a Windows
+  contributor would need the copy fallback. Acceptable for the current team.
+- The thin hook delegates to `scripts/check-mutants-diff.sh`, so the gate logic
+  stays testable without git's push machinery (ADR-0001 boundary discipline).

--- a/docs/agent-notes/workspace-and-ci.md
+++ b/docs/agent-notes/workspace-and-ci.md
@@ -48,3 +48,17 @@ How the Rust workspace, tests, and CI fit together (Slice 1 walking skeleton).
   cargo-mutants step is `continue-on-error`); the job summary reports "clean"
   only when the step exited 0, so a crashed run cannot masquerade as
   no-survivors.
+- 2026-06-06 (#24): **One-time dev setup** — run `bash scripts/install-hooks.sh`
+  to enable the pre-push mutation gate. It symlinks `.githooks/*` into
+  `.git/hooks/` (per ADR-0002; not `core.hooksPath`, which would disable the
+  roborev `post-commit` hook). Re-run after pulling new hooks.
+- 2026-06-06 (#24): The pre-push hook runs `cargo mutants --in-diff` over the
+  pushed range so only a branch's **changed core lines** are mutated — fast
+  enough to gate every push, unlike the whole-crate CI run (#2). A survivor
+  blocks the push; `git push --no-verify` bypasses it. The thin `.githooks/
+  pre-push` delegates to `scripts/check-mutants-diff.sh <base>` (testable
+  without git's push machinery). Base = `merge-base` with the integration
+  branch (`git config blendtutor.mutants.base`, default
+  `origin/staging/rewrite-in-rust-lol`) for a new branch, else the remote sha.
+  If the base can't be resolved (integration branch not fetched) the hook
+  **warns and skips** rather than blocking — a setup gap is not a survivor.

--- a/scripts/check-mutants-diff.sh
+++ b/scripts/check-mutants-diff.sh
@@ -13,7 +13,16 @@ set -euo pipefail
 
 base="${1:?usage: check-mutants-diff.sh <base-ref>}"
 
-diff="$(git diff --no-color "$base"...HEAD)"
+# Fail loudly (and block) on a bad base ref rather than emitting a raw git error
+# or, worse, silently skipping the gate.
+if ! git rev-parse --verify --quiet "$base^{commit}" >/dev/null; then
+  echo "mutants(in-diff): base ref '$base' is not a valid commit" >&2
+  exit 2
+fi
+
+# --no-ext-diff / --no-color keep the output a clean unified diff regardless of
+# the user's diff.external or textconv config, which --in-diff must parse.
+diff="$(git diff --no-color --no-ext-diff "$base"...HEAD)"
 if [ -z "$diff" ]; then
   echo "mutants(in-diff): no commits vs $base — nothing to check"
   exit 0
@@ -25,5 +34,6 @@ printf '%s\n' "$diff" >"$tmp"
 
 echo "mutants(in-diff): mutating changed core lines since $base …"
 # Exit status propagates: cargo-mutants returns nonzero when a mutant survives,
-# which blocks the push. With no core mutants in the diff it returns 0 (fast).
+# which blocks the push. When the diff touches no core mutants it returns 0
+# (nothing to test — no per-mutant builds).
 cargo mutants --in-diff "$tmp"

--- a/scripts/check-mutants-diff.sh
+++ b/scripts/check-mutants-diff.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Block a push when the pushed `core` changes leave a surviving mutant.
+#
+# Issue #24: mutation testing as a per-push gate. Runs `cargo mutants --in-diff`
+# over the range being pushed (<base>...HEAD), so only the lines this branch
+# adds/changes are mutated; `.cargo/mutants.toml` (#2) further scopes mutation to
+# the `core` crate. A surviving mutant means a changed core branch that no test
+# pins — the push is blocked (nonzero exit). `git push --no-verify` bypasses it.
+#
+# Thin enough to call from .githooks/pre-push, and runnable by hand:
+#   scripts/check-mutants-diff.sh origin/staging/rewrite-in-rust-lol
+set -euo pipefail
+
+base="${1:?usage: check-mutants-diff.sh <base-ref>}"
+
+diff="$(git diff --no-color "$base"...HEAD)"
+if [ -z "$diff" ]; then
+  echo "mutants(in-diff): no commits vs $base — nothing to check"
+  exit 0
+fi
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+printf '%s\n' "$diff" >"$tmp"
+
+echo "mutants(in-diff): mutating changed core lines since $base …"
+# Exit status propagates: cargo-mutants returns nonzero when a mutant survives,
+# which blocks the push. With no core mutants in the diff it returns 0 (fast).
+cargo mutants --in-diff "$tmp"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Install repo-managed git hooks (issue #24, ADR-0002). Idempotent — re-run
+# after pulling new hooks.
+#
+# Symlinks each file in .githooks/ into the repo's hooks directory so the
+# version-controlled source stays the live hook. We deliberately do NOT set
+# core.hooksPath: that would replace .git/hooks wholesale and disable other
+# locally-installed hooks (e.g. the roborev post-commit gate). Symlinking
+# coexists with them.
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+src="$root/.githooks"
+dst="$(git rev-parse --git-path hooks)" # absolute or repo-relative hooks dir
+mkdir -p "$dst"
+
+for hook in "$src"/*; do
+  [ -e "$hook" ] || continue
+  name="$(basename "$hook")"
+  # Target is relative to the symlink's location (.git/hooks/), so the link
+  # survives the repo being moved.
+  ln -sf "../../.githooks/$name" "$dst/$name"
+  echo "installed $name -> .githooks/$name"
+done

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -17,8 +17,11 @@ mkdir -p "$dst"
 for hook in "$src"/*; do
   [ -e "$hook" ] || continue
   name="$(basename "$hook")"
-  # Target is relative to the symlink's location (.git/hooks/), so the link
-  # survives the repo being moved.
-  ln -sf "../../.githooks/$name" "$dst/$name"
+  # Absolute target: correct regardless of where the hooks dir sits — a
+  # worktree's hooks live under .git/worktrees/<name>/, not two levels below the
+  # root, so a fixed-depth relative link would dangle there. Each clone runs
+  # this locally, so the machine-specific path is fine; re-run after moving the
+  # repo.
+  ln -sf "$src/$name" "$dst/$name"
   echo "installed $name -> .githooks/$name"
 done

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -19,19 +19,22 @@ for hook in "$src"/*; do
   # symlinked in as a broken hook.
   [ -x "$hook" ] || continue
   name="$(basename "$hook")"
-  # Don't clobber a real (non-symlink) hook a developer installed by hand: warn
-  # and leave it. An existing symlink is ours to refresh (keeps this idempotent).
-  if [ -e "$dst/$name" ] && [ ! -L "$dst/$name" ]; then
-    echo "install-hooks: $dst/$name exists and is not a symlink — leaving it;" \
-      "remove it to manage $name via .githooks" >&2
-    continue
-  fi
   # Absolute target so the link always resolves: `git rev-parse --git-path
   # hooks` can return a hooks dir whose depth below the repo root varies
   # (gitfile or submodule layouts, a relocated common dir, or invocation from a
   # subdirectory), where a fixed-depth ../../ relative target would dangle. Each
   # clone runs this locally, so the machine-specific path is fine; re-run after
   # moving the repo.
-  ln -sf "$src/$name" "$dst/$name"
+  target="$src/$name"
+  dest="$dst/$name"
+  # Manage only our own link. If something is already there and it is not our
+  # link — a real file, or a symlink pointing elsewhere (incl. a dangling one) —
+  # leave it untouched with a warning. Our own link is refreshed (idempotent).
+  if { [ -e "$dest" ] || [ -L "$dest" ]; } && [ "$(readlink "$dest" 2>/dev/null || true)" != "$target" ]; then
+    echo "install-hooks: $dest already exists and is not our link — leaving it;" \
+      "remove it to manage $name via .githooks" >&2
+    continue
+  fi
+  ln -sf "$target" "$dest"
   echo "installed $name -> .githooks/$name"
 done

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -17,11 +17,12 @@ mkdir -p "$dst"
 for hook in "$src"/*; do
   [ -e "$hook" ] || continue
   name="$(basename "$hook")"
-  # Absolute target: correct regardless of where the hooks dir sits — a
-  # worktree's hooks live under .git/worktrees/<name>/, not two levels below the
-  # root, so a fixed-depth relative link would dangle there. Each clone runs
-  # this locally, so the machine-specific path is fine; re-run after moving the
-  # repo.
+  # Absolute target so the link always resolves: `git rev-parse --git-path
+  # hooks` can return a hooks dir whose depth below the repo root varies
+  # (gitfile or submodule layouts, a relocated common dir, or invocation from a
+  # subdirectory), where a fixed-depth ../../ relative target would dangle. Each
+  # clone runs this locally, so the machine-specific path is fine; re-run after
+  # moving the repo.
   ln -sf "$src/$name" "$dst/$name"
   echo "installed $name -> .githooks/$name"
 done

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -19,6 +19,13 @@ for hook in "$src"/*; do
   # symlinked in as a broken hook.
   [ -x "$hook" ] || continue
   name="$(basename "$hook")"
+  # Don't clobber a real (non-symlink) hook a developer installed by hand: warn
+  # and leave it. An existing symlink is ours to refresh (keeps this idempotent).
+  if [ -e "$dst/$name" ] && [ ! -L "$dst/$name" ]; then
+    echo "install-hooks: $dst/$name exists and is not a symlink — leaving it;" \
+      "remove it to manage $name via .githooks" >&2
+    continue
+  fi
   # Absolute target so the link always resolves: `git rev-parse --git-path
   # hooks` can return a hooks dir whose depth below the repo root varies
   # (gitfile or submodule layouts, a relocated common dir, or invocation from a

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -15,7 +15,9 @@ dst="$(git rev-parse --git-path hooks)" # absolute or repo-relative hooks dir
 mkdir -p "$dst"
 
 for hook in "$src"/*; do
-  [ -e "$hook" ] || continue
+  # Only executable files are hooks — skip docs or stray files so they are not
+  # symlinked in as a broken hook.
+  [ -x "$hook" ] || continue
   name="$(basename "$hook")"
   # Absolute target so the link always resolves: `git rev-parse --git-path
   # hooks` can return a hooks dir whose depth below the repo root varies


### PR DESCRIPTION
## Summary
- Add a **local, blocking pre-push gate** that runs `cargo mutants --in-diff` over a branch's changed lines (scoped to `core` via #2's `.cargo/mutants.toml`). A surviving mutant on changed core code blocks the push; `git push --no-verify` bypasses.
- Ship the hook as a version-controlled `.githooks/pre-push` + an idempotent `scripts/install-hooks.sh` (symlink install), so it coexists with the existing roborev `post-commit` hook (ADR-0002).
- Keep slow whole-crate mutation off CI — that stays the non-gating workflow from #2; this gate is fast because `--in-diff` only mutates the lines a PR touches.

## Issue
Closes #24

## Slices implemented
- **AC1 — uncovered changed core line blocks the push.** `scripts/check-mutants-diff.sh` diffs `<base>...HEAD` and runs `cargo mutants --in-diff`; cargo-mutants' nonzero exit on a survivor propagates out. Verified: a throwaway uncovered `pub fn is_even` produced 5 MISSED mutants at `crates/core/src/lib.rs:52` and the gate exited 2 (blocked); `--in-diff` mutated only the changed line.
- **AC2 — covered / non-core change passes fast.** A script-only diff reports "Diff changes no Rust source files" → exit 0. An empty range short-circuits before invoking cargo-mutants.
- **AC3 — version-controlled hook + one-time setup.** `bash scripts/install-hooks.sh` symlinks `.githooks/pre-push` into `.git/hooks/` (absolute target; coexists with roborev `post-commit` — verified). Dogfooded: this very push fired the hook live (passed, no core changes). `git config blendtutor.mutants.base <ref>` overrides the integration base.

## Design / decisions
- **ADR-0002** records why the hook ships via `.githooks/` + symlink-install rather than `core.hooksPath` — the latter replaces `.git/hooks` wholesale and would silently disable the roborev `post-commit` gate.
- **Boundary cut (§3):** thin `.githooks/pre-push` → testable `scripts/check-mutants-diff.sh`. The gate logic is exercisable without git's push machinery.
- **Fail-open on setup gaps:** if the integration base can't be resolved (fresh clone, not fetched), the hook **warns and skips** rather than blocking every push — a setup gap isn't a surviving mutant. Direct script invocation stays strict (bad base → exit 2).

## Notes / follow-ups
- **Deferred (roborev):** a stubbed-`cargo` bats regression test for the gate's exit-code paths and the hook's base computation. Behavior is demonstrated (AC1/AC2 negative controls) + dogfooded; adding a bats harness is optional infra the repo doesn't yet have. Worth a follow-up issue.
- Depends on #2 (merged). Base branch is `staging/rewrite-in-rust-lol`.

## Test plan
- [x] nextest / clippy / fmt clean (no Rust code changed; tooling only)
- [x] AC1 blocks (5 survivors → exit 2), AC2 passes (exit 0), AC3 installs + dogfooded on push
- [x] Hook coexists with roborev post-commit; fail-open on unresolvable base verified
- [x] Roborev findings resolved (clean on HEAD)
- [x] ADR-0002 written
- [x] Rodney verification (N/A — not UI-touching)