### PR TITLE
[feature] R runner — subprocess execution with capture + timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +160,7 @@ dependencies = [
 name = "blendtutor-core"
 version = "0.1.0"
 dependencies = [
+ "command-group",
  "serde",
  "serde-saphyr",
  "serde_json",
@@ -231,6 +243,18 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "command-group"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68fa787550392a9d58f44c21a3022cfb3ea3e2458b7f85d3b399d0ceeccf409"
+dependencies = [
+ "async-trait",
+ "nix",
+ "tokio",
+ "winapi",
+]
 
 [[package]]
 name = "console"
@@ -412,6 +436,17 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -843,6 +878,28 @@ checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,7 @@ dependencies = [
  "serde-saphyr",
  "serde_json",
  "tempfile",
+ "tokio",
  "toml",
 ]
 
@@ -172,6 +173,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cfg-if"
@@ -397,6 +404,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +446,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "predicates"
@@ -603,6 +627,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,6 +683,32 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "toml"
@@ -723,6 +783,12 @@ checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,12 @@ repository = "https://github.com/mcmullarkey/blendtutor"
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 assert_cmd = "2"
+command-group = { version = "5", features = ["tokio"] }
 insta = "1"
 predicates = "3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-saphyr = "0.0.27"
 tempfile = "3"
+tokio = { version = "1", features = ["rt", "macros", "process", "time", "io-util"] }
 toml = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/mcmullarkey/blendtutor"
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 assert_cmd = "2"
-command-group = { version = "5", features = ["tokio"] }
+command-group = { version = "5", features = ["with-tokio"] }
 insta = "1"
 predicates = "3"
 serde = { version = "1", features = ["derive"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,5 +15,3 @@ toml = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
-tempfile = { workspace = true }
-tokio = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -6,8 +6,11 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+command-group = { workspace = true }
 serde = { workspace = true }
 serde-saphyr = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
 toml = { workspace = true }
 
 [dev-dependencies]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -13,3 +13,4 @@ toml = { workspace = true }
 [dev-dependencies]
 serde_json = { workspace = true }
 tempfile = { workspace = true }
+tokio = { workspace = true }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -16,6 +16,7 @@
 
 pub mod course;
 pub mod lesson;
+pub mod runner;
 
 use std::error::Error;
 use std::fmt;

--- a/crates/core/src/runner/mod.rs
+++ b/crates/core/src/runner/mod.rs
@@ -1,0 +1,140 @@
+//! The language-runner seam: a [`Runner`] trait and the normalized result of
+//! running learner code.
+//!
+//! [`Runner`] is the boundary every execution and grading slice depends on, so a
+//! second language (Python, Slice 8) or a hosted backend is a new `impl Runner`
+//! rather than an edit at each call site (ADR-0005, §3.4). This module owns the
+//! seam and the [`ExecutionResult`] shape; the R-specific subprocess mechanics
+//! live in the private `r` submodule. It does not know about lessons or LLMs
+//! (§4.1).
+
+use std::error::Error;
+use std::fmt;
+use std::future::Future;
+use std::time::Duration;
+
+mod r;
+
+pub use r::RRunner;
+
+/// A wall-clock bound on a single execution.
+///
+/// A newtype over [`Duration`] so a timeout is never confused with an arbitrary
+/// duration argument elsewhere (§1.4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Timeout(pub Duration);
+
+/// The normalized outcome of running learner code to completion or timeout.
+///
+/// The observable channels are kept in distinct fields rather than one merged
+/// buffer (§1.2): a later grading prompt reads `stdout` and `stderr`
+/// independently and must never see one bleed into the other. An
+/// [`ExecutionResult`] only ever represents a process that actually *ran* — a
+/// failure to launch the interpreter is a [`RunnerError`], never a value here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionResult {
+    /// Everything the program wrote to standard output.
+    pub stdout: String,
+    /// Everything the program wrote to standard error.
+    pub stderr: String,
+    /// The process exit code, or `None` when it was terminated by a signal
+    /// (e.g. killed on timeout).
+    pub exit: Option<i32>,
+    /// The final evaluated expression's value, reserved for the grading prompt.
+    /// `None` until its producer lands with grading (Slice 9, ADR-0005).
+    pub final_value: Option<String>,
+    /// Whether the run was killed for exceeding its [`Timeout`].
+    pub timed_out: bool,
+}
+
+impl ExecutionResult {
+    /// Assemble a result from raw captured bytes — the pure normalization step,
+    /// kept separate from the effectful spawn so it is testable on bytes alone
+    /// (§2.3, §5.3). Output is decoded lossily; a runner never rejects learner
+    /// output for not being valid UTF-8.
+    pub(crate) fn from_capture(
+        stdout: &[u8],
+        stderr: &[u8],
+        exit: Option<i32>,
+        timed_out: bool,
+    ) -> Self {
+        Self {
+            stdout: String::from_utf8_lossy(stdout).into_owned(),
+            stderr: String::from_utf8_lossy(stderr).into_owned(),
+            exit,
+            final_value: None,
+            timed_out,
+        }
+    }
+}
+
+/// Runs learner code and reports what it did.
+///
+/// The seam every execution and grading slice depends on (§3.4). `execute` is
+/// fallible: an [`Err`] means the interpreter never ran (spawn or IO failure),
+/// which is categorically distinct from the program running and writing to
+/// stderr — so [`ExecutionResult`] never has to encode "we could not start".
+///
+/// Declared returning `impl Future` rather than with `async fn` so the public
+/// trait stays clear of the `async_fn_in_trait` lint under `-D warnings`.
+pub trait Runner {
+    /// Execute `code`, returning its normalized [`ExecutionResult`].
+    ///
+    /// `checks` is reserved for the grading slice (which refines its element
+    /// type); v1 execution does not yet consume it.
+    fn execute(
+        &self,
+        code: &str,
+        checks: &[String],
+    ) -> impl Future<Output = Result<ExecutionResult, RunnerError>> + Send;
+}
+
+/// A failure to *run* learner code: the interpreter could not be spawned, or its
+/// output pipes could not be read.
+///
+/// Distinct from a program that ran and failed — that is an [`ExecutionResult`]
+/// with a non-zero `exit`. Kept a typed error so `core` stays free of `anyhow`
+/// (ADR-0001).
+#[derive(Debug)]
+pub struct RunnerError {
+    context: &'static str,
+    source: std::io::Error,
+}
+
+impl RunnerError {
+    /// Wrap an IO failure with the runner stage that produced it.
+    pub(crate) fn new(context: &'static str, source: std::io::Error) -> Self {
+        Self { context, source }
+    }
+}
+
+impl fmt::Display for RunnerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.context, self.source)
+    }
+}
+
+impl Error for RunnerError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_capture_keeps_streams_distinct_and_passes_exit_through() {
+        let result = ExecutionResult::from_capture(b"OUT", b"ERR", Some(0), false);
+        assert_eq!(result.stdout, "OUT");
+        assert_eq!(result.stderr, "ERR");
+        assert!(
+            !result.stdout.contains("ERR"),
+            "stderr must not bleed into stdout"
+        );
+        assert_eq!(result.exit, Some(0));
+        assert!(!result.timed_out);
+        assert_eq!(result.final_value, None);
+    }
+}

--- a/crates/core/src/runner/mod.rs
+++ b/crates/core/src/runner/mod.rs
@@ -137,4 +137,14 @@ mod tests {
         assert!(!result.timed_out);
         assert_eq!(result.final_value, None);
     }
+
+    #[test]
+    fn runner_error_displays_its_stage_and_exposes_the_io_source() {
+        let io = std::io::Error::new(std::io::ErrorKind::NotFound, "boom");
+        let err = RunnerError::new("spawn Rscript", io);
+
+        assert_eq!(err.to_string(), "spawn Rscript: boom");
+        let source = Error::source(&err).expect("the io::Error is reachable as the source");
+        assert_eq!(source.to_string(), "boom");
+    }
 }

--- a/crates/core/src/runner/r.rs
+++ b/crates/core/src/runner/r.rs
@@ -1,0 +1,121 @@
+//! R execution mechanics: spawn `Rscript`, capture its streams separately,
+//! bound it with a timeout, and reap a runaway process tree.
+//!
+//! This module owns *only* the R subprocess details (ADR-0005, §4.1); callers
+//! depend on the [`Runner`](super::Runner) trait, not on [`RRunner`].
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use command_group::AsyncCommandGroup;
+use tokio::io::AsyncReadExt;
+use tokio::process::Command;
+use tokio::task::JoinHandle;
+use tokio::time::timeout;
+
+use super::{ExecutionResult, Runner, RunnerError, Timeout};
+
+/// A [`Runner`] backed by a real `Rscript` subprocess.
+#[derive(Debug, Clone)]
+pub struct RRunner {
+    timeout: Timeout,
+}
+
+impl RRunner {
+    /// Build a runner that kills any execution exceeding `timeout`.
+    pub fn new(timeout: Timeout) -> Self {
+        Self { timeout }
+    }
+}
+
+impl Default for RRunner {
+    /// A 30-second bound — generous for a lesson exercise, finite for a runaway.
+    fn default() -> Self {
+        Self::new(Timeout(Duration::from_secs(30)))
+    }
+}
+
+impl Runner for RRunner {
+    async fn execute(
+        &self,
+        code: &str,
+        _checks: &[String],
+    ) -> Result<ExecutionResult, RunnerError> {
+        // Per-execute temp dir as CWD: file-writing code is isolated to it and
+        // the directory is removed when `run_dir` drops at the end of this fn.
+        let run_dir =
+            tempfile::TempDir::new().map_err(|e| RunnerError::new("create run directory", e))?;
+
+        // `--vanilla` skips user/site `.Rprofile`/`.Renviron`, so capture is
+        // deterministic across machines and no profile output bleeds into stdout.
+        // `group_spawn` puts the child in its own process group so the whole tree
+        // can be killed on timeout, not just the leader.
+        let mut child = Command::new("Rscript")
+            .arg("--vanilla")
+            .arg("-e")
+            .arg(code)
+            .current_dir(run_dir.path())
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .group_spawn()
+            .map_err(|e| RunnerError::new("spawn Rscript", e))?;
+
+        // Drain both pipes concurrently so a chatty program cannot deadlock the
+        // wait by filling a pipe buffer; the reads make progress while we await
+        // the process below.
+        let mut stdout = child.inner().stdout.take().expect("stdout piped above");
+        let mut stderr = child.inner().stderr.take().expect("stderr piped above");
+        let out_task: JoinHandle<std::io::Result<Vec<u8>>> = tokio::spawn(async move {
+            let mut buf = Vec::new();
+            stdout.read_to_end(&mut buf).await.map(|_| buf)
+        });
+        let err_task: JoinHandle<std::io::Result<Vec<u8>>> = tokio::spawn(async move {
+            let mut buf = Vec::new();
+            stderr.read_to_end(&mut buf).await.map(|_| buf)
+        });
+
+        let (exit, timed_out) = match timeout(self.timeout.0, child.wait()).await {
+            Ok(status) => {
+                let status = status.map_err(|e| RunnerError::new("wait for Rscript", e))?;
+                (status.code(), false)
+            }
+            Err(_elapsed) => {
+                // SIGKILL the whole process group so an R child that spawned its
+                // own children is reaped, not leaked; then reap the leader.
+                child
+                    .kill()
+                    .await
+                    .map_err(|e| RunnerError::new("kill Rscript group", e))?;
+                let status = child
+                    .wait()
+                    .await
+                    .map_err(|e| RunnerError::new("reap Rscript group", e))?;
+                (status.code(), true)
+            }
+        };
+
+        // Every group process is gone, so both pipes have closed and the readers
+        // have finished; collect their bytes.
+        let stdout = join_capture(out_task, "collect stdout").await?;
+        let stderr = join_capture(err_task, "collect stderr").await?;
+
+        Ok(ExecutionResult::from_capture(
+            &stdout, &stderr, exit, timed_out,
+        ))
+        // `run_dir` drops here → the temp directory is removed.
+    }
+}
+
+/// Await a stream-reader task, flattening its join error and IO error into a
+/// [`RunnerError`].
+async fn join_capture(
+    task: JoinHandle<std::io::Result<Vec<u8>>>,
+    context: &'static str,
+) -> Result<Vec<u8>, RunnerError> {
+    match task.await {
+        Ok(Ok(bytes)) => Ok(bytes),
+        Ok(Err(io_err)) => Err(RunnerError::new(context, io_err)),
+        Err(join_err) => Err(RunnerError::new(context, std::io::Error::other(join_err))),
+    }
+}

--- a/crates/core/tests/runner.rs
+++ b/crates/core/tests/runner.rs
@@ -58,5 +58,8 @@ async fn captures_stdout_stderr_exit_separately() {
         result.stdout
     );
     assert_eq!(result.exit, Some(0), "a clean exit is Some(0), not a blob");
-    assert!(!result.timed_out, "a fast snippet must not be marked timed out");
+    assert!(
+        !result.timed_out,
+        "a fast snippet must not be marked timed out"
+    );
 }

--- a/crates/core/tests/runner.rs
+++ b/crates/core/tests/runner.rs
@@ -6,6 +6,7 @@
 //! missing external tool is a skip, not a failure (see
 //! `docs/agent-notes/workspace-and-ci.md`).
 
+use std::path::PathBuf;
 use std::time::Duration;
 
 use blendtutor_core::runner::{ExecutionResult, RRunner, Runner, Timeout};
@@ -128,5 +129,54 @@ async fn timeout_kills_process_tree_under_natural_runtime() {
         size_at_return, size_after,
         "the grandchild kept writing after the timeout — the process group was not \
          killed (sentinel grew {size_at_return} -> {size_after})"
+    );
+}
+
+/// AC3 — file-writing code runs in an isolated temp working directory that is
+/// removed when the run returns, and the caller's own directory is left
+/// untouched: a relative write lands in the temp dir, not back in the CWD.
+#[tokio::test]
+async fn runs_in_isolated_temp_dir_cleaned_up() {
+    if rscript_absent() {
+        return;
+    }
+
+    // Treat a fresh dir as the caller's CWD, with a pre-existing marker. nextest
+    // runs each test in its own process, so changing the process CWD here cannot
+    // disturb sibling tests — and a non-isolating regression would drop its
+    // stray `out.txt` here rather than in the source tree.
+    let outer = tempfile::tempdir().expect("create outer dir");
+    let marker = outer.path().join("marker.txt");
+    std::fs::write(&marker, b"keep me").expect("seed marker");
+    std::env::set_current_dir(outer.path()).expect("cd into outer dir");
+
+    // R reports its working directory (so the test can locate the run dir) then
+    // writes a file by *relative* path — which must land in the isolated run
+    // dir, not back in `outer`.
+    let runner = RRunner::default();
+    let result = runner
+        .execute("cat(getwd()); writeLines('x', 'out.txt')", &[])
+        .await
+        .expect("Rscript should spawn and run to completion");
+
+    let run_dir = PathBuf::from(result.stdout.trim());
+    // `getwd()` resolves symlinks (macOS /var -> /private/var), so canonicalize
+    // the temp root before the prefix check.
+    let temp_root = std::fs::canonicalize(std::env::temp_dir()).expect("canonicalize temp dir");
+    assert!(
+        run_dir.starts_with(&temp_root),
+        "run dir must be under the system temp dir {temp_root:?}, got {run_dir:?}"
+    );
+    assert!(
+        !run_dir.exists(),
+        "the per-run temp dir must be removed when execute returns, but {run_dir:?} survived"
+    );
+    assert!(
+        !outer.path().join("out.txt").exists(),
+        "a relative write escaped the isolated run dir into the caller's directory"
+    );
+    assert!(
+        marker.exists(),
+        "the caller's pre-existing marker was disturbed by the run"
     );
 }

--- a/crates/core/tests/runner.rs
+++ b/crates/core/tests/runner.rs
@@ -117,6 +117,11 @@ async fn timeout_kills_process_tree_under_natural_runtime() {
 
     // Give any un-reaped grandchild a full second to keep growing the sentinel.
     let size_at_return = std::fs::metadata(&sentinel).expect("stat sentinel").len();
+    assert!(
+        size_at_return > 0,
+        "the grandchild never wrote to the sentinel — the test cannot prove a kill \
+         reached the group, so a frozen size would be a vacuous pass"
+    );
     tokio::time::sleep(Duration::from_secs(1)).await;
     let size_after = std::fs::metadata(&sentinel).expect("stat sentinel").len();
     assert_eq!(

--- a/crates/core/tests/runner.rs
+++ b/crates/core/tests/runner.rs
@@ -63,3 +63,65 @@ async fn captures_stdout_stderr_exit_separately() {
         "a fast snippet must not be marked timed out"
     );
 }
+
+/// AC2 — when a run exceeds its timeout, the whole process tree (not just the
+/// leader) is killed and a timeout result is returned, rather than the call
+/// hanging for the run's natural duration. The grandchild's sentinel must stop
+/// growing, which only holds if the kill reached the process *group*.
+#[tokio::test]
+async fn timeout_kills_process_tree_under_natural_runtime() {
+    if rscript_absent() {
+        return;
+    }
+
+    // A persistent dir — NOT the runner's temp CWD — for the grandchild's script
+    // and the sentinel it appends to, both referenced by absolute path so they
+    // survive the run dir being cleaned up.
+    let dir = tempfile::tempdir().expect("create test dir");
+    let sentinel = dir.path().join("sentinel.txt");
+    let child_script = dir.path().join("child.R");
+    std::fs::write(&sentinel, b"").expect("seed sentinel");
+    std::fs::write(
+        &child_script,
+        format!(
+            "repeat {{\n  cat('.', file = '{}', append = TRUE)\n  Sys.sleep(0.02)\n}}\n",
+            sentinel.display()
+        ),
+    )
+    .expect("write child script");
+
+    // The parent spawns the grandchild (detached from our pipes so a leak shows
+    // as a growing sentinel, not a hung read) then sleeps far past the timeout.
+    let code = format!(
+        "system2('Rscript', c('--vanilla', '{}'), wait = FALSE, stdout = FALSE, stderr = FALSE)\n\
+         Sys.sleep(60)\n",
+        child_script.display()
+    );
+
+    let runner = RRunner::new(Timeout(Duration::from_secs(2)));
+    let start = std::time::Instant::now();
+    let result = runner
+        .execute(&code, &[])
+        .await
+        .expect("a runaway run is a timeout, not a runner error");
+    let elapsed = start.elapsed();
+
+    assert!(
+        result.timed_out,
+        "a run past its timeout must be marked timed out"
+    );
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "execute must kill the tree near the 2s timeout, not wait out the 60s sleep; took {elapsed:?}"
+    );
+
+    // Give any un-reaped grandchild a full second to keep growing the sentinel.
+    let size_at_return = std::fs::metadata(&sentinel).expect("stat sentinel").len();
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let size_after = std::fs::metadata(&sentinel).expect("stat sentinel").len();
+    assert_eq!(
+        size_at_return, size_after,
+        "the grandchild kept writing after the timeout — the process group was not \
+         killed (sentinel grew {size_at_return} -> {size_after})"
+    );
+}

--- a/crates/core/tests/runner.rs
+++ b/crates/core/tests/runner.rs
@@ -34,7 +34,13 @@ async fn captures_stdout_stderr_exit_separately() {
 
     let runner = RRunner::new(Timeout(Duration::from_secs(30)));
     // `cat` writes to stdout; `message` writes to stderr; the program exits 0.
-    let result: ExecutionResult = runner.execute("cat('OUT'); message('ERR')", &[]).await;
+    // `execute` is fallible: an `Err` means the interpreter never ran (spawn/IO
+    // failure), which is categorically distinct from R writing to stderr, so the
+    // two never collapse into one buffer.
+    let result: ExecutionResult = runner
+        .execute("cat('OUT'); message('ERR')", &[])
+        .await
+        .expect("Rscript should spawn and run to completion");
 
     assert!(
         result.stdout.contains("OUT"),

--- a/crates/core/tests/runner.rs
+++ b/crates/core/tests/runner.rs
@@ -1,0 +1,56 @@
+//! Integration tests for the language-runner seam, exercised against a real
+//! `Rscript`.
+//!
+//! These spawn the real interpreter, so they skip-with-notice when `Rscript` is
+//! absent rather than fail spuriously — mirroring the Slice-1 convention that a
+//! missing external tool is a skip, not a failure (see
+//! `docs/agent-notes/workspace-and-ci.md`).
+
+use std::time::Duration;
+
+use blendtutor_core::runner::{ExecutionResult, RRunner, Runner, Timeout};
+
+/// True (after printing a notice) when `Rscript` is not on `PATH`, so a test can
+/// `return` early instead of failing on machines without R installed.
+fn rscript_absent() -> bool {
+    let present = std::process::Command::new("Rscript")
+        .arg("--version")
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false);
+    if !present {
+        eprintln!("SKIP: Rscript absent — skipping real-interpreter runner test");
+    }
+    !present
+}
+
+/// AC1 — stdout, stderr, and exit status land in three distinct fields of a
+/// normalized [`ExecutionResult`]; the streams do not bleed into one another.
+#[tokio::test]
+async fn captures_stdout_stderr_exit_separately() {
+    if rscript_absent() {
+        return;
+    }
+
+    let runner = RRunner::new(Timeout(Duration::from_secs(30)));
+    // `cat` writes to stdout; `message` writes to stderr; the program exits 0.
+    let result: ExecutionResult = runner.execute("cat('OUT'); message('ERR')", &[]).await;
+
+    assert!(
+        result.stdout.contains("OUT"),
+        "stdout should carry cat() output, got {:?}",
+        result.stdout
+    );
+    assert!(
+        result.stderr.contains("ERR"),
+        "stderr should carry message() output, got {:?}",
+        result.stderr
+    );
+    assert!(
+        !result.stdout.contains("ERR"),
+        "stderr must not bleed into stdout, got {:?}",
+        result.stdout
+    );
+    assert_eq!(result.exit, Some(0), "a clean exit is Some(0), not a blob");
+    assert!(!result.timed_out, "a fast snippet must not be marked timed out");
+}

--- a/docs/adr/0005-runner-trait-and-subprocess-model.md
+++ b/docs/adr/0005-runner-trait-and-subprocess-model.md
@@ -1,0 +1,88 @@
+# ADR-0005: Runner trait and the R subprocess execution model
+
+- Status: Accepted
+- Date: 2026-06-06
+
+(The plan and issue #7 refer to this as "ADR-0003" — that number was assigned
+to the lesson schema before this slice; the runner ADR is 0005.)
+
+## Context
+
+Issue #7 ports the R package's code execution (the `submit_code()` / student
+loop in `R/educator_tools.R`, which shells out to run learner R code) into the
+Rust `core`. Every later slice — Python execution (Slice 8), grading (Slice 9),
+the CLI grade command — depends on *running learner code and observing what it
+did*. The R side runs code and conflates its observations: stdout, messages, and
+errors arrive interleaved, and a runaway loop has no bound.
+
+We need the language-neutral seam those slices depend on, plus its first concrete
+implementation (R via real `Rscript`). The decisions: where the boundary sits,
+how an execution's observations are typed, and how a subprocess is bounded so a
+child that spawns its own children cannot outlive the call.
+
+## Options
+
+1. **Concrete `RRunner` only, no trait.** Grading and the CLI call the R runner
+   directly. Simplest now, but welds every consumer to R: adding the Python
+   runner (Slice 8) or swapping to webR/Pyodide for the browser build forces an
+   edit at each call site, and `core::grading` would import R subprocess
+   mechanics it has no business knowing (§3.4, §4.1 violations).
+2. **`Runner` trait + `RRunner` impl.** Consumers depend on
+   `Runner::execute`; `core::runner::r` owns the R subprocess mechanics alone.
+   A second language or a hosted backend is a new `impl Runner`, invisible to
+   callers (§3.4). The cost is one indirection and a provisional `checks`
+   parameter whose element type the grading slice will refine.
+
+## Decision
+
+Option 2.
+
+- **Seam (§3.4).** `Runner::execute(&self, code, checks) -> Result<ExecutionResult, RunnerError>`.
+  The method is declared returning `impl Future<Output = …> + Send` rather than
+  with `async fn`, so the public trait stays clear of the `async_fn_in_trait`
+  lint under CI's `-D warnings`. `checks: &[String]` is provisional — reserved
+  for the grading slice, which refines the element type; v1 execution does not
+  yet consume it.
+- **Fallibility (§1.3).** `execute` is fallible. An `Err(RunnerError)` means the
+  interpreter never ran (spawn failure, pipe/IO error) — categorically distinct
+  from R running and writing to stderr. So `ExecutionResult` only ever represents
+  a process that actually ran, and a launch failure can never masquerade as a
+  learner diagnostic in `stderr`.
+- **Observations (§1.2).** `ExecutionResult { stdout, stderr, exit: Option<i32>,
+  final_value: Option<String>, timed_out: bool }` — five distinct fields, not one
+  blob. `final_value` is reserved for the grading prompt and is `None` in this
+  slice (its producer arrives with grading, Slice 9); the field is part of the
+  agreed shape so the type does not churn when that slice lands. Building the
+  result from captured bytes is a pure `ExecutionResult::from_capture` (§2.3,
+  §5.3), separate from the effectful spawn.
+- **Timeout (§1.4).** A `Timeout(Duration)` newtype, not a magic integer.
+- **Subprocess model.** `tokio::process` spawns `Rscript -e <code>` with piped
+  stdout/stderr, in a **new process group** via `command-group`. On timeout the
+  whole group is SIGKILLed, so an R child that spawned grandchildren is reaped
+  rather than leaked. `command-group` is chosen over hand-rolled
+  `nix::setpgid` + `killpg` (less `unsafe`, maintained, cross-platform).
+- **Isolation.** Each `execute` runs in a per-call `tempfile::TempDir` as the
+  subprocess CWD, dropped on return — file-writing code is contained and cleaned
+  up, and the caller's CWD is untouched.
+
+**Sandbox posture (trusted-local, v1).** Student code runs in a local subprocess
+bounded only by the timeout and the temp CWD. There is **no** security sandbox:
+the model is a single trusted user grading their own learners locally. A hosted,
+multi-tenant sandbox is a separate effort (issue #7 Out of Scope) and would be a
+new `impl Runner`, not a change to this one.
+
+## Consequences
+
+- The Python runner, grading, and the CLI depend on `Runner`, never on `RRunner`
+  or `Rscript`; a representation change to R execution stays inside
+  `core::runner::r` (§3.2). `core::runner::r` never knows about lessons or LLMs
+  (§4.1).
+- Process-group kill adds the `command-group` dependency and means timeout
+  behavior is only meaningfully testable against a real interpreter that spawns a
+  child — so AC2 is a real-`Rscript` integration test, skipped-with-notice when R
+  is absent (Slice-1 convention), not a unit test.
+- `tokio` enters the workspace here. `core` gains an async, effectful surface for
+  the first time; the pure lesson/course code is unaffected.
+- `final_value` ships as a typed `None` ahead of its producer. This is a
+  deliberate forward-shape commitment (the grading slice fills it), called out so
+  an always-`None` field is not mistaken for a defect before Slice 9.

--- a/docs/agent-notes/runner.md
+++ b/docs/agent-notes/runner.md
@@ -1,0 +1,66 @@
+---
+topic: runner
+created: 2026-06-06
+slices: [7]
+---
+
+How `core::runner` runs learner code: the language-neutral seam and the R
+subprocess mechanics. The Python runner (Slice 8) mirrors this design.
+
+- 2026-06-06 (#7): The seam is the `Runner` trait in `crates/core/src/runner/mod.rs`
+  (`execute(&self, code, checks) -> Result<ExecutionResult, RunnerError>`).
+  Consumers (grading, CLI, Slice 8) depend on the trait, never on the concrete
+  `RRunner` (§3.4, ADR-0005). The R-specific code lives in the private `r`
+  submodule and is re-exported as `runner::RRunner`.
+- 2026-06-06 (#7): The trait method is declared returning
+  `impl Future<Output = …> + Send`, NOT `async fn`. A public trait with `async fn`
+  trips clippy's `async_fn_in_trait`, which is an error under CI's `-D warnings`.
+  The impl block still writes a plain `async fn execute` — that satisfies the
+  `impl Future` RPITIT. Mirror this for the Python runner.
+- 2026-06-06 (#7): `execute` is fallible on purpose. `Err(RunnerError)` means the
+  interpreter never ran (spawn/IO failure); a program that ran and wrote to stderr
+  is `Ok` with a populated `stderr`. So a launch failure can never masquerade as a
+  learner diagnostic (§1.3). `RunnerError` is a typed error (context string + the
+  io::Error source) so `core` stays `anyhow`-free (ADR-0001).
+- 2026-06-06 (#7): `ExecutionResult` keeps `stdout`/`stderr`/`exit`/`final_value`/
+  `timed_out` as five distinct fields (§1.2). `final_value` is a reserved forward
+  shape — always `None` until grading (Slice 9) supplies its producer. `checks`
+  is likewise reserved (`&[String]`, unused in v1); the grading slice refines the
+  element type.
+- 2026-06-06 (#7): **command-group feature flag is `with-tokio`, not `tokio`.**
+  Selecting `features = ["tokio"]` only turns on the optional tokio dependency and
+  silently leaves `AsyncCommandGroup`/`AsyncGroupChild` un-exported — you get
+  "no method named `group_spawn`". Use `command-group = { features = ["with-tokio"] }`.
+- 2026-06-06 (#7): **Process-group kill is load-bearing for the timeout.** Spawn
+  via `AsyncCommandGroup::group_spawn` (new process group), and on timeout call
+  `AsyncGroupChild::kill().await` (SIGKILL to the whole group). The tokio
+  `Child::kill` (reachable via `child.inner().kill()`) kills only the leader — an
+  R child that spawned its own children leaks. AC2's negative control proved this:
+  leader-only kill let the grandchild keep growing its sentinel.
+- 2026-06-06 (#7): **Drain stdout/stderr concurrently or `wait` deadlocks.** A
+  program that fills a ~64 KB pipe buffer blocks on write while `wait` blocks on
+  exit. Take the piped handles off `child.inner()` and read them in `tokio::spawn`
+  tasks before awaiting the process, then join the tasks after. When a test has R
+  spawn a background child, detach the child's stdio (`system2(..., stdout = FALSE,
+  stderr = FALSE)`) so a not-yet-reaped grandchild holding the inherited pipe open
+  can't hang the read — a leak then shows as a growing file, not a hang.
+- 2026-06-06 (#7): Spawn `Rscript --vanilla -e <code>`. `--vanilla` skips user/site
+  `.Rprofile`/`.Renviron`, so capture is reproducible across machines and no
+  profile output bleeds into stdout. The repo root carries a `.Rprofile`/`.Renviron`;
+  the runner's temp CWD avoids them anyway, but `--vanilla` also blocks the user's
+  `~/.Rprofile`.
+- 2026-06-06 (#7): Each `execute` runs in a per-call `tempfile::TempDir` set as the
+  subprocess CWD, dropped on return (isolation + cleanup, AC3). `tempfile` is a
+  normal `core` dependency now (not dev-only) because production code uses it.
+- 2026-06-06 (#7): Real-`Rscript` tests live in `crates/core/tests/runner.rs` and
+  guard with `rscript_absent()` (skip-with-notice when R is missing) per the
+  Slice-1 convention. Two test gotchas worth reusing for Slice 8:
+  - **macOS temp-dir symlink:** `getwd()` (and any interpreter cwd report)
+    canonicalizes `/var` → `/private/var`, so `env::temp_dir()` must be
+    `fs::canonicalize`d before a `starts_with` prefix assertion.
+  - **`set_current_dir` is safe here** only because `cargo nextest run` executes
+    each test in its own process; a plain `cargo test` (threads) would race.
+- 2026-06-06 (#7): Integration tests (`tests/*.rs`) see the crate's normal
+  `[dependencies]` — do **not** duplicate `tokio`/`tempfile` into
+  `[dev-dependencies]` (roborev caught this on #7). Only test-exclusive crates
+  (e.g. `serde_json`) belong in `[dev-dependencies]`.


### PR DESCRIPTION
## Summary
- Adds the language-neutral `Runner` trait and `ExecutionResult` (distinct `stdout`/`stderr`/`exit`/`final_value`/`timed_out` fields, §1.2) in `core::runner`, plus `RRunner` — the first impl — backed by a real `Rscript` subprocess (`core::runner::r`, §4.1).
- `execute` is fallible (`Result<ExecutionResult, RunnerError>`) so a spawn/IO failure is the `Err` arm, never folded into R stderr (§1.3). The subprocess is **group-spawned** with a `Timeout(Duration)` newtype (§1.4) and killed as a process *group* on timeout, so a runaway R child tree is reaped, not leaked. Each run uses an isolated `tempfile::TempDir` CWD that is cleaned up on return.
- Brings `tokio` + `command-group` into the workspace; **ADR-0005** records the seam, the subprocess model, and the trusted-local sandbox posture.

## Issue
Closes #7

## Slices implemented
- **AC1** — `cat('OUT'); message('ERR')` via real `Rscript` lands stdout `"OUT"`, stderr `"ERR"`, `exit == Some(0)`, `timed_out == false` in four distinct fields with no stream bleed. (`captures_stdout_stderr_exit_separately` + a pure `from_capture` unit test on bytes)
- **AC2** — a 2s `Timeout` against R that spawns a *detached grandchild* then sleeps 60s returns `timed_out == true` in <5s, and the grandchild's sentinel stops growing — proving the kill reached the process **group**. (`timeout_kills_process_tree_under_natural_runtime`; negative control: a leader-only kill let the grandchild grow the sentinel 67→104, failing the test as designed)
- **AC3** — R writing a relative `out.txt` runs in a temp-dir CWD under `env::temp_dir()` that no longer exists after the call; the caller's directory gains no `out.txt` and its pre-existing marker is undisturbed. (`runs_in_isolated_temp_dir_cleaned_up`; two negative controls broke isolation and cleanup, both failed as designed)

Real-`Rscript` tests skip-with-notice when R is absent (Slice-1 convention).

## Notes
- Base branch is **`staging/rewrite-in-rust-lol`**, not `main`.
- The ADR is **0005**, not the "0003" the issue/plan referenced — 0003 is the lesson schema (0001–0004 already taken).
- `final_value` ships as a reserved `None` and `checks` as a reserved `&[String]` — forward shapes the grading slice (#9) fills; documented in ADR-0005.
- The trait method returns `impl Future + Send` rather than `async fn` to stay clear of clippy's `async_fn_in_trait` under `-D warnings`.
- Out of scope per the issue: a hosted/sandboxed executor. v1 is trusted-local (timeout + temp cwd, no security sandbox).

## Test plan
- [x] All unit + integration tests pass — `cargo nextest run --locked`: 39 passed
- [x] `cargo clippy --all-targets --locked -- -D warnings` and `cargo fmt --all --check` clean (real exit 0)
- [x] Pre-push `cargo mutants --in-diff` gate: 0 missed (5 caught, 3 unviable)
- [x] Roborev findings resolved (fallible seam, dev-dep dedup, AC2 vacuous-pass guard)
- [x] ADR written — ADR-0005
- [ ] Rodney verification — N/A (no UI surface)