### PR TITLE
[feature] Lesson discovery — course directory + manifest, list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,7 @@ dependencies = [
  "serde-saphyr",
  "serde_json",
  "tempfile",
+ "toml",
 ]
 
 [[package]]
@@ -266,6 +267,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,10 +322,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "insta"
@@ -571,6 +594,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +649,47 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "unicode-ident"
@@ -718,6 +791,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-saphyr = "0.0.27"
 tempfile = "3"
+toml = "0.8"

--- a/crates/cli/src/commands/list.rs
+++ b/crates/cli/src/commands/list.rs
@@ -1,0 +1,23 @@
+//! `blendtutor list <course>` — discover the lessons in a course directory and
+//! report each one's id, language, and title, including any that failed to load.
+
+use std::path::Path;
+use std::process::ExitCode;
+
+use blendtutor_core::course::Course;
+
+use crate::output::{self, ListReport, OutputFormat};
+
+/// Open the course at `dir`, discover its lessons, and render the listing in
+/// `format`.
+///
+/// The command shapes data and defers all formatting to the renderer (§5.1). A
+/// missing or malformed manifest is a whole-course failure that propagates to
+/// `main` as an error; an individual lesson that fails to load is reported as a
+/// row in the listing, not a command failure, so discovery still exits zero.
+pub fn run(dir: &Path, format: OutputFormat) -> anyhow::Result<ExitCode> {
+    let course = Course::open(dir)?;
+    let report = ListReport::from_discovery(course.discover());
+    output::emit_list(&report, format)?;
+    Ok(ExitCode::SUCCESS)
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -4,4 +4,5 @@
 //! renders the result for the terminal. No domain logic lives here — that is
 //! `core`'s responsibility (the dependency only ever points cli → core).
 
+pub mod list;
 pub mod validate;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -39,7 +39,13 @@ enum Commands {
         format: OutputFormat,
     },
     /// List the lessons discoverable in a course.
-    List,
+    List {
+        /// Path to the course directory (the one holding `blendtutor.toml`).
+        path: PathBuf,
+        /// Output format: `human` (default) or `json`.
+        #[arg(long, value_enum, default_value_t = OutputFormat::Human)]
+        format: OutputFormat,
+    },
     /// Run a lesson interactively with LLM feedback.
     Run,
     /// Run feedback-quality evals for a lesson.
@@ -56,7 +62,7 @@ impl Commands {
             Commands::Init => "init",
             Commands::New => "new",
             Commands::Validate { .. } => "validate",
-            Commands::List => "list",
+            Commands::List { .. } => "list",
             Commands::Run => "run",
             Commands::Eval => "eval",
             Commands::Build => "build",
@@ -68,6 +74,7 @@ fn main() -> anyhow::Result<ExitCode> {
     let cli = Cli::parse();
     match cli.command {
         Commands::Validate { path, format } => commands::validate::run(&path, format),
+        Commands::List { path, format } => commands::list::run(&path, format),
         other => Err(blendtutor_core::NotYetImplemented::new(other.name()).into()),
     }
 }

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -384,10 +384,20 @@ mod tests {
         let json = render_list(&mixed_report(), OutputFormat::Json);
         let rows: serde_json::Value = serde_json::from_str(&json).expect("list json parses");
 
+        // The array preserves manifest order and length — one row per entry.
+        assert_eq!(rows.as_array().expect("json is an array").len(), 3);
+
         assert_eq!(rows[0]["id"], "add-two");
         assert_eq!(rows[0]["language"], "r");
         assert_eq!(rows[0]["title"], "Add Two Numbers");
         assert!(rows[0]["error"].is_null(), "a found row has no error");
+
+        // The second found row carries the *other* language — proof both
+        // languages are emitted, not one default repeated.
+        assert_eq!(rows[1]["id"], "greet");
+        assert_eq!(rows[1]["language"], "python");
+        assert_eq!(rows[1]["title"], "Greet Someone");
+        assert!(rows[1]["error"].is_null(), "a found row has no error");
 
         assert_eq!(rows[2]["id"], "broken");
         assert!(
@@ -396,5 +406,18 @@ mod tests {
         );
         assert!(rows[2]["title"].is_null(), "a failed row has no title");
         assert_eq!(rows[2]["error"], "invalid lesson: missing field `language`");
+    }
+
+    /// An empty course is a real, if unusual, state: human says so in words and
+    /// JSON is an empty array, not blank output. Pinning both keeps the wording
+    /// and the `[]` contract from drifting silently.
+    #[test]
+    fn list_renders_an_empty_course_in_both_formats() {
+        let empty = ListReport { rows: vec![] };
+        assert_eq!(
+            render_list(&empty, OutputFormat::Human),
+            "No lessons found."
+        );
+        assert_eq!(render_list(&empty, OutputFormat::Json), "[]");
     }
 }

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -279,9 +279,18 @@ fn render_list(report: &ListReport, format: OutputFormat) -> String {
     }
 }
 
+/// The first line of a possibly multi-line value. A lesson title (a YAML block
+/// scalar) or a discovery error (the multi-line parser message) would otherwise
+/// embed newlines into a table row and break its alignment; the full text is
+/// kept in the JSON view for machine consumers.
+fn first_line(text: &str) -> &str {
+    text.lines().next().unwrap_or("")
+}
+
 /// The human listing: one aligned `id  language  title` line per lesson, with a
-/// failed lesson shown as an `ERROR` row carrying its message. An empty course
-/// says so rather than printing nothing.
+/// failed lesson shown as an `ERROR` row carrying its message. Each cell is
+/// reduced to its first line so a multi-line title or error cannot break the
+/// table. An empty course says so rather than printing nothing.
 fn render_list_human(report: &ListReport) -> String {
     if report.rows.is_empty() {
         return "No lessons found.".to_string();
@@ -289,7 +298,7 @@ fn render_list_human(report: &ListReport) -> String {
     let id_width = report
         .rows
         .iter()
-        .map(|row| row.id().len())
+        .map(|row| first_line(row.id()).len())
         .max()
         .unwrap_or(0);
     report
@@ -300,8 +309,18 @@ fn render_list_human(report: &ListReport) -> String {
                 id,
                 language,
                 title,
-            } => format!("{id:<id_width$}  {:<7}  {title}", language_code(language)),
-            LessonRow::Failed { id, error } => format!("{id:<id_width$}  {:<7}  {error}", "ERROR"),
+            } => format!(
+                "{:<id_width$}  {:<7}  {}",
+                first_line(id),
+                language_code(language),
+                first_line(title)
+            ),
+            LessonRow::Failed { id, error } => format!(
+                "{:<id_width$}  {:<7}  {}",
+                first_line(id),
+                "ERROR",
+                first_line(error)
+            ),
         })
         .collect::<Vec<_>>()
         .join("\n")
@@ -363,7 +382,10 @@ mod tests {
                 },
                 LessonRow::Failed {
                     id: "broken".to_string(),
-                    error: "invalid lesson: missing field `language`".to_string(),
+                    // A realistic, multi-line parser message: the human table must
+                    // flatten it to one line while JSON keeps it whole.
+                    error: "invalid lesson: missing field `language`\n --> <input>:5:1\n  | ^"
+                        .to_string(),
                 },
             ],
         }
@@ -405,7 +427,12 @@ mod tests {
             "a failed row has no language"
         );
         assert!(rows[2]["title"].is_null(), "a failed row has no title");
-        assert_eq!(rows[2]["error"], "invalid lesson: missing field `language`");
+        // JSON keeps the full multi-line message — machine consumers get every
+        // line, unlike the human table which shows only the first.
+        assert_eq!(
+            rows[2]["error"],
+            "invalid lesson: missing field `language`\n --> <input>:5:1\n  | ^"
+        );
     }
 
     /// An empty course is a real, if unusual, state: human says so in words and

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -12,6 +12,9 @@ use std::process::ExitCode;
 use clap::ValueEnum;
 use serde::Serialize;
 
+use blendtutor_core::course::{DiscoveryError, LessonSummary};
+use blendtutor_core::lesson::Language;
+
 /// How a command's result is rendered for the user.
 ///
 /// Modelling the choice as an enum rather than a string makes dispatch
@@ -159,6 +162,157 @@ pub fn emit_validate(report: &ValidateReport, format: OutputFormat) -> io::Resul
     }
 }
 
+/// One row of a lesson listing as the cli renders it: a lesson that was
+/// discovered, or one that failed to load. Modelling the two as a sum type keeps
+/// a row from being half-found, half-failed (§1.1).
+enum LessonRow {
+    Found {
+        id: String,
+        language: Language,
+        title: String,
+    },
+    Failed {
+        id: String,
+        error: String,
+    },
+}
+
+impl LessonRow {
+    /// The row's course slug, shown in every format and used to size the human
+    /// table's first column.
+    fn id(&self) -> &str {
+        match self {
+            LessonRow::Found { id, .. } | LessonRow::Failed { id, .. } => id,
+        }
+    }
+}
+
+/// The outcome of discovering a course's lessons: one [`LessonRow`] per manifest
+/// entry, in manifest order. The pure value the `list` command computes and then
+/// hands to [`emit_list`].
+pub struct ListReport {
+    rows: Vec<LessonRow>,
+}
+
+impl ListReport {
+    /// Build a report from the rows `core` discovered: each `Ok` lesson becomes a
+    /// found row, each `Err` a failed row carrying its slug and message. Order is
+    /// preserved so the listing follows the manifest. The command shapes this
+    /// data; the renderer only formats it (§5.1).
+    pub fn from_discovery(rows: Vec<Result<LessonSummary, DiscoveryError>>) -> Self {
+        let rows = rows
+            .into_iter()
+            .map(|row| match row {
+                Ok(summary) => LessonRow::Found {
+                    id: summary.id.to_string(),
+                    language: summary.language,
+                    title: summary.title,
+                },
+                Err(error) => LessonRow::Failed {
+                    id: error.id().to_string(),
+                    error: error.to_string(),
+                },
+            })
+            .collect();
+        Self { rows }
+    }
+}
+
+/// The lowercase, machine-readable spelling of a lesson language for the JSON and
+/// human listings. An exhaustive match (§1.2): a new `Language` variant forces a
+/// spelling here rather than defaulting silently. Lowercase is the wire form,
+/// decoupled from the enum's YAML spelling (`R`/`Python`).
+fn language_code(language: &Language) -> &'static str {
+    match language {
+        Language::R => "r",
+        Language::Python => "python",
+    }
+}
+
+/// The machine-readable view of one lesson row: a stable, documented shape with
+/// `id` always present, `language`/`title` for a found lesson, `error` for a
+/// failed one. Every key is always emitted (the absent side is `null`) so
+/// consumers can rely on the shape.
+#[derive(Serialize)]
+struct LessonRowView<'a> {
+    id: &'a str,
+    language: Option<&'a str>,
+    title: Option<&'a str>,
+    error: Option<&'a str>,
+}
+
+impl<'a> LessonRowView<'a> {
+    fn of(row: &'a LessonRow) -> Self {
+        match row {
+            LessonRow::Found {
+                id,
+                language,
+                title,
+            } => Self {
+                id,
+                language: Some(language_code(language)),
+                title: Some(title),
+                error: None,
+            },
+            LessonRow::Failed { id, error } => Self {
+                id,
+                language: None,
+                title: None,
+                error: Some(error),
+            },
+        }
+    }
+}
+
+/// Render a [`ListReport`] in `format` without performing any I/O (§2.1).
+///
+/// Both formats are a single document on stdout: JSON is a stable array of row
+/// objects; human is an aligned table. Unlike `validate`, the listing has no
+/// stderr split — an error row is part of the listing's data, not a diagnostic.
+fn render_list(report: &ListReport, format: OutputFormat) -> String {
+    match format {
+        OutputFormat::Json => {
+            let view: Vec<LessonRowView> = report.rows.iter().map(LessonRowView::of).collect();
+            serde_json::to_string(&view).expect("lesson rows serialize infallibly")
+        }
+        OutputFormat::Human => render_list_human(report),
+    }
+}
+
+/// The human listing: one aligned `id  language  title` line per lesson, with a
+/// failed lesson shown as an `ERROR` row carrying its message. An empty course
+/// says so rather than printing nothing.
+fn render_list_human(report: &ListReport) -> String {
+    if report.rows.is_empty() {
+        return "No lessons found.".to_string();
+    }
+    let id_width = report
+        .rows
+        .iter()
+        .map(|row| row.id().len())
+        .max()
+        .unwrap_or(0);
+    report
+        .rows
+        .iter()
+        .map(|row| match row {
+            LessonRow::Found {
+                id,
+                language,
+                title,
+            } => format!("{id:<id_width$}  {:<7}  {title}", language_code(language)),
+            LessonRow::Failed { id, error } => format!("{id:<id_width$}  {:<7}  {error}", "ERROR"),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Render `report` in `format` and write it to stdout — the single place the
+/// listing reaches the terminal (§2.4, §5.1).
+pub fn emit_list(report: &ListReport, format: OutputFormat) -> io::Result<()> {
+    writeln!(io::stdout(), "{}", render_list(report, format))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -190,5 +344,57 @@ mod tests {
         // The finding is a diagnostic, so it belongs on stderr.
         assert_eq!(rendered.stream, Stream::Err);
         insta::assert_snapshot!(rendered.text);
+    }
+
+    /// A report fixture: two discovered lessons (one R, one Python) and one that
+    /// failed to load — the AC2 shape, used to pin both the human and JSON views.
+    fn mixed_report() -> ListReport {
+        ListReport {
+            rows: vec![
+                LessonRow::Found {
+                    id: "add-two".to_string(),
+                    language: Language::R,
+                    title: "Add Two Numbers".to_string(),
+                },
+                LessonRow::Found {
+                    id: "greet".to_string(),
+                    language: Language::Python,
+                    title: "Greet Someone".to_string(),
+                },
+                LessonRow::Failed {
+                    id: "broken".to_string(),
+                    error: "invalid lesson: missing field `language`".to_string(),
+                },
+            ],
+        }
+    }
+
+    /// Pin the human listing — aligned `id language title` rows plus the `ERROR`
+    /// row — so any drift in spacing or wording fails loudly.
+    #[test]
+    fn list_human_matches_snapshot() {
+        insta::assert_snapshot!(render_list(&mixed_report(), OutputFormat::Human));
+    }
+
+    /// The JSON view is a stable array: a found row carries `language`/`title`
+    /// with `error: null`; a failed row carries `error` with the other fields
+    /// null. Both keys always present so consumers can rely on the shape.
+    #[test]
+    fn list_json_separates_found_rows_from_failed_rows() {
+        let json = render_list(&mixed_report(), OutputFormat::Json);
+        let rows: serde_json::Value = serde_json::from_str(&json).expect("list json parses");
+
+        assert_eq!(rows[0]["id"], "add-two");
+        assert_eq!(rows[0]["language"], "r");
+        assert_eq!(rows[0]["title"], "Add Two Numbers");
+        assert!(rows[0]["error"].is_null(), "a found row has no error");
+
+        assert_eq!(rows[2]["id"], "broken");
+        assert!(
+            rows[2]["language"].is_null(),
+            "a failed row has no language"
+        );
+        assert!(rows[2]["title"].is_null(), "a failed row has no title");
+        assert_eq!(rows[2]["error"], "invalid lesson: missing field `language`");
     }
 }

--- a/crates/cli/src/snapshots/blendtutor__output__tests__list_human_matches_snapshot.snap
+++ b/crates/cli/src/snapshots/blendtutor__output__tests__list_human_matches_snapshot.snap
@@ -1,0 +1,7 @@
+---
+source: crates/cli/src/output.rs
+expression: "render_list(&mixed_report(), OutputFormat::Human)"
+---
+add-two  r        Add Two Numbers
+greet    python   Greet Someone
+broken   ERROR    invalid lesson: missing field `language`

--- a/crates/cli/tests/list.rs
+++ b/crates/cli/tests/list.rs
@@ -1,0 +1,77 @@
+//! Integration tests for `blendtutor list`.
+//!
+//! Exercises lesson discovery end to end via the built binary (`assert_cmd`):
+//! point `list` at a course directory and observe the rows it reports — the
+//! slice's "when I run list, I see every lesson" behavior. Discovery rules are
+//! unit-tested in `blendtutor-core`.
+
+use assert_cmd::Command;
+use serde_json::Value;
+
+/// A course directory with a manifest and two valid lessons, one `r` and one
+/// `python`. Lives under `core`'s fixtures (the schema's home) and is referenced
+/// cross-crate by path.
+const COURSE_BASIC: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../core/tests/fixtures/course_basic"
+);
+
+/// Run `list <course> --format json` via the built binary and parse stdout as a
+/// JSON array of lesson rows.
+fn list_json(course: &str) -> (std::process::Output, Vec<Value>) {
+    let output = Command::cargo_bin("blendtutor")
+        .unwrap()
+        .arg("list")
+        .arg(course)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let rows: Vec<Value> = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("list json did not parse: {e}; stdout={stdout:?}"));
+    (output, rows)
+}
+
+#[test]
+fn list_reports_each_lessons_id_language_and_title() {
+    let (output, rows) = list_json(COURSE_BASIC);
+
+    assert!(
+        output.status.success(),
+        "`list` on a valid course should exit 0, got {:?}; stderr={:?}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(rows.len(), 2, "course_basic has exactly two lessons");
+
+    // Both languages are present and lowercased — not collapsed to one default.
+    let mut languages: Vec<&str> = rows
+        .iter()
+        .map(|r| r["language"].as_str().expect("each row carries a language"))
+        .collect();
+    languages.sort_unstable();
+    assert_eq!(languages, ["python", "r"]);
+
+    // Each row's title is the lesson's parsed name, not the manifest id nor an
+    // empty default. Asserting the specific (id, language, title) triples kills a
+    // "title defaults to id" fake-pass that a bare non-empty check would miss.
+    let triple = |id: &str| -> (String, String) {
+        let row = rows
+            .iter()
+            .find(|r| r["id"] == id)
+            .unwrap_or_else(|| panic!("a row with id {id:?} should be listed; rows={rows:?}"));
+        (
+            row["language"].as_str().unwrap().to_string(),
+            row["title"].as_str().unwrap().to_string(),
+        )
+    };
+    assert_eq!(
+        triple("add-two"),
+        ("r".to_string(), "Add Two Numbers".to_string())
+    );
+    assert_eq!(
+        triple("greet"),
+        ("python".to_string(), "Greet Someone".to_string())
+    );
+}

--- a/crates/cli/tests/list.rs
+++ b/crates/cli/tests/list.rs
@@ -16,6 +16,13 @@ const COURSE_BASIC: &str = concat!(
     "/../core/tests/fixtures/course_basic"
 );
 
+/// A course with two valid lessons and one malformed lesson whose manifest slug
+/// is `broken`. Drives the partial-failure behavior.
+const COURSE_PARTIAL: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../core/tests/fixtures/course_partial"
+);
+
 /// Run `list <course> --format json` via the built binary and parse stdout as a
 /// JSON array of lesson rows.
 fn list_json(course: &str) -> (std::process::Output, Vec<Value>) {
@@ -73,5 +80,59 @@ fn list_reports_each_lessons_id_language_and_title() {
     assert_eq!(
         triple("greet"),
         ("python".to_string(), "Greet Someone".to_string())
+    );
+}
+
+#[test]
+fn list_reports_a_malformed_lesson_as_an_error_row_without_losing_the_good_ones() {
+    let (output, rows) = list_json(COURSE_PARTIAL);
+
+    // A bad lesson does not fail the command — discovery still succeeds.
+    assert!(
+        output.status.success(),
+        "`list` should still exit 0 with one bad lesson, got {:?}; stderr={:?}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Two good rows survive (error null). This fails the abort fake-pass: aborting
+    // on the first bad lesson would leave fewer than two good rows.
+    let good = rows.iter().filter(|r| r["error"].is_null()).count();
+    assert_eq!(good, 2, "both valid lessons remain listed");
+
+    // Exactly one `broken` row bears an error marker. This fails the swallow
+    // fake-pass: silently dropping the bad lesson would leave zero such rows.
+    let broken = rows
+        .iter()
+        .filter(|r| r["id"] == "broken" && !r["error"].is_null())
+        .count();
+    assert_eq!(
+        broken, 1,
+        "the malformed lesson is an error row, neither aborted nor dropped; rows={rows:?}"
+    );
+}
+
+#[test]
+fn list_on_a_directory_without_a_manifest_exits_nonzero() {
+    // The symmetric twin of a per-lesson failure: a missing manifest is a
+    // whole-course failure, so the command itself fails rather than listing rows.
+    let dir = tempfile::tempdir().unwrap();
+    let output = Command::cargo_bin("blendtutor")
+        .unwrap()
+        .arg("list")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "a course directory with no blendtutor.toml cannot be listed"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .to_lowercase()
+            .contains("manifest"),
+        "the failure should name the manifest; stderr={:?}",
+        String::from_utf8_lossy(&output.stderr)
     );
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 [dependencies]
 serde = { workspace = true }
 serde-saphyr = { workspace = true }
+toml = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/core/src/course.rs
+++ b/crates/core/src/course.rs
@@ -64,10 +64,42 @@ impl Manifest {
     ///
     /// The pure parse boundary (§2.1): the caller reads the file, this turns the
     /// text into the typed model. A malformed document or a typo'd key yields
-    /// [`ManifestError::Parse`] carrying the parser message.
+    /// [`ManifestError::Parse`]; a lesson path that would escape the course
+    /// directory yields [`ManifestError::UnsafePath`]. Both are caught here,
+    /// before any lesson file is read (§1.3.1), so a parsed `Manifest` only ever
+    /// names files inside its own course.
     pub fn parse(toml: &str) -> Result<Manifest, ManifestError> {
-        toml::from_str(toml).map_err(|e| ManifestError::Parse(e.to_string()))
+        let manifest: Manifest =
+            toml::from_str(toml).map_err(|e| ManifestError::Parse(e.to_string()))?;
+        manifest.validate_paths()?;
+        Ok(manifest)
     }
+
+    /// Reject any entry whose path would reach outside the course directory.
+    ///
+    /// A manifest is author-written but a course may be shared, so an absolute
+    /// path or a `..` component is refused at the boundary rather than handed to
+    /// [`Course::discover`] as a read of an arbitrary file (§1.3.1).
+    fn validate_paths(&self) -> Result<(), ManifestError> {
+        for entry in &self.lessons {
+            if escapes_course_dir(&entry.path) {
+                return Err(ManifestError::UnsafePath {
+                    id: entry.id.clone(),
+                    path: entry.path.clone(),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Whether `path` would resolve outside the course directory: an absolute path,
+/// or one with a `..` component that climbs above the root.
+fn escapes_course_dir(path: &Path) -> bool {
+    path.is_absolute()
+        || path
+            .components()
+            .any(|component| matches!(component, std::path::Component::ParentDir))
 }
 
 /// Why a `blendtutor.toml` could not be turned into a [`Manifest`].
@@ -82,6 +114,14 @@ pub enum ManifestError {
     /// The file was read but is not a valid manifest (bad TOML, a missing or
     /// typo'd key). Carries the parser message.
     Parse(String),
+    /// An entry's `path` would resolve outside the course directory (it is
+    /// absolute or climbs through `..`), so it is refused before any file is read.
+    UnsafePath {
+        /// The slug of the offending entry.
+        id: LessonSlug,
+        /// The rejected path, as written in the manifest.
+        path: PathBuf,
+    },
 }
 
 impl fmt::Display for ManifestError {
@@ -89,6 +129,11 @@ impl fmt::Display for ManifestError {
         match self {
             ManifestError::Read(e) => write!(f, "could not read course manifest: {e}"),
             ManifestError::Parse(msg) => write!(f, "invalid course manifest: {msg}"),
+            ManifestError::UnsafePath { id, path } => write!(
+                f,
+                "lesson {id:?} path {path:?} escapes the course directory; \
+                 lesson paths must be relative and stay within the course",
+            ),
         }
     }
 }
@@ -97,7 +142,7 @@ impl Error for ManifestError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             ManifestError::Read(e) => Some(e),
-            ManifestError::Parse(_) => None,
+            ManifestError::Parse(_) | ManifestError::UnsafePath { .. } => None,
         }
     }
 }
@@ -260,6 +305,20 @@ pathh = "add_two.yaml"
             matches!(err, ManifestError::Parse(_)),
             "a malformed manifest is a parse error, got: {err:?}"
         );
+    }
+
+    #[test]
+    fn manifest_parse_rejects_a_path_escaping_the_course_directory() {
+        for escaping in ["../secrets.yaml", "/etc/passwd", "nested/../../up.yaml"] {
+            let err = Manifest::parse(&format!(
+                "[[lessons]]\nid = \"x\"\npath = {escaping:?}\n"
+            ))
+            .expect_err("a path leaving the course directory must be refused");
+            assert!(
+                matches!(err, ManifestError::UnsafePath { .. }),
+                "an escaping path should be UnsafePath, got: {err:?} for {escaping}"
+            );
+        }
     }
 
     #[test]

--- a/crates/core/src/course.rs
+++ b/crates/core/src/course.rs
@@ -386,4 +386,66 @@ pathh = "add_two.yaml"
             "a missing manifest is a read error, got: {err:?}"
         );
     }
+
+    #[test]
+    fn manifest_error_display_and_source_distinguish_each_variant() {
+        use std::io::{Error as IoError, ErrorKind};
+
+        // Read names itself a read failure and exposes the io::Error as its source.
+        let read = ManifestError::Read(IoError::new(ErrorKind::NotFound, "nope"));
+        assert!(
+            read.to_string().contains("could not read course manifest"),
+            "Read should label itself, got: {read}"
+        );
+        assert!(
+            std::error::Error::source(&read).is_some(),
+            "Read should expose the io::Error as its source"
+        );
+
+        // Parse carries the parser message and has no nested source.
+        let parse = ManifestError::Parse("bad toml".to_string());
+        let parse_msg = parse.to_string();
+        assert!(
+            parse_msg.contains("invalid course manifest") && parse_msg.contains("bad toml"),
+            "Parse should frame and carry the message, got: {parse_msg}"
+        );
+        assert!(std::error::Error::source(&parse).is_none());
+
+        // UnsafePath says the path escapes and has no nested source.
+        let unsafe_path = ManifestError::UnsafePath {
+            id: LessonSlug("x".to_string()),
+            path: PathBuf::from("../escape.yaml"),
+        };
+        assert!(
+            unsafe_path.to_string().contains("escapes"),
+            "UnsafePath should say the path escapes, got: {unsafe_path}"
+        );
+        assert!(std::error::Error::source(&unsafe_path).is_none());
+    }
+
+    #[test]
+    fn discovery_error_display_and_source_surface_the_underlying_load_failure() {
+        let course = Course::open(Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/course_partial"
+        )))
+        .expect("course_partial should open");
+        let rows = course.discover();
+        let err = rows
+            .iter()
+            .filter_map(|row| row.as_ref().err())
+            .next()
+            .expect("the malformed lesson produces an error");
+
+        // Display surfaces the underlying load failure rather than an empty string.
+        assert!(
+            err.to_string().contains("language"),
+            "Display should surface the missing-field cause, got: {err}"
+        );
+        // The LoadError is exposed as the source, preserving the error chain.
+        assert!(
+            std::error::Error::source(err).is_some(),
+            "DiscoveryError should expose its LoadError as the source"
+        );
+    }
 }

--- a/crates/core/src/course.rs
+++ b/crates/core/src/course.rs
@@ -64,10 +64,11 @@ impl Manifest {
     ///
     /// The pure parse boundary (§2.1): the caller reads the file, this turns the
     /// text into the typed model. A malformed document or a typo'd key yields
-    /// [`ManifestError::Parse`]; a lesson path that would escape the course
-    /// directory yields [`ManifestError::UnsafePath`]. Both are caught here,
-    /// before any lesson file is read (§1.3.1), so a parsed `Manifest` only ever
-    /// names files inside its own course.
+    /// [`ManifestError::Parse`]; a lesson path that escapes the course directory
+    /// yields [`ManifestError::UnsafePath`]. Both are caught here, before any
+    /// lesson file is read (§1.3.1), so a parsed `Manifest` carries only relative,
+    /// non-`..` paths. The check is lexical — it does not resolve symlinks, so a
+    /// symlink inside the course could still point elsewhere.
     pub fn parse(toml: &str) -> Result<Manifest, ManifestError> {
         let manifest: Manifest =
             toml::from_str(toml).map_err(|e| ManifestError::Parse(e.to_string()))?;
@@ -93,8 +94,9 @@ impl Manifest {
     }
 }
 
-/// Whether `path` would resolve outside the course directory: an absolute path,
-/// or one with a `..` component that climbs above the root.
+/// Whether `path` is lexically outside the course directory: an absolute path,
+/// or one carrying a `..` component. A lexical check only — it does not resolve
+/// symlinks, so a symlink within the course is not followed.
 fn escapes_course_dir(path: &Path) -> bool {
     path.is_absolute()
         || path

--- a/crates/core/src/course.rs
+++ b/crates/core/src/course.rs
@@ -312,10 +312,8 @@ pathh = "add_two.yaml"
     #[test]
     fn manifest_parse_rejects_a_path_escaping_the_course_directory() {
         for escaping in ["../secrets.yaml", "/etc/passwd", "nested/../../up.yaml"] {
-            let err = Manifest::parse(&format!(
-                "[[lessons]]\nid = \"x\"\npath = {escaping:?}\n"
-            ))
-            .expect_err("a path leaving the course directory must be refused");
+            let err = Manifest::parse(&format!("[[lessons]]\nid = \"x\"\npath = {escaping:?}\n"))
+                .expect_err("a path leaving the course directory must be refused");
             assert!(
                 matches!(err, ManifestError::UnsafePath { .. }),
                 "an escaping path should be UnsafePath, got: {err:?} for {escaping}"

--- a/crates/core/src/course.rs
+++ b/crates/core/src/course.rs
@@ -348,6 +348,36 @@ pathh = "add_two.yaml"
     }
 
     #[test]
+    fn discover_reports_a_malformed_lesson_as_an_error_row_keeping_the_good_ones() {
+        let course = Course::open(Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/course_partial"
+        )))
+        .expect("course_partial should open");
+        let rows = course.discover();
+
+        // Three manifest entries -> three rows. Partial failure is represented as
+        // a Vec<Result>: it is neither flattened to Result<Vec> (which would abort
+        // the whole scan on the first bad lesson) nor filtered down to the good
+        // ones (the R-style silent swallow).
+        assert_eq!(rows.len(), 3, "one row per manifest entry");
+        assert_eq!(
+            rows.iter().filter(|row| row.is_ok()).count(),
+            2,
+            "the two valid lessons still discover"
+        );
+
+        let errors: Vec<&DiscoveryError> =
+            rows.iter().filter_map(|row| row.as_ref().err()).collect();
+        assert_eq!(errors.len(), 1, "exactly the one malformed lesson errors");
+        assert_eq!(
+            errors[0].id().to_string(),
+            "broken",
+            "the error row carries the manifest slug, not the unparseable lesson's name"
+        );
+    }
+
+    #[test]
     fn open_missing_manifest_is_a_read_error_not_a_parse_error() {
         let err = Course::open(Path::new("/no/such/course"))
             .expect_err("a directory without a manifest cannot open");

--- a/crates/core/src/course.rs
+++ b/crates/core/src/course.rs
@@ -1,0 +1,300 @@
+//! Course discovery: a course directory's manifest and the lessons it lists.
+//!
+//! Holds the [`Manifest`] (the parsed `blendtutor.toml`), the [`Course`] that
+//! owns a course directory, and [`Course::discover`] — the effectful walk that
+//! reads each listed lesson and summarizes it. A discovered entry is a
+//! `Result<LessonSummary, DiscoveryError>` so a malformed lesson is reported as
+//! an error row, never aborting the scan nor silently dropped (ADR-0004). This
+//! module does not validate lesson semantics beyond what [`crate::lesson`]
+//! already does (§4.1); it adds only the course-scoped slug and the
+//! partial-failure shape.
+
+use std::error::Error;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::lesson::{Language, Lesson, LoadError, read_lesson_file};
+
+/// The manifest file at the root of every course directory.
+const MANIFEST_FILENAME: &str = "blendtutor.toml";
+
+/// A lesson's course-scoped identity: the `id` an author gives an entry in
+/// `blendtutor.toml`.
+///
+/// A newtype over `String` (§1.4) so a course slug is never confused with the
+/// lesson's own `lesson_name` title or with arbitrary text. The slug is assigned
+/// by the course, not the lesson (ADR-0004): a lesson file does not know which
+/// course lists it.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct LessonSlug(String);
+
+impl fmt::Display for LessonSlug {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// One lesson's entry in a [`Manifest`]: its course slug and the file that holds
+/// it, relative to the manifest.
+///
+/// Unknown keys are rejected (§1.3.1) so an author's typo in `blendtutor.toml`
+/// fails loudly rather than dropping silently, matching the lesson model.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ManifestEntry {
+    /// The lesson's course-scoped id.
+    pub id: LessonSlug,
+    /// The lesson file, relative to the course directory.
+    pub path: PathBuf,
+}
+
+/// A course manifest: the ordered list of lessons a course contains, parsed from
+/// `blendtutor.toml`.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Manifest {
+    /// The lessons this course lists, in author order.
+    pub lessons: Vec<ManifestEntry>,
+}
+
+impl Manifest {
+    /// Parse a manifest from a `blendtutor.toml` document.
+    ///
+    /// The pure parse boundary (§2.1): the caller reads the file, this turns the
+    /// text into the typed model. A malformed document or a typo'd key yields
+    /// [`ManifestError::Parse`] carrying the parser message.
+    pub fn parse(toml: &str) -> Result<Manifest, ManifestError> {
+        toml::from_str(toml).map_err(|e| ManifestError::Parse(e.to_string()))
+    }
+}
+
+/// Why a `blendtutor.toml` could not be turned into a [`Manifest`].
+///
+/// Read failures stay distinct from parse failures (mirroring
+/// [`LoadError`](crate::lesson::LoadError)) so a missing manifest is never
+/// reported as a malformed one.
+#[derive(Debug)]
+pub enum ManifestError {
+    /// The manifest file could not be read (missing, permissions).
+    Read(std::io::Error),
+    /// The file was read but is not a valid manifest (bad TOML, a missing or
+    /// typo'd key). Carries the parser message.
+    Parse(String),
+}
+
+impl fmt::Display for ManifestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ManifestError::Read(e) => write!(f, "could not read course manifest: {e}"),
+            ManifestError::Parse(msg) => write!(f, "invalid course manifest: {msg}"),
+        }
+    }
+}
+
+impl Error for ManifestError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            ManifestError::Read(e) => Some(e),
+            ManifestError::Parse(_) => None,
+        }
+    }
+}
+
+/// A course directory: its root and parsed manifest.
+///
+/// Construct one through [`Course::open`]; a value of this type has, by
+/// construction, a manifest that parsed.
+#[derive(Debug, Clone)]
+pub struct Course {
+    root: PathBuf,
+    manifest: Manifest,
+}
+
+impl Course {
+    /// Open the course rooted at `dir` by reading and parsing its
+    /// `blendtutor.toml`.
+    ///
+    /// The effectful shell (§2.2) over the pure [`Manifest::parse`]. A missing or
+    /// malformed manifest is a whole-course failure (ADR-0004) — distinct from a
+    /// single bad lesson, which [`discover`](Course::discover) reports as a row.
+    pub fn open(dir: &Path) -> Result<Course, ManifestError> {
+        let text =
+            std::fs::read_to_string(dir.join(MANIFEST_FILENAME)).map_err(ManifestError::Read)?;
+        let manifest = Manifest::parse(&text)?;
+        Ok(Course {
+            root: dir.to_path_buf(),
+            manifest,
+        })
+    }
+
+    /// Discover every lesson the manifest lists, one row per entry.
+    ///
+    /// Each entry yields `Ok(LessonSummary)` if its lesson loads and validates,
+    /// or `Err(DiscoveryError)` carrying the entry's slug if it does not — so a
+    /// malformed lesson neither aborts the scan nor disappears (ADR-0004, §1.2).
+    /// The per-lesson read is effectful; the [`summarize`] it feeds is pure
+    /// (§2.1, §2.2), depending on [`crate::lesson`] in one direction (§3.1).
+    pub fn discover(&self) -> Vec<Result<LessonSummary, DiscoveryError>> {
+        self.manifest
+            .lessons
+            .iter()
+            .map(|entry| {
+                read_lesson_file(&self.root.join(&entry.path))
+                    .map(|lesson| summarize(entry.id.clone(), &lesson))
+                    .map_err(|source| DiscoveryError {
+                        id: entry.id.clone(),
+                        source,
+                    })
+            })
+            .collect()
+    }
+}
+
+/// One discovered lesson, as listed: its course slug, language, and title.
+///
+/// The title is the lesson's own `lesson_name`; the slug is the manifest id. They
+/// are distinct fields so the listing can show both, and a missing title can
+/// never quietly default to the id (ADR-0004).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LessonSummary {
+    /// The lesson's course-scoped id, from the manifest.
+    pub id: LessonSlug,
+    /// The language the lesson is authored in.
+    pub language: Language,
+    /// The lesson's human-readable title (its `lesson_name`).
+    pub title: String,
+}
+
+/// Summarize a loaded lesson under its course slug.
+///
+/// Pure (§2.2): it derives the list row from the already-validated lesson and the
+/// manifest-assigned id. It reads `lesson` and never the other way round (§3.1).
+fn summarize(id: LessonSlug, lesson: &Lesson) -> LessonSummary {
+    LessonSummary {
+        id,
+        language: lesson.language.clone(),
+        title: lesson.lesson_name.to_string(),
+    }
+}
+
+/// Why one manifest entry could not be discovered: its slug and the underlying
+/// load failure.
+///
+/// Carrying the slug lets the listing report a broken lesson as a row that still
+/// names which lesson broke; wrapping the [`LoadError`] preserves the
+/// read-vs-validation distinction rather than flattening it to a bare string.
+#[derive(Debug)]
+pub struct DiscoveryError {
+    id: LessonSlug,
+    source: LoadError,
+}
+
+impl DiscoveryError {
+    /// The course slug of the entry that failed to load.
+    pub fn id(&self) -> &LessonSlug {
+        &self.id
+    }
+}
+
+impl fmt::Display for DiscoveryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // The slug is rendered by the listing alongside the message; here we
+        // surface just the cause so callers compose their own framing.
+        self.source.fmt(f)
+    }
+}
+
+impl Error for DiscoveryError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The course fixture with a manifest and two valid lessons, one R and one
+    /// Python. Lives under this crate's fixtures (the schema's home).
+    fn course_basic() -> &'static Path {
+        Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/course_basic"
+        ))
+    }
+
+    #[test]
+    fn manifest_parse_reads_each_entrys_id_and_path() {
+        let manifest = Manifest::parse(
+            r#"
+[[lessons]]
+id = "add-two"
+path = "add_two.yaml"
+
+[[lessons]]
+id = "greet"
+path = "greet.yaml"
+"#,
+        )
+        .expect("a well-formed manifest should parse");
+
+        assert_eq!(manifest.lessons.len(), 2);
+        assert_eq!(manifest.lessons[0].id, LessonSlug("add-two".to_string()));
+        assert_eq!(manifest.lessons[0].path, PathBuf::from("add_two.yaml"));
+        assert_eq!(manifest.lessons[1].id, LessonSlug("greet".to_string()));
+    }
+
+    #[test]
+    fn manifest_parse_rejects_unknown_key_so_author_typos_surface() {
+        let err = Manifest::parse(
+            r#"
+[[lessons]]
+id = "add-two"
+pathh = "add_two.yaml"
+"#,
+        )
+        .expect_err("a typo'd key must not be silently dropped");
+        assert!(
+            matches!(err, ManifestError::Parse(_)),
+            "a malformed manifest is a parse error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn discover_summarizes_each_lesson_with_its_slug_language_and_title() {
+        let course = Course::open(course_basic()).expect("course_basic should open");
+        let rows = course.discover();
+
+        assert_eq!(rows.len(), 2, "course_basic lists two lessons");
+
+        let summary = |slug: &str| -> LessonSummary {
+            rows.iter()
+                .filter_map(|r| r.as_ref().ok())
+                .find(|s| s.id == LessonSlug(slug.to_string()))
+                .unwrap_or_else(|| panic!("an Ok row with slug {slug:?} should be discovered"))
+                .clone()
+        };
+
+        // The slug comes from the manifest; language and title come from the
+        // parsed lesson — distinct sources, so a "title == id" collapse is caught.
+        let add_two = summary("add-two");
+        assert_eq!(add_two.language, Language::R);
+        assert_eq!(add_two.title, "Add Two Numbers");
+
+        let greet = summary("greet");
+        assert_eq!(greet.language, Language::Python);
+        assert_eq!(greet.title, "Greet Someone");
+    }
+
+    #[test]
+    fn open_missing_manifest_is_a_read_error_not_a_parse_error() {
+        let err = Course::open(Path::new("/no/such/course"))
+            .expect_err("a directory without a manifest cannot open");
+        assert!(
+            matches!(err, ManifestError::Read(_)),
+            "a missing manifest is a read error, got: {err:?}"
+        );
+    }
+}

--- a/crates/core/src/course.rs
+++ b/crates/core/src/course.rs
@@ -107,7 +107,7 @@ fn escapes_course_dir(path: &Path) -> bool {
 /// Why a `blendtutor.toml` could not be turned into a [`Manifest`].
 ///
 /// Read failures stay distinct from parse failures (mirroring
-/// [`LoadError`](crate::lesson::LoadError)) so a missing manifest is never
+/// [`LoadError`]) so a missing manifest is never
 /// reported as a malformed one.
 #[derive(Debug)]
 pub enum ManifestError {
@@ -181,7 +181,7 @@ impl Course {
     /// Each entry yields `Ok(LessonSummary)` if its lesson loads and validates,
     /// or `Err(DiscoveryError)` carrying the entry's slug if it does not — so a
     /// malformed lesson neither aborts the scan nor disappears (ADR-0004, §1.2).
-    /// The per-lesson read is effectful; the [`summarize`] it feeds is pure
+    /// The per-lesson read is effectful; the `summarize` it feeds is pure
     /// (§2.1, §2.2), depending on [`crate::lesson`] in one direction (§3.1).
     pub fn discover(&self) -> Vec<Result<LessonSummary, DiscoveryError>> {
         self.manifest

--- a/crates/core/src/lesson.rs
+++ b/crates/core/src/lesson.rs
@@ -137,7 +137,7 @@ impl Lesson {
     /// The pure parse boundary (§2.1, §1.3.1): it deserializes the document into
     /// the typed model — a missing required field or wrong type yields
     /// [`ValidationError::Parse`] naming the field — then runs
-    /// [`validate_semantics`](Lesson::validate_semantics) for the rules structure
+    /// `validate_semantics` for the rules structure
     /// alone cannot express. Returns a [`Lesson`] only if both succeed.
     pub fn parse(yaml: &str) -> Result<Lesson, ValidationError> {
         let lesson: Lesson =

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,6 +14,7 @@
 // rustdoc warnings" — then holds unconditionally, not only under -D warnings.
 #![deny(missing_docs)]
 
+pub mod course;
 pub mod lesson;
 
 use std::error::Error;

--- a/crates/core/tests/fixtures/course_basic/add_two.yaml
+++ b/crates/core/tests/fixtures/course_basic/add_two.yaml
@@ -1,0 +1,13 @@
+lesson_name: "Add Two Numbers"
+language: R
+description: "Write a function that adds two numbers"
+
+exercise:
+  type: "function_writing"
+  prompt: |
+    Write a function called 'add_two' that takes two numeric arguments
+    (x and y) and returns their sum.
+  llm_evaluation_prompt: |
+    Evaluate the student's submission:
+    {student_code}
+    Reply with feedback.

--- a/crates/core/tests/fixtures/course_basic/blendtutor.toml
+++ b/crates/core/tests/fixtures/course_basic/blendtutor.toml
@@ -1,0 +1,9 @@
+# A minimal course manifest: an ordered list of lessons, each a stable course
+# slug `id` paired with the lesson file `path` (relative to this manifest).
+[[lessons]]
+id = "add-two"
+path = "add_two.yaml"
+
+[[lessons]]
+id = "greet"
+path = "greet.yaml"

--- a/crates/core/tests/fixtures/course_basic/greet.yaml
+++ b/crates/core/tests/fixtures/course_basic/greet.yaml
@@ -1,0 +1,13 @@
+lesson_name: "Greet Someone"
+language: Python
+description: "Write a function that greets a person by name"
+
+exercise:
+  type: "function_writing"
+  prompt: |
+    Write a function called 'greet' that takes a name and returns a
+    greeting string.
+  llm_evaluation_prompt: |
+    Evaluate the student's submission:
+    {student_code}
+    Reply with feedback.

--- a/crates/core/tests/fixtures/course_partial/add_two.yaml
+++ b/crates/core/tests/fixtures/course_partial/add_two.yaml
@@ -1,0 +1,13 @@
+lesson_name: "Add Two Numbers"
+language: R
+description: "Write a function that adds two numbers"
+
+exercise:
+  type: "function_writing"
+  prompt: |
+    Write a function called 'add_two' that takes two numeric arguments
+    (x and y) and returns their sum.
+  llm_evaluation_prompt: |
+    Evaluate the student's submission:
+    {student_code}
+    Reply with feedback.

--- a/crates/core/tests/fixtures/course_partial/blendtutor.toml
+++ b/crates/core/tests/fixtures/course_partial/blendtutor.toml
@@ -1,0 +1,13 @@
+# A course with two valid lessons and one malformed lesson (`broken`). Discovery
+# must report the bad one as an error row without losing the good two.
+[[lessons]]
+id = "add-two"
+path = "add_two.yaml"
+
+[[lessons]]
+id = "greet"
+path = "greet.yaml"
+
+[[lessons]]
+id = "broken"
+path = "broken.yaml"

--- a/crates/core/tests/fixtures/course_partial/broken.yaml
+++ b/crates/core/tests/fixtures/course_partial/broken.yaml
@@ -1,0 +1,9 @@
+# Malformed on purpose: the required `language` field is missing, so
+# Lesson::parse rejects it and discovery reports this entry as an error row.
+lesson_name: "Broken Lesson"
+
+exercise:
+  prompt: "Write a function."
+  llm_evaluation_prompt: |
+    Evaluate the student's submission:
+    {student_code}

--- a/crates/core/tests/fixtures/course_partial/greet.yaml
+++ b/crates/core/tests/fixtures/course_partial/greet.yaml
@@ -1,0 +1,13 @@
+lesson_name: "Greet Someone"
+language: Python
+description: "Write a function that greets a person by name"
+
+exercise:
+  type: "function_writing"
+  prompt: |
+    Write a function called 'greet' that takes a name and returns a
+    greeting string.
+  llm_evaluation_prompt: |
+    Evaluate the student's submission:
+    {student_code}
+    Reply with feedback.

--- a/docs/adr/0003-lesson-schema.md
+++ b/docs/adr/0003-lesson-schema.md
@@ -48,8 +48,10 @@ Two deltas from the R behavior, both deliberate:
 - **`LessonId` carries the `lesson_name` value as the v1 identity.** The lesson
   file has no separate id field, and a stable slug id belongs with discovery
   (Slice 6, course dir + manifest). The newtype keeps a lesson's identity from
-  being confused with arbitrary strings now (§1.4); promoting it to a distinct
-  slug later is a localized change inside `lesson`.
+  being confused with arbitrary strings now (§1.4). Refined by ADR-0004: the slug
+  did not replace `LessonId` inside `lesson` — it is course-scoped (the manifest
+  assigns it), so it lives as a separate `LessonSlug` in `core::course`, and
+  `lesson_name`/`LessonId` stays the lesson's own title.
 
 YAML is parsed with **`serde-saphyr`** (pure-Rust, no `unsafe`, line-numbered
 errors). `serde_yml` is rejected (RUSTSEC-2025-0068, unsound); `serde_yaml` is

--- a/docs/adr/0004-course-manifest-discovery.md
+++ b/docs/adr/0004-course-manifest-discovery.md
@@ -1,0 +1,83 @@
+# ADR-0004: Course manifest and lesson discovery
+
+- Status: Accepted
+- Date: 2026-06-06
+
+## Context
+
+Issue #6 ports the R package's `list_lessons()` / `invalidate_lesson_cache()`
+(`R/lesson_loader.R`, `R/package_discovery.R`) into the Rust `core`. The R side
+scans every *installed package* for an `inst/lessons/` directory, builds an
+untyped index, caches it, and **silently swallows** a lesson it cannot read — so
+a broken lesson simply vanishes from the list and the author never learns why.
+
+The Rust rewrite is a single binary over a course *directory*, so discovery is
+filesystem-scoped (no cross-package cache — that is why `invalidate_lesson_cache`
+has no port). Two questions: (1) how is a course described — what is the manifest
+and where does it live; (2) how is a course with a malformed lesson represented,
+so partial failure neither aborts discovery nor disappears. Later slices depend
+on the answer: `init` (#14) scaffolds the manifest, `new` (#15) registers a
+lesson in it, `build` (#16/#17) reads lesson titles from it.
+
+## Options
+
+**Manifest format**
+
+1. **YAML manifest**, parsed with the same `serde-saphyr` the lessons use. One
+   format, one parser. But it conflates *content* (the lesson) with *course
+   structure* (config), and the `init` slice already names the file
+   `blendtutor.toml`.
+2. **TOML `blendtutor.toml`** at the course root: config-shaped, familiar to the
+   Rust/CLI audience (mirrors `Cargo.toml`), cleanly separating the course's
+   spine from lesson content. Costs one dependency (`toml`).
+3. **No manifest — scan every `*.yaml`.** Zero config, but no stable ids, no
+   author-controlled ordering, and no way to keep a non-lesson YAML out. This
+   implicit discovery is exactly what made the R side fragile.
+
+**Partial failure**
+
+- **A. `Result<Vec<LessonSummary>, E>`** — abort on the first bad lesson. One
+  broken file hides every good one.
+- **B. `Vec<LessonSummary>`**, dropping the bad ones (R's silent swallow). Good
+  lessons list; broken ones vanish without a trace.
+- **C. `Vec<Result<LessonSummary, DiscoveryError>>`** — every manifest entry
+  yields a row, success or failure. Partial failure is represented, not collapsed
+  (§1.1, §1.2).
+
+## Decision
+
+Manifest = **option 2**, partial failure = **option C**.
+
+- `blendtutor.toml` holds an ordered `[[lessons]]` array of `{ id, path }`. `id`
+  is a course-scoped slug — a new `LessonSlug` newtype (§1.4) — and `path` is the
+  lesson file relative to the manifest. The slug is distinct from the lesson's own
+  `lesson_name` *title*: a lesson does not know which course lists it, so the
+  course assigns the id (this is where ADR-0003's foreseen "distinct slug id"
+  landed — in `course`, not by repurposing `lesson::LessonId`).
+- `core::course` owns `Manifest::parse` (pure TOML → typed), `Course::open(dir)`
+  (effectful: reads `dir/blendtutor.toml`), and `Course::discover()` (effectful
+  walk that reads each lesson file and feeds the **pure** `summarize`, §2.1/§2.2).
+- A missing or malformed *manifest* is a whole-course failure: `Course::open`
+  returns an error the CLI propagates at its edge, exactly as a read error is
+  propagated, never as a lesson finding. A missing or malformed *lesson* is one
+  `Err(DiscoveryError)` row carrying its slug — it does not abort the siblings.
+- `core::course` does not re-validate lesson semantics: it calls `lesson::parse`
+  in one direction (§3.1) and adds only the course slug and the partial-failure
+  shape (§4.1).
+
+## Consequences
+
+- A second parser (`toml`) enters the tree. Justified: the manifest is config and
+  the lessons are content, and slices 14/15 already assume `blendtutor.toml`.
+- `DiscoveryError` wraps the lesson's `LoadError`, so the slice-4 distinction
+  between a read failure and a validation failure survives into a discovery row
+  rather than being flattened to a bare string at the boundary.
+- The JSON `language` spelling is lowercase (`r`/`python`), rendered in the cli
+  seam and decoupled from the `Language` enum's YAML spelling (`R`/`Python`) — the
+  same representation/wire split ADR-0003 and the output seam (#5) already use.
+- `LessonSlug` is an unvalidated newtype today (any non-empty string an author
+  writes). Empty-slug rejection waits for an authoring command (`new`, #15) that
+  *produces* a slug; discovery only reads what is already on disk.
+- Growing the manifest later (course title, per-lesson metadata) is an additive
+  change to `Manifest`; `deny_unknown_fields` makes an author's typo'd key fail
+  loudly rather than drop silently, matching the lesson model (ADR-0003).

--- a/docs/agent-notes/course-discovery.md
+++ b/docs/agent-notes/course-discovery.md
@@ -1,0 +1,54 @@
+---
+topic: course-discovery
+created: 2026-06-06
+slices: [6]
+---
+
+How a course directory is described and how its lessons are discovered
+(`core::course`, `cli::commands::list`, `cli::output`). See ADR-0004 for the
+decision record and [[lesson-model]] for the typed lesson `parse` it builds on.
+
+- 2026-06-06 (#6): The course manifest is **`blendtutor.toml` (TOML)**, not YAML —
+  a deliberate split: the manifest is *config* (mirrors `Cargo.toml`), the lessons
+  are *content* (YAML, ported from R). TOML uses the `toml` crate
+  (`toml::from_str`); YAML still uses `serde-saphyr`. Slices 14 (`init`) / 15
+  (`new`) / 16–17 (`build`) all read or write this same `blendtutor.toml` shape, so
+  it is a cross-slice contract, not a slice-6-local file.
+- 2026-06-06 (#6): A manifest is `Manifest { lessons: Vec<ManifestEntry{ id, path }> }`.
+  `id` is a **`LessonSlug` newtype** — the *course-scoped* identity, assigned by the
+  manifest, distinct from the lesson's own `lesson_name` *title* (which stays a
+  `lesson::LessonId`). This is where ADR-0003's foreseen "distinct slug id" landed:
+  in `course`, NOT by repurposing `lesson::LessonId`. So the `list` row's `id`
+  (slug) and `title` (lesson_name) come from different sources — a lesson file does
+  not know which course lists it.
+- 2026-06-06 (#6): **Partial failure is represented, not collapsed.**
+  `Course::discover() -> Vec<Result<LessonSummary, DiscoveryError>>` — one row per
+  manifest entry. A malformed lesson is an `Err` row carrying its slug; it neither
+  aborts the scan (which `Result<Vec<_>>` would) nor disappears (the R
+  `list_lessons` silent swallow). `DiscoveryError` wraps the lesson's `LoadError`,
+  so the read-vs-validation distinction survives into the row. Tests fix both
+  fake-passes (abort → good-count wrong; swallow → broken-row count 0).
+- 2026-06-06 (#6): `Course::open(dir)` (effectful: reads `dir/blendtutor.toml`) is
+  separate from `discover()` (effectful walk) which feeds the **pure** `summarize`.
+  A missing/malformed *manifest* is a whole-course `ManifestError` at `open` —
+  propagated to `main` as an anyhow error at the CLI edge (exit nonzero), exactly
+  like a read error — whereas a bad *lesson* is a row. Two different failure layers.
+- 2026-06-06 (#6): The `list` JSON shape is a **flat array of
+  `{id, language, title, error}` rows**, every key always present (the absent side
+  `null`): a found row has `error:null`; a failed row has `language:null`,
+  `title:null` + the message. `language` is **lowercased to the wire form**
+  (`r`/`python`) by `cli::output::language_code` (exhaustive match, §1.2), decoupled
+  from the `Language` enum's YAML spelling (`R`/`Python`) — same representation/wire
+  split as the validate seam ([[output]]).
+- 2026-06-06 (#6): Unlike `validate` (which splits stdout=data / stderr=findings),
+  **`list` writes the whole document to stdout** in both formats — an error row is
+  part of the listing's data ("which lessons exist, including broken ones"), not a
+  diagnostic. `render_list` returns a plain `String` (no `Stream`), still pure and
+  snapshot-tested; the cli-owned `ListReport`/`LessonRow` is built from core's
+  `discover()` so `render_*` is testable without public `LessonSlug`/`DiscoveryError`
+  constructors (no core API widening for tests).
+- 2026-06-06 (#6): `Manifest::parse` refuses a lesson `path` that is absolute or
+  carries `..` (`ManifestError::UnsafePath`), before any file read (§1.3.1) — a
+  shared course can't turn `list` into an arbitrary-file read. The check is
+  **lexical only**: it does not resolve symlinks. Empty-slug rejection is deferred
+  until `new` (#15) actually *produces* slugs; discovery only reads.

--- a/docs/agent-notes/course-discovery.md
+++ b/docs/agent-notes/course-discovery.md
@@ -52,3 +52,16 @@ decision record and [[lesson-model]] for the typed lesson `parse` it builds on.
   shared course can't turn `list` into an arbitrary-file read. The check is
   **lexical only**: it does not resolve symlinks. Empty-slug rejection is deferred
   until `new` (#15) actually *produces* slugs; discovery only reads.
+- 2026-06-06 (#6): The human listing reduces **each cell to its first line**
+  (`cli::output::first_line`) on purpose — a `DiscoveryError`'s Display is the
+  multi-line serde-saphyr parser message, which otherwise sprawls the `ERROR` row
+  across a dozen lines and breaks the table's alignment (adversarial pass-1 caught
+  it; the snapshot had hidden it behind a clean one-line error). JSON keeps the
+  **full** message; human is a one-line-per-row summary (run `validate` for the
+  full text). Don't "fix" the flattening thinking it truncates data.
+- 2026-06-06 (#6): Aside found while greening this slice — `docs.yml`
+  (`cargo doc` with `RUSTDOCFLAGS=-D warnings`) had been **red on staging since #4**:
+  a public doc comment linked to a private item, and `rustdoc::private_intra_doc_links`
+  under `-D warnings` fails the *whole crate* doc build (not just one item). If you
+  write `[`thing`]` linking a private fn from public docs, the docs gate breaks —
+  use plain text. Slice 6 swept the existing offenders.


### PR DESCRIPTION
## Summary
- Add `core::course`: a `blendtutor.toml` (TOML) course manifest and `Course::discover()`, which reads each listed lesson and returns one row per entry as `Vec<Result<LessonSummary, DiscoveryError>>` — a malformed lesson is an error row carrying its slug, neither aborting the scan nor silently dropped (the R `list_lessons` swallow).
- Wire `blendtutor list <course> --format human|json`: the command opens the course, discovers its lessons, and renders a stable listing. JSON is a flat array of `{id, language, title, error}` rows (`language` lowercased to the wire form); human is an aligned table with `ERROR` rows.
- Ports R `list_lessons()` / `invalidate_lesson_cache()` as filesystem-scoped discovery (no cross-package cache). The slug `id` (manifest) is distinct from the lesson's `lesson_name` title.

## Issue
Closes #6

## Slices implemented
- **AC1** — `list` shows each lesson's id, language, title (human + json). Covered by `course::tests::discover_summarizes_each_lesson_*`, `output::tests::list_*`, and the integration test `list_reports_each_lessons_id_language_and_title`. The spec `jq` probe returns `true`.
- **AC2** — a malformed lesson is an error row; the good ones still list. Covered by `course::tests::discover_reports_a_malformed_lesson_as_an_error_row_keeping_the_good_ones` (asserts `Vec<Result>` with Ok==2 + one Err resolving to `broken`) and the integration test `list_reports_a_malformed_lesson_as_an_error_row_*` (fails both the abort and swallow fake-passes). Negative-control verified (swallow impl → both assertions fail; reverted).

## Design / ADR
- **ADR-0004** records the manifest format (TOML) and the partial-failure shape; refines ADR-0003's note on where the slug lives (`core::course`, not `lesson::LessonId`).
- Manifest paths that escape the course dir (absolute / `..`) are refused at the parse boundary (§1.3.1, lexical check). `discover`'s effectful walk feeds a pure `summarize` (§2.1/§2.2) depending on `lesson::parse` one direction (§3.1).

## Verification (CLI, not UI — no rodney)
- `cargo nextest run --locked` — 35 passing.
- `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, `RUSTDOCFLAGS=-D warnings cargo doc --no-deps` — all clean. The rustdoc fix also restores the docs.yml gate, red on staging since #29 (a pre-existing slice-4 private-doc-link).
- `cargo mutants --in-diff` (pre-push gate) — 0 missed (10 caught, 7 unviable).
- AC1 probe: `blendtutor list ./crates/core/tests/fixtures/course_basic --format json | jq -e '…'` → `true`.
- AC2 probe: `blendtutor list ./crates/core/tests/fixtures/course_partial --format json | jq -e '…'` → `true`.

## Test plan
- [x] All unit + integration tests pass
- [x] Roborev findings resolved (path-traversal guard, docstring scope, empty-state + second-row coverage)
- [x] ADRs written/updated (ADR-0004; ADR-0003 refined)
- [x] Rodney verification — n/a (CLI slice, no web UI)