### PR TITLE
[feature] Lesson model — parse, validate, JSON round-trip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
 name = "blendtutor-cli"
 version = "0.1.0"
 dependencies = [
@@ -142,6 +148,7 @@ dependencies = [
  "serde",
  "serde-saphyr",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -238,6 +245,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +327,12 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "memchr"
@@ -428,6 +457,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +558,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,7 @@ dependencies = [
  "blendtutor-core",
  "clap",
  "predicates",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,36 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
 ]
 
 [[package]]
@@ -68,6 +92,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +119,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "blendtutor-cli"
 version = "0.1.0"
 dependencies = [
@@ -102,6 +138,11 @@ dependencies = [
 [[package]]
 name = "blendtutor-core"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde-saphyr",
+ "serde_json",
+]
 
 [[package]]
 name = "bstr"
@@ -113,6 +154,18 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
@@ -167,12 +220,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "granit-parser"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50ba32164f9e098d5da618776a32afbb32270adcbe3d3d006107dae11e37c91"
+dependencies = [
+ "arraydeque",
+ "smallvec",
 ]
 
 [[package]]
@@ -188,6 +283,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +310,12 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "normalize-line-endings"
@@ -213,6 +331,12 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -269,6 +393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,12 +428,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde-saphyr"
+version = "0.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5897b4c3faadadd35fdb6689f015641f3bc481d5adaaac56231ea15aeb243db3"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64",
+ "encoding_rs_io",
+ "getrandom",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde",
+ "smallvec",
+ "zmij",
 ]
 
 [[package]]
@@ -325,6 +481,25 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "strsim"
@@ -356,10 +531,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -368,6 +555,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -384,3 +625,35 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +83,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "blendtutor-cli"
 version = "0.1.0"
 dependencies = [
@@ -81,6 +96,7 @@ dependencies = [
  "assert_cmd",
  "blendtutor-core",
  "clap",
+ "predicates",
 ]
 
 [[package]]
@@ -151,6 +167,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +200,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,7 +228,10 @@ checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
 dependencies = [
  "anstyle",
  "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]
@@ -226,10 +269,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ repository = "https://github.com/mcmullarkey/blendtutor"
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 assert_cmd = "2"
+predicates = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ predicates = "3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-saphyr = "0.0.27"
+tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 assert_cmd = "2"
 predicates = "3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde-saphyr = "0.0.27"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,3 +17,4 @@ clap = { workspace = true }
 [dev-dependencies]
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,3 +16,4 @@ clap = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }
+predicates = { workspace = true }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,0 +1,7 @@
+//! Subcommand handlers.
+//!
+//! Each module turns parsed arguments into a call to `blendtutor-core` and
+//! renders the result for the terminal. No domain logic lives here — that is
+//! `core`'s responsibility (the dependency only ever points cli → core).
+
+pub mod validate;

--- a/crates/cli/src/commands/validate.rs
+++ b/crates/cli/src/commands/validate.rs
@@ -1,0 +1,16 @@
+//! `blendtutor validate <path>` — load a lesson file and report whether it is
+//! valid, exiting zero on success and non-zero (with the specific problem) on
+//! failure.
+
+use std::path::Path;
+
+/// Load and validate the lesson at `path`, printing an OK line on success.
+///
+/// All parsing and validation live in `blendtutor-core`; on failure the typed
+/// `LoadError` propagates to `main`, which prints it to stderr and exits
+/// non-zero. The error's message names the offending field or rule.
+pub fn run(path: &Path) -> anyhow::Result<()> {
+    let lesson = blendtutor_core::lesson::read_lesson_file(path)?;
+    println!("OK: \"{}\" is a valid lesson", lesson.lesson_name.0);
+    Ok(())
+}

--- a/crates/cli/src/commands/validate.rs
+++ b/crates/cli/src/commands/validate.rs
@@ -11,6 +11,6 @@ use std::path::Path;
 /// non-zero. The error's message names the offending field or rule.
 pub fn run(path: &Path) -> anyhow::Result<()> {
     let lesson = blendtutor_core::lesson::read_lesson_file(path)?;
-    println!("OK: \"{}\" is a valid lesson", lesson.lesson_name.0);
+    println!("OK: \"{}\" is a valid lesson", lesson.lesson_name);
     Ok(())
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3,7 +3,11 @@
 //! A thin shell: parse arguments and delegate to `blendtutor-core`. No domain
 //! logic lives here.
 
+use std::path::PathBuf;
+
 use clap::{Parser, Subcommand};
+
+mod commands;
 
 /// Author and run interactive R and Python coding lessons with LLM feedback.
 #[derive(Parser)]
@@ -23,7 +27,10 @@ enum Commands {
     /// Create a new lesson from a template.
     New,
     /// Validate a lesson file against the schema.
-    Validate,
+    Validate {
+        /// Path to the lesson YAML file.
+        path: PathBuf,
+    },
     /// List the lessons discoverable in a course.
     List,
     /// Run a lesson interactively with LLM feedback.
@@ -37,11 +44,11 @@ enum Commands {
 impl Commands {
     /// The subcommand's canonical name, for user-facing messages. The match is
     /// exhaustive, so a new variant cannot silently skip getting a name.
-    const fn name(self) -> &'static str {
+    const fn name(&self) -> &'static str {
         match self {
             Commands::Init => "init",
             Commands::New => "new",
-            Commands::Validate => "validate",
+            Commands::Validate { .. } => "validate",
             Commands::List => "list",
             Commands::Run => "run",
             Commands::Eval => "eval",
@@ -52,5 +59,8 @@ impl Commands {
 
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
-    Err(blendtutor_core::NotYetImplemented::new(cli.command.name()).into())
+    match cli.command {
+        Commands::Validate { path } => commands::validate::run(&path),
+        other => Err(blendtutor_core::NotYetImplemented::new(other.name()).into()),
+    }
 }

--- a/crates/cli/tests/validate.rs
+++ b/crates/cli/tests/validate.rs
@@ -5,6 +5,8 @@
 //! validate, I see Y" behavior. Pure parse/validate rules are unit-tested in
 //! `blendtutor-core`.
 
+use std::io::Write;
+
 use assert_cmd::Command;
 
 /// The ported example lesson, valid and complete. Lives under `core`'s fixtures
@@ -24,4 +26,22 @@ fn validate_valid_lesson_reports_ok_and_exit_zero() {
         .success()
         // Word-bounded so a stray "invalid" in error text can't masquerade as a pass.
         .stdout(predicates::str::is_match(r"(?i)\bOK\b|\bvalid\b").unwrap());
+}
+
+#[test]
+fn validate_invalid_lesson_exits_nonzero_naming_problem() {
+    // A lesson missing the required `exercise.llm_evaluation_prompt`.
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    file.write_all(
+        b"lesson_name: \"Adder\"\nlanguage: R\nexercise:\n  prompt: \"Write add_two\"\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("blendtutor")
+        .unwrap()
+        .arg("validate")
+        .arg(file.path())
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("llm_evaluation_prompt"));
 }

--- a/crates/cli/tests/validate.rs
+++ b/crates/cli/tests/validate.rs
@@ -9,8 +9,10 @@ use assert_cmd::Command;
 
 /// The ported example lesson, valid and complete. Lives under `core`'s fixtures
 /// (the schema's home) and is referenced cross-crate by path.
-const VALID_LESSON: &str =
-    concat!(env!("CARGO_MANIFEST_DIR"), "/../core/tests/fixtures/lessons/add_two_numbers.yaml");
+const VALID_LESSON: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../core/tests/fixtures/lessons/add_two_numbers.yaml"
+);
 
 #[test]
 fn validate_valid_lesson_reports_ok_and_exit_zero() {

--- a/crates/cli/tests/validate.rs
+++ b/crates/cli/tests/validate.rs
@@ -20,5 +20,6 @@ fn validate_valid_lesson_reports_ok_and_exit_zero() {
         .arg(VALID_LESSON)
         .assert()
         .success()
-        .stdout(predicates::str::is_match("(?i)OK|valid").unwrap());
+        // Word-bounded so a stray "invalid" in error text can't masquerade as a pass.
+        .stdout(predicates::str::is_match(r"(?i)\bOK\b|\bvalid\b").unwrap());
 }

--- a/crates/cli/tests/validate.rs
+++ b/crates/cli/tests/validate.rs
@@ -1,0 +1,24 @@
+//! Integration tests for `blendtutor validate`.
+//!
+//! Exercises the command end to end via the built binary (`assert_cmd`),
+//! observing exit status and user-facing output — the slice's "when I run
+//! validate, I see Y" behavior. Pure parse/validate rules are unit-tested in
+//! `blendtutor-core`.
+
+use assert_cmd::Command;
+
+/// The ported example lesson, valid and complete. Lives under `core`'s fixtures
+/// (the schema's home) and is referenced cross-crate by path.
+const VALID_LESSON: &str =
+    concat!(env!("CARGO_MANIFEST_DIR"), "/../core/tests/fixtures/lessons/add_two_numbers.yaml");
+
+#[test]
+fn validate_valid_lesson_reports_ok_and_exit_zero() {
+    Command::cargo_bin("blendtutor")
+        .unwrap()
+        .arg("validate")
+        .arg(VALID_LESSON)
+        .assert()
+        .success()
+        .stdout(predicates::str::is_match("(?i)OK|valid").unwrap());
+}

--- a/crates/cli/tests/validate.rs
+++ b/crates/cli/tests/validate.rs
@@ -45,3 +45,23 @@ fn validate_invalid_lesson_exits_nonzero_naming_problem() {
         .failure()
         .stderr(predicates::str::contains("llm_evaluation_prompt"));
 }
+
+#[test]
+fn validate_lesson_without_student_code_placeholder_exits_nonzero_naming_the_rule() {
+    // The other AC2 branch: llm_evaluation_prompt is present but lacks the
+    // {student_code} placeholder. The error must name the field and the rule.
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    file.write_all(
+        b"lesson_name: \"Adder\"\nlanguage: R\nexercise:\n  prompt: \"Write add_two\"\n  llm_evaluation_prompt: \"Grade the submission.\"\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("blendtutor")
+        .unwrap()
+        .arg("validate")
+        .arg(file.path())
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("llm_evaluation_prompt"))
+        .stderr(predicates::str::contains("{student_code}"));
+}

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -4,3 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde-saphyr = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -11,3 +11,4 @@ serde-saphyr = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/core/src/lesson.rs
+++ b/crates/core/src/lesson.rs
@@ -367,4 +367,33 @@ exercise:
             serde_json::from_str(&json).expect("lesson should deserialize from JSON");
         assert_eq!(roundtripped, original);
     }
+
+    #[test]
+    fn lesson_id_displays_its_value() {
+        let lesson = Lesson::parse(VALID_YAML).expect("valid lesson should parse");
+        assert_eq!(lesson.lesson_name.to_string(), "Adder");
+    }
+
+    #[test]
+    fn load_error_display_and_source_surface_the_cause() {
+        let invalid = LoadError::Invalid(ValidationError::MissingStudentCodePlaceholder);
+        assert!(
+            invalid.to_string().contains("{student_code}"),
+            "Invalid should display the validation message, got: {invalid}"
+        );
+        assert!(
+            std::error::Error::source(&invalid).is_some(),
+            "Invalid should expose the ValidationError as its source"
+        );
+
+        let read = LoadError::Read(std::io::Error::new(std::io::ErrorKind::NotFound, "nope"));
+        assert!(
+            read.to_string().contains("could not read"),
+            "Read should label itself a read failure, got: {read}"
+        );
+        assert!(
+            std::error::Error::source(&read).is_some(),
+            "Read should expose the io::Error as its source"
+        );
+    }
 }

--- a/crates/core/src/lesson.rs
+++ b/crates/core/src/lesson.rs
@@ -211,6 +211,7 @@ language: R
 description: "Add two numbers"
 textbook_reference: "Chapter 2"
 exercise:
+  type: "function_writing"
   prompt: "Write a function add_two(x, y)."
   code_template: "add_two <- function(x, y) {}"
   example_usage: "add_two(3, 5)  # 8"
@@ -238,6 +239,9 @@ exercise:
         let lesson = Lesson::parse(VALID_YAML).expect("valid lesson should parse");
         assert_eq!(lesson.lesson_name, LessonId("Adder".to_string()));
         assert_eq!(lesson.language, Language::R);
+        // The snake_case `type` value maps to the enum; the round-trip test then
+        // confirms this populated optional survives JSON unchanged.
+        assert_eq!(lesson.exercise.kind, Some(ExerciseKind::FunctionWriting));
     }
 
     #[test]

--- a/crates/core/src/lesson.rs
+++ b/crates/core/src/lesson.rs
@@ -38,27 +38,42 @@ pub enum Language {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LessonId(pub String);
 
+/// The kind of exercise a lesson poses.
+///
+/// An enum, not a string, so an unknown kind is rejected at the parse boundary
+/// rather than carried downstream (§1.2). The R package authors only
+/// function-writing exercises today; new variants are added as the runner gains
+/// support for them (Slice 9).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExerciseKind {
+    /// Write a function to a specification.
+    FunctionWriting,
+}
+
 /// The exercise a lesson poses.
 ///
 /// The two required prompts carry the learner-facing task and the grading
 /// template; the optional fields are authoring aids. `llm_evaluation_prompt`
 /// must contain the `{student_code}` placeholder — enforced by [`Lesson::parse`],
-/// not by this type alone.
+/// not by this type alone. Unknown keys are rejected (§1.3.1) so an author's
+/// typo in an optional field surfaces rather than silently dropping to `None`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Exercise {
     /// What the learner is asked to do. Required.
     pub prompt: String,
     /// The prompt sent to the LLM to grade a submission. Required; must contain
     /// the `{student_code}` placeholder.
     pub llm_evaluation_prompt: String,
+    /// The kind of exercise, from the YAML `type` key. Optional.
+    #[serde(rename = "type")]
+    pub kind: Option<ExerciseKind>,
     /// Optional starter code shown to the learner.
-    #[serde(default)]
     pub code_template: Option<String>,
     /// Optional example invocations.
-    #[serde(default)]
     pub example_usage: Option<String>,
     /// Optional human-readable success criteria.
-    #[serde(default)]
     pub success_criteria: Option<String>,
 }
 
@@ -67,6 +82,7 @@ pub struct Exercise {
 /// Construct one only through [`Lesson::parse`] — a value of this type is, by
 /// construction, structurally complete and semantically valid (ADR-0003).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Lesson {
     /// The lesson's identity (v1: its name). Required.
     pub lesson_name: LessonId,
@@ -75,10 +91,8 @@ pub struct Lesson {
     /// The exercise the lesson poses. Required.
     pub exercise: Exercise,
     /// Optional one-line summary.
-    #[serde(default)]
     pub description: Option<String>,
     /// Optional pointer to a textbook section.
-    #[serde(default)]
     pub textbook_reference: Option<String>,
 }
 
@@ -243,6 +257,80 @@ exercise:
         assert!(
             msg.contains("{student_code}"),
             "error should name the placeholder rule, got: {msg}"
+        );
+    }
+
+    const UNKNOWN_LANGUAGE_YAML: &str = r#"
+lesson_name: "Adder"
+language: Go
+exercise:
+  prompt: "Write a function add_two(x, y)."
+  llm_evaluation_prompt: "Grade this: {student_code}"
+"#;
+
+    const UNKNOWN_FIELD_YAML: &str = r#"
+lesson_name: "Adder"
+language: R
+descriptio: "typo'd optional field"
+exercise:
+  prompt: "Write a function add_two(x, y)."
+  llm_evaluation_prompt: "Grade this: {student_code}"
+"#;
+
+    #[test]
+    fn parse_rejects_unknown_language() {
+        let err = Lesson::parse(UNKNOWN_LANGUAGE_YAML)
+            .expect_err("an unknown language is not a valid lesson");
+        assert!(
+            err.to_string().contains("Go"),
+            "error should name the rejected language, got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_unknown_field_so_author_typos_surface() {
+        let err = Lesson::parse(UNKNOWN_FIELD_YAML)
+            .expect_err("a typo'd optional field must not be silently dropped");
+        assert!(
+            err.to_string().contains("descriptio"),
+            "error should name the unknown field, got: {err}"
+        );
+    }
+
+    #[test]
+    fn read_lesson_file_loads_and_parses_the_ported_fixture() {
+        let path = Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/lessons/add_two_numbers.yaml"
+        ));
+        let lesson = read_lesson_file(path).expect("ported fixture should load and validate");
+        assert_eq!(lesson.language, Language::R);
+        assert_eq!(lesson.exercise.kind, Some(ExerciseKind::FunctionWriting));
+    }
+
+    #[test]
+    fn read_lesson_file_missing_path_is_a_read_error_not_a_validation_error() {
+        let err = read_lesson_file(Path::new("/no/such/lesson.yaml"))
+            .expect_err("a missing file cannot load");
+        assert!(
+            matches!(err, LoadError::Read(_)),
+            "a missing file is a read error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn read_lesson_file_invalid_contents_is_a_validation_error() {
+        // Write a known-bad lesson to a temp path, then load it through the shell.
+        let path = std::env::temp_dir().join("blendtutor_invalid_lesson_test.yaml");
+        std::fs::write(&path, PROMPT_WITHOUT_PLACEHOLDER_YAML).unwrap();
+        let err = read_lesson_file(&path).expect_err("a {student_code}-less lesson is invalid");
+        let _ = std::fs::remove_file(&path);
+        assert!(
+            matches!(
+                err,
+                LoadError::Invalid(ValidationError::MissingStudentCodePlaceholder)
+            ),
+            "invalid contents should surface as a validation error, got: {err:?}"
         );
     }
 

--- a/crates/core/src/lesson.rs
+++ b/crates/core/src/lesson.rs
@@ -36,7 +36,13 @@ pub enum Language {
 /// (§1.4). In v1 it carries the `lesson_name` value; a distinct slug id arrives
 /// with lesson discovery (Slice 6, see ADR-0003).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LessonId(pub String);
+pub struct LessonId(String);
+
+impl fmt::Display for LessonId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
 
 /// The kind of exercise a lesson poses.
 ///

--- a/crates/core/src/lesson.rs
+++ b/crates/core/src/lesson.rs
@@ -287,6 +287,25 @@ exercise:
         );
     }
 
+    const UNKNOWN_EXERCISE_TYPE_YAML: &str = r#"
+lesson_name: "Adder"
+language: R
+exercise:
+  type: "essay_writing"
+  prompt: "Write a function add_two(x, y)."
+  llm_evaluation_prompt: "Grade this: {student_code}"
+"#;
+
+    #[test]
+    fn parse_rejects_unknown_exercise_type() {
+        let err = Lesson::parse(UNKNOWN_EXERCISE_TYPE_YAML)
+            .expect_err("an unknown exercise type is not a valid lesson");
+        assert!(
+            err.to_string().contains("essay_writing"),
+            "error should name the rejected exercise type, got: {err}"
+        );
+    }
+
     #[test]
     fn parse_rejects_unknown_field_so_author_typos_surface() {
         let err = Lesson::parse(UNKNOWN_FIELD_YAML)
@@ -320,11 +339,11 @@ exercise:
 
     #[test]
     fn read_lesson_file_invalid_contents_is_a_validation_error() {
-        // Write a known-bad lesson to a temp path, then load it through the shell.
-        let path = std::env::temp_dir().join("blendtutor_invalid_lesson_test.yaml");
-        std::fs::write(&path, PROMPT_WITHOUT_PLACEHOLDER_YAML).unwrap();
-        let err = read_lesson_file(&path).expect_err("a {student_code}-less lesson is invalid");
-        let _ = std::fs::remove_file(&path);
+        // A unique, auto-removed temp file (no fixed-path race, no leak on panic).
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut file, PROMPT_WITHOUT_PLACEHOLDER_YAML.as_bytes()).unwrap();
+        let err =
+            read_lesson_file(file.path()).expect_err("a {student_code}-less lesson is invalid");
         assert!(
             matches!(
                 err,

--- a/crates/core/src/lesson.rs
+++ b/crates/core/src/lesson.rs
@@ -1,0 +1,257 @@
+//! The lesson schema: a typed model and its validating parse boundary.
+//!
+//! Holds the [`Lesson`]/[`Exercise`] types, the [`Language`] enum, the
+//! [`LessonId`] newtype, and [`Lesson::parse`] — the only constructor, which
+//! deserializes a YAML document and then enforces the semantic rules (notably
+//! the `{student_code}` placeholder) so a constructed [`Lesson`] is valid by
+//! type (ADR-0003). This module does not execute code, call LLMs, or render
+//! output; that belongs to the runner, provider, and cli layers.
+
+use std::error::Error;
+use std::fmt;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+/// The literal placeholder a lesson's evaluation prompt must contain so the
+/// runner can splice the learner's submission into it before grading.
+const STUDENT_CODE_PLACEHOLDER: &str = "{student_code}";
+
+/// The language a lesson is authored in.
+///
+/// An enum rather than a free string, so an unknown language is rejected at the
+/// parse boundary instead of travelling downstream as data (§1.2). The variant
+/// names match the YAML/JSON spelling (`R`, `Python`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Language {
+    /// The R language.
+    R,
+    /// The Python language.
+    Python,
+}
+
+/// A lesson's stable identity.
+///
+/// A newtype over `String` so a lesson id is never confused with arbitrary text
+/// (§1.4). In v1 it carries the `lesson_name` value; a distinct slug id arrives
+/// with lesson discovery (Slice 6, see ADR-0003).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LessonId(pub String);
+
+/// The exercise a lesson poses.
+///
+/// The two required prompts carry the learner-facing task and the grading
+/// template; the optional fields are authoring aids. `llm_evaluation_prompt`
+/// must contain the `{student_code}` placeholder — enforced by [`Lesson::parse`],
+/// not by this type alone.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Exercise {
+    /// What the learner is asked to do. Required.
+    pub prompt: String,
+    /// The prompt sent to the LLM to grade a submission. Required; must contain
+    /// the `{student_code}` placeholder.
+    pub llm_evaluation_prompt: String,
+    /// Optional starter code shown to the learner.
+    #[serde(default)]
+    pub code_template: Option<String>,
+    /// Optional example invocations.
+    #[serde(default)]
+    pub example_usage: Option<String>,
+    /// Optional human-readable success criteria.
+    #[serde(default)]
+    pub success_criteria: Option<String>,
+}
+
+/// A single lesson: its identity, language, and exercise, with optional prose.
+///
+/// Construct one only through [`Lesson::parse`] — a value of this type is, by
+/// construction, structurally complete and semantically valid (ADR-0003).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Lesson {
+    /// The lesson's identity (v1: its name). Required.
+    pub lesson_name: LessonId,
+    /// The language the lesson is authored in. Required.
+    pub language: Language,
+    /// The exercise the lesson poses. Required.
+    pub exercise: Exercise,
+    /// Optional one-line summary.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Optional pointer to a textbook section.
+    #[serde(default)]
+    pub textbook_reference: Option<String>,
+}
+
+/// Why a YAML document is not a valid lesson.
+#[derive(Debug)]
+pub enum ValidationError {
+    /// The document is not structurally a lesson: a required field is missing,
+    /// a value has the wrong type, or the YAML is malformed. Carries the
+    /// underlying parser message, which names the offending field.
+    Parse(String),
+    /// `exercise.llm_evaluation_prompt` is present but lacks the literal
+    /// `{student_code}` placeholder, so a learner's submission could never be
+    /// inserted into it.
+    MissingStudentCodePlaceholder,
+}
+
+impl fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ValidationError::Parse(msg) => write!(f, "invalid lesson: {msg}"),
+            ValidationError::MissingStudentCodePlaceholder => write!(
+                f,
+                "exercise.llm_evaluation_prompt must contain the literal \
+                 {STUDENT_CODE_PLACEHOLDER} placeholder so the learner's \
+                 submission can be inserted",
+            ),
+        }
+    }
+}
+
+impl Error for ValidationError {}
+
+impl Lesson {
+    /// Parse a lesson from a YAML document.
+    ///
+    /// The pure parse boundary (§2.1, §1.3.1): it deserializes the document into
+    /// the typed model — a missing required field or wrong type yields
+    /// [`ValidationError::Parse`] naming the field — then runs
+    /// [`validate_semantics`](Lesson::validate_semantics) for the rules structure
+    /// alone cannot express. Returns a [`Lesson`] only if both succeed.
+    pub fn parse(yaml: &str) -> Result<Lesson, ValidationError> {
+        let lesson: Lesson =
+            serde_saphyr::from_str(yaml).map_err(|e| ValidationError::Parse(e.to_string()))?;
+        lesson.validate_semantics()?;
+        Ok(lesson)
+    }
+
+    /// Enforce the semantic rules that structure alone cannot.
+    ///
+    /// Currently a single rule: the evaluation prompt must contain the
+    /// `{student_code}` placeholder. Split from the structural deserialize so
+    /// each name covers its body (§5.1).
+    fn validate_semantics(&self) -> Result<(), ValidationError> {
+        if !self
+            .exercise
+            .llm_evaluation_prompt
+            .contains(STUDENT_CODE_PLACEHOLDER)
+        {
+            return Err(ValidationError::MissingStudentCodePlaceholder);
+        }
+        Ok(())
+    }
+}
+
+/// Why a lesson file could not be loaded.
+#[derive(Debug)]
+pub enum LoadError {
+    /// The file could not be read (missing, permissions, or not UTF-8).
+    Read(std::io::Error),
+    /// The file was read, but its contents are not a valid lesson.
+    Invalid(ValidationError),
+}
+
+impl fmt::Display for LoadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LoadError::Read(e) => write!(f, "could not read lesson file: {e}"),
+            LoadError::Invalid(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl Error for LoadError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            LoadError::Read(e) => Some(e),
+            LoadError::Invalid(e) => Some(e),
+        }
+    }
+}
+
+/// Read and parse a lesson from a file on disk.
+///
+/// The thin effectful shell over the pure [`Lesson::parse`] (§2.2): it performs
+/// the file read, then delegates all structure and validation to `parse`. The
+/// two failure modes stay distinct in the type so a read error is never
+/// mistaken for a validation error (§3.1).
+pub fn read_lesson_file(path: &Path) -> Result<Lesson, LoadError> {
+    let text = std::fs::read_to_string(path).map_err(LoadError::Read)?;
+    Lesson::parse(&text).map_err(LoadError::Invalid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID_YAML: &str = r#"
+lesson_name: "Adder"
+language: R
+description: "Add two numbers"
+textbook_reference: "Chapter 2"
+exercise:
+  prompt: "Write a function add_two(x, y)."
+  code_template: "add_two <- function(x, y) {}"
+  example_usage: "add_two(3, 5)  # 8"
+  success_criteria: "Returns the sum of its two arguments."
+  llm_evaluation_prompt: "Grade this submission:\n{student_code}\nReply with feedback."
+"#;
+
+    const MISSING_EVAL_PROMPT_YAML: &str = r#"
+lesson_name: "Adder"
+language: R
+exercise:
+  prompt: "Write a function add_two(x, y)."
+"#;
+
+    const PROMPT_WITHOUT_PLACEHOLDER_YAML: &str = r#"
+lesson_name: "Adder"
+language: R
+exercise:
+  prompt: "Write a function add_two(x, y)."
+  llm_evaluation_prompt: "Grade the student's submission and reply with feedback."
+"#;
+
+    #[test]
+    fn parse_accepts_valid_lesson() {
+        let lesson = Lesson::parse(VALID_YAML).expect("valid lesson should parse");
+        assert_eq!(lesson.lesson_name, LessonId("Adder".to_string()));
+        assert_eq!(lesson.language, Language::R);
+    }
+
+    #[test]
+    fn parse_rejects_missing_required_field_naming_it() {
+        let err = Lesson::parse(MISSING_EVAL_PROMPT_YAML)
+            .expect_err("a lesson without llm_evaluation_prompt is invalid");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("llm_evaluation_prompt"),
+            "error should name the missing field, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_prompt_missing_student_code_placeholder() {
+        let err = Lesson::parse(PROMPT_WITHOUT_PLACEHOLDER_YAML)
+            .expect_err("a prompt without {student_code} is invalid");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("llm_evaluation_prompt"),
+            "error should name the field, got: {msg}"
+        );
+        assert!(
+            msg.contains("{student_code}"),
+            "error should name the placeholder rule, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn lesson_json_roundtrip_preserves_value() {
+        let original = Lesson::parse(VALID_YAML).expect("valid lesson should parse");
+        let json = serde_json::to_string(&original).expect("lesson should serialize to JSON");
+        let roundtripped: Lesson =
+            serde_json::from_str(&json).expect("lesson should deserialize from JSON");
+        assert_eq!(roundtripped, original);
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,6 +14,8 @@
 // rustdoc warnings" — then holds unconditionally, not only under -D warnings.
 #![deny(missing_docs)]
 
+pub mod lesson;
+
 use std::error::Error;
 use std::fmt;
 

--- a/crates/core/tests/fixtures/lessons/add_two_numbers.yaml
+++ b/crates/core/tests/fixtures/lessons/add_two_numbers.yaml
@@ -1,0 +1,42 @@
+lesson_name: "Writing Your First Function"
+language: R
+description: "Learn to write a simple function that adds two numbers"
+textbook_reference: "Just Enough Software Engineering - Chapter 2: Functions"
+
+exercise:
+  type: "function_writing"
+  code_template: |
+    # Write a function called 'add_two' that adds two numbers
+    # Function should take parameters x and y
+    # Function should return their sum
+
+    add_two <- function(x, y) {
+      # Your code here
+
+    }
+  prompt: |
+    Write a function called 'add_two' that takes two numeric arguments
+    (x and y) and returns their sum.
+
+  example_usage: |
+    add_two(3, 5)  # should return 8
+    add_two(10, -2)  # should return 8
+
+  success_criteria: |
+    - Function is named 'add_two'
+    - Takes exactly 2 parameters
+    - Returns the sum of the parameters
+    - Handles numeric inputs correctly
+
+  llm_evaluation_prompt: |
+    You are evaluating student code for a software engineering course.
+
+    Exercise: Write a function called 'add_two' that takes two numeric
+    arguments and returns their sum.
+
+    Student submitted this code:
+    {student_code}
+
+    Evaluate the code and call the respond_with_feedback function with your assessment.
+    Set is_correct to true if the code meets all requirements, false otherwise.
+    Provide brief, encouraging feedback (2-3 sentences) in feedback_message.

--- a/docs/adr/0003-lesson-schema.md
+++ b/docs/adr/0003-lesson-schema.md
@@ -1,0 +1,76 @@
+# ADR-0003: Lesson schema — a typed model behind a validating parse boundary
+
+- Status: Accepted
+- Date: 2026-06-06
+
+## Context
+
+Issue #4 ports the R package's lesson YAML (`inst/lessons/add_two_numbers.yaml`)
+and its `validate_lesson()` (`R/educator_tools.R`) into the Rust `core`. The R
+side parses YAML into an untyped list and validates after the fact: required
+fields (`lesson_name`, `exercise.prompt`, `exercise.llm_evaluation_prompt`)
+*abort*, while the `{student_code}` placeholder rule only *warns*. Downstream R
+code then reaches into the list by string key, so a malformed lesson can travel
+far before failing.
+
+We need a representation for the Rust rewrite that the browser build (JSON) and
+`--format json` (Slice 5) can both consume, and that the runner (Slices 7–9) can
+trust without re-checking. The question is where validation lives and how the
+shape is typed.
+
+## Options
+
+1. **Untyped map + a `validate()` pass** (port R as-is) — `HashMap`-shaped
+   value, validated by a function that returns a list of warnings/errors.
+   Faithful to R, but every consumer re-derives structure by key lookup, illegal
+   states stay representable, and "valid" is a runtime property no type carries.
+2. **Typed model behind a `Lesson::parse(&str)` boundary** — required fields are
+   non-`Option`; `Language` is an enum; the lesson identity is a `LessonId`
+   newtype; semantic rules (the `{student_code}` placeholder) run inside `parse`
+   and return `Err(ValidationError)`. A constructed `Lesson` is, by construction,
+   valid — consumers receive the typed value, never the raw YAML (§1.1–§1.4,
+   §1.3.1).
+
+## Decision
+
+Option 2. `core::lesson` owns a typed `Lesson`/`Exercise` model, a `Language { R,
+Python }` enum (serialized as `R`/`Python` to match the YAML), and a `LessonId`
+newtype. `Lesson::parse(&str) -> Result<Lesson, ValidationError>` is the only
+constructor: it deserializes structure (serde) then runs `validate_semantics`
+(§5.1 split). File reading is a separate effectful `read_lesson_file` (§2.2);
+`parse` is pure and string-tested (§2.3).
+
+Two deltas from the R behavior, both deliberate:
+
+- **`{student_code}` is a hard error, not a warning.** Inserting student code is
+  the lesson's whole purpose; a prompt missing the placeholder is broken, so
+  `parse` refuses it at the boundary (§1.3.1) rather than warning and proceeding.
+- **`LessonId` carries the `lesson_name` value as the v1 identity.** The lesson
+  file has no separate id field, and a stable slug id belongs with discovery
+  (Slice 6, course dir + manifest). The newtype keeps a lesson's identity from
+  being confused with arbitrary strings now (§1.4); promoting it to a distinct
+  slug later is a localized change inside `lesson`.
+
+YAML is parsed with **`serde-saphyr`** (pure-Rust, no `unsafe`, line-numbered
+errors). `serde_yml` is rejected (RUSTSEC-2025-0068, unsound); `serde_yaml` is
+archived.
+
+Recorded forward shape (not realized in this slice): check/test bodies are
+code-strings executed by the runner (now native, later webR/Pyodide), and eval
+cases live in a sibling `eval_<lesson>.yaml` so lesson files stay
+learner-shippable. A future ADR locks those when Slices 7–12 implement them.
+
+## Consequences
+
+- A constructed `Lesson` is valid by type; the runner and the JSON seam consume
+  it without re-validating, and a representation change to the YAML stays inside
+  `core::lesson` (§3.2).
+- The public surface is small — `Lesson`, `parse`, `ValidationError`,
+  `read_lesson_file` (§4.3); `core::lesson` never executes code, calls LLMs, or
+  renders output (§4.1).
+- Unknown YAML keys (e.g. `exercise.type`) are ignored, not rejected, so the R
+  example ports unchanged; modelling them is deferred to the slice that needs
+  them rather than added speculatively.
+- Stricter than R: a `{student_code}`-less prompt that the R package merely
+  warned about now fails `validate`. This is the intended tightening, called out
+  here so the behavior change is not a surprise at cutover (Slice 20).

--- a/docs/adr/0003-lesson-schema.md
+++ b/docs/adr/0003-lesson-schema.md
@@ -65,12 +65,20 @@ learner-shippable. A future ADR locks those when Slices 7–12 implement them.
 - A constructed `Lesson` is valid by type; the runner and the JSON seam consume
   it without re-validating, and a representation change to the YAML stays inside
   `core::lesson` (§3.2).
-- The public surface is small — `Lesson`, `parse`, `ValidationError`,
-  `read_lesson_file` (§4.3); `core::lesson` never executes code, calls LLMs, or
-  renders output (§4.1).
-- Unknown YAML keys (e.g. `exercise.type`) are ignored, not rejected, so the R
-  example ports unchanged; modelling them is deferred to the slice that needs
-  them rather than added speculatively.
+- The entry points are few — `Lesson::parse` and `read_lesson_file`, returning
+  `ValidationError`/`LoadError`. The remaining public names (`Exercise`,
+  `Language`, `LessonId`, `ExerciseKind`) are the lesson value's own structure,
+  public because they are fields of a `Lesson` callers read and serialize, not
+  separate concerns — so the surface sits a little above the §4.3 ~5 soft
+  ceiling for a cohesive reason rather than from sprawl. `core::lesson` never
+  executes code, calls LLMs, or renders output (§4.1).
+- Unknown YAML keys are **rejected** (`#[serde(deny_unknown_fields)]`), so an
+  author's typo in an optional field (e.g. `descriptio`) fails `validate`
+  instead of silently dropping to `None` (§1.3.1) — the right trade for a
+  hand-authored, learner-shippable format. The one key the R example carries,
+  `exercise.type`, is therefore modelled as an `ExerciseKind` enum (one variant,
+  `function_writing`, matching today's lessons) rather than ignored; new kinds
+  are added as the runner supports them (Slice 9), not speculatively.
 - Stricter than R: a `{student_code}`-less prompt that the R package merely
   warned about now fails `validate`. This is the intended tightening, called out
   here so the behavior change is not a surprise at cutover (Slice 20).

--- a/docs/agent-notes/lesson-model.md
+++ b/docs/agent-notes/lesson-model.md
@@ -1,0 +1,53 @@
+---
+topic: lesson-model
+created: 2026-06-06
+slices: [4]
+---
+
+How the lesson schema is typed, parsed, and validated (`core::lesson`). See
+ADR-0003 for the decision record.
+
+- 2026-06-06 (#4): The lesson schema is a typed model in `crates/core/src/lesson.rs`,
+  not an untyped map. `Lesson::parse(&str) -> Result<Lesson, ValidationError>` is
+  the only constructor and the single validation boundary: a constructed `Lesson`
+  is valid by type, so the runner/JSON-seam consumers never re-validate. Required
+  fields (`lesson_name`, `exercise.prompt`, `exercise.llm_evaluation_prompt`) are
+  non-`Option` so a serde-default `None` cannot silently pass.
+- 2026-06-06 (#4): `parse` is split into two phases (§5.1): serde-saphyr
+  *deserialize* (structure — a missing required field yields
+  `ValidationError::Parse` whose message names the field, propagated from serde's
+  "missing field `…`") then `validate_semantics` (rules structure can't express).
+  Today the only semantic rule is the `{student_code}` placeholder.
+- 2026-06-06 (#4): The `{student_code}` rule is a **hard error** here, unlike the
+  R package's `validate_lesson()` which only *warns*. A prompt lacking the literal
+  `{student_code}` returns `Err(ValidationError::MissingStudentCodePlaceholder)`,
+  whose Display names both `llm_evaluation_prompt` and `{student_code}`. Tighter
+  than R on purpose (ADR-0003).
+- 2026-06-06 (#4): Both `Lesson` and `Exercise` carry `#[serde(deny_unknown_fields)]`,
+  so an author's typo in an *optional* field (e.g. `descriptio`) fails validation
+  instead of dropping to `None` (§1.3.1). Consequence: every YAML key the example
+  lessons use must be modelled — that's why `exercise.type` is modelled as the
+  `ExerciseKind` enum (one variant, `function_writing`) rather than ignored. Add a
+  variant when a new exercise kind appears (Slice 9), don't relax the deny.
+- 2026-06-06 (#4): `Language { R, Python }` and `ExerciseKind` are enums, not
+  strings (§1.2) — an unknown value is a parse error. `LessonId` is a newtype with
+  a **private** inner `String` + `Display`; print `lesson.lesson_name` directly,
+  never reach for `.0` (the CLI leak roborev caught). In v1 `LessonId` carries the
+  `lesson_name` value as the lesson's identity; a distinct slug id is deferred to
+  discovery (Slice 6).
+- 2026-06-06 (#4): Effectful/pure split (§2.2) — `read_lesson_file(&Path)` is the
+  thin shell that reads the file then calls the pure `parse`. Its `LoadError` keeps
+  read failures (`Read`) distinct from validation failures (`Invalid`) so a missing
+  file is never reported as a schema problem. The CLI maps `LoadError` into anyhow
+  at the edge via `?`; `core` stays anyhow-free.
+- 2026-06-06 (#4): Fixtures live under `crates/core/tests/fixtures/lessons/`
+  (the schema's home); the cli integration test references the ported
+  `add_two_numbers.yaml` cross-crate via
+  `concat!(env!("CARGO_MANIFEST_DIR"), "/../core/tests/fixtures/...")`. The
+  `validate` success line is `OK: "<name>" is a valid lesson` — CLI tests assert a
+  word-bounded `\bOK\b|\bvalid\b` on stdout so a stray "invalid" can't false-pass.
+- 2026-06-06 (#4): YAML crate is **`serde-saphyr`** (`serde_saphyr::from_str`);
+  do NOT use `serde_yml` (RUSTSEC-2025-0068) or the archived `serde_yaml`. JSON
+  round-trip (the browser-build / `--format json` bridge) uses `serde_json` and is
+  asserted by value (`assert_eq!` on the full struct), so a lossy/`skip` serializer
+  fails the test.


### PR DESCRIPTION
## Summary
- Adds `core::lesson`: a typed `Lesson` model (`Language`/`ExerciseKind` enums, `LessonId` newtype, required fields non-`Option`) behind `Lesson::parse` — the single validating boundary. A constructed `Lesson` is valid by type, so the runner and JSON seam never re-validate.
- Wires `blendtutor validate <lesson.yaml>`: a valid lesson prints OK / exit 0; an invalid one reports the specific problem on stderr / exit non-zero, via the effectful `read_lesson_file` shell over the pure `parse`.
- Ports the R `add_two_numbers.yaml` fixture and the `validate_lesson()` behavior, with two deliberate tightenings vs R (see ADR-0003).

## Issue
Closes #4 (merges into `staging/rewrite-in-rust-lol`, the Rust-rewrite integration branch — not `main`).

## Slices implemented
- **AC1** — valid ported fixture reports OK, exit 0 · `validate_valid_lesson_reports_ok_and_exit_zero` (cli, `assert_cmd`).
- **AC2** — missing required field **or** `{student_code}`-less prompt names the exact problem, exits non-zero · pure `parse_rejects_*` unit tests (assert the field path **and** the `{student_code}` rule) + `validate_invalid_lesson_exits_nonzero_naming_problem` (cli).
- **AC3** — parsed lesson round-trips losslessly through JSON · `lesson_json_roundtrip_preserves_value` (`assert_eq!` on the full struct).

## Design notes
- `{student_code}` is a **hard error** here, where R only warned (ADR-0003) — inserting learner code is the lesson's whole purpose.
- `#[serde(deny_unknown_fields)]` on `Lesson`/`Exercise` so an author's typo in an optional field fails validation instead of dropping to `None` (§1.3.1); `exercise.type` is therefore modelled as the `ExerciseKind` enum rather than ignored.
- `LessonId` has a private inner `String` + `Display` (no `.0` leak); v1 identity is the `lesson_name` value, slug id deferred to Slice 6.
- YAML via `serde-saphyr` (`serde_yml` is RUSTSEC-2025-0068; `serde_yaml` archived). JSON via `serde_json`.
- ADR-0003 records the schema decisions; `docs/agent-notes/lesson-model.md` seeded.

## Test plan
- [x] All unit + integration tests pass (`cargo nextest run --locked` — 15 tests)
- [x] `cargo clippy --all-targets -- -D warnings` + `cargo fmt --all --check` clean
- [x] Mutation-in-diff gate clean (6 caught, 0 missed)
- [x] Roborev findings resolved (each commit gated)
- [x] ADR-0003 written
- [ ] Rodney verification — N/A (no UI surface; CLI + library only)