### PR TITLE
[ci] Bump GitHub Actions off deprecated Node 20 before 2026-06-16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     name: fmt · clippy · nextest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # rust-toolchain.toml pins the channel and the rustfmt/clippy components;
       # rustup installs them on first cargo use, so the file is the single source

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
     name: build site (mdBook + rustdoc)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # rust-toolchain.toml is the single source of truth for the toolchain
       # (channel + components); rustup installs it on first cargo use. See ci.yml.
@@ -68,7 +68,7 @@ jobs:
           cp -R target/doc docs/book/book/api
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/book/book
 
@@ -88,4 +88,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -32,7 +32,7 @@ jobs:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'mutation')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # rust-toolchain.toml is the single source of truth for the toolchain
       # (channel + rustfmt/clippy); see ci.yml.


### PR DESCRIPTION
## Summary
Bump pinned `actions/*` off Node 20 ahead of GitHub's 2026-06-16 forced Node 24 cutover, so CI, mutation testing, and the docs build+deploy keep working.

## Issue
Closes #27

## Changes
- `actions/checkout` v4 → v5 (ci.yml, mutants.yml, docs.yml)
- `actions/upload-pages-artifact` v3 → v5 (docs.yml)
- `actions/deploy-pages` v4 → v5 (docs.yml)

checkout pinned to v5 (first Node 24 major, minimal jump from v4); the Pages actions to v5 (matched generation). `Swatinem/rust-cache@v2` and `taiki-e/install-action@v2` were not flagged and are left as-is.

## Test plan
- [ ] CI green (fmt·clippy·nextest)
- [ ] Docs build+deploy green on the staging merge; live site still serves `/` and `/api/blendtutor_core/`
- [ ] `git grep -nE 'actions/(checkout@v4|upload-pages-artifact@v3|deploy-pages@v4)' .github/` returns nothing