### PR TITLE
[feature] Python runner — subprocess execution through the Runner trait

### DIFF
--- a/crates/core/src/runner/mod.rs
+++ b/crates/core/src/runner/mod.rs
@@ -13,8 +13,10 @@ use std::fmt;
 use std::future::Future;
 use std::time::Duration;
 
+mod python;
 mod r;
 
+pub use python::PythonRunner;
 pub use r::RRunner;
 
 /// A wall-clock bound on a single execution.

--- a/crates/core/src/runner/mod.rs
+++ b/crates/core/src/runner/mod.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 
 mod python;
 mod r;
+mod subprocess;
 
 pub use python::PythonRunner;
 pub use r::RRunner;
@@ -99,14 +100,21 @@ pub trait Runner {
 /// (ADR-0001).
 #[derive(Debug)]
 pub struct RunnerError {
-    context: &'static str,
+    context: String,
     source: std::io::Error,
 }
 
 impl RunnerError {
-    /// Wrap an IO failure with the runner stage that produced it.
-    pub(crate) fn new(context: &'static str, source: std::io::Error) -> Self {
-        Self { context, source }
+    /// Wrap an IO failure with the runner stage that produced it. `context`
+    /// accepts both a `&'static str` (a fixed stage like `"collect stdout"`) and
+    /// an owned `String` (a stage that names the interpreter, e.g.
+    /// `format!("spawn {program}")`), so the shared subprocess core can report
+    /// which interpreter failed without each stage label being a separate const.
+    pub(crate) fn new(context: impl Into<String>, source: std::io::Error) -> Self {
+        Self {
+            context: context.into(),
+            source,
+        }
     }
 }
 

--- a/crates/core/src/runner/python.rs
+++ b/crates/core/src/runner/python.rs
@@ -1,0 +1,129 @@
+//! Python execution mechanics: spawn the interpreter through `uv`, capture its
+//! streams separately, bound it with a timeout, and reap a runaway process tree.
+//!
+//! This module owns *only* the Python subprocess details (ADR-0005, §4.1);
+//! callers depend on the [`Runner`](super::Runner) trait, not on
+//! [`PythonRunner`]. It mirrors the R runner; the shared spawn/timeout/temp-cwd
+//! core is factored out of both in this slice's refactor step (§4.2).
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use command_group::AsyncCommandGroup;
+use tokio::io::AsyncReadExt;
+use tokio::process::Command;
+use tokio::task::JoinHandle;
+use tokio::time::timeout;
+
+use super::{ExecutionResult, Runner, RunnerError, Timeout};
+
+/// A [`Runner`] backed by a real Python subprocess spawned through `uv`.
+#[derive(Debug, Clone)]
+pub struct PythonRunner {
+    timeout: Timeout,
+}
+
+impl PythonRunner {
+    /// Build a runner that kills any execution exceeding `timeout`.
+    pub fn new(timeout: Timeout) -> Self {
+        Self { timeout }
+    }
+}
+
+impl Default for PythonRunner {
+    /// A 30-second bound — generous for a lesson exercise, finite for a runaway.
+    fn default() -> Self {
+        Self::new(Timeout(Duration::from_secs(30)))
+    }
+}
+
+impl Runner for PythonRunner {
+    async fn execute(
+        &self,
+        code: &str,
+        _checks: &[String],
+    ) -> Result<ExecutionResult, RunnerError> {
+        // Per-execute temp dir as CWD: file-writing code is isolated to it and
+        // the directory is removed when `run_dir` drops at the end of this fn.
+        let run_dir =
+            tempfile::TempDir::new().map_err(|e| RunnerError::new("create run directory", e))?;
+
+        // Spawn Python through `uv` (the project's always-uv rule). `--no-project`
+        // ignores any surrounding pyproject so capture is reproducible; `--quiet`
+        // keeps uv's own chatter out of the streams; `-I` runs Python isolated
+        // (no user site, no `PYTHON*` env), the analog of R's `--vanilla`.
+        // `group_spawn` puts the tree in its own process group so a timeout kills
+        // `uv` *and* the python child it launches, not just the leader.
+        let mut child = Command::new("uv")
+            .arg("run")
+            .arg("--no-project")
+            .arg("--quiet")
+            .arg("python")
+            .arg("-I")
+            .arg("-c")
+            .arg(code)
+            .current_dir(run_dir.path())
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .group_spawn()
+            .map_err(|e| RunnerError::new("spawn uv", e))?;
+
+        // Drain both pipes concurrently so a chatty program cannot deadlock the
+        // wait by filling a pipe buffer; the reads make progress while we await
+        // the process below.
+        let mut stdout = child.inner().stdout.take().expect("stdout piped above");
+        let mut stderr = child.inner().stderr.take().expect("stderr piped above");
+        let out_task: JoinHandle<std::io::Result<Vec<u8>>> = tokio::spawn(async move {
+            let mut buf = Vec::new();
+            stdout.read_to_end(&mut buf).await.map(|_| buf)
+        });
+        let err_task: JoinHandle<std::io::Result<Vec<u8>>> = tokio::spawn(async move {
+            let mut buf = Vec::new();
+            stderr.read_to_end(&mut buf).await.map(|_| buf)
+        });
+
+        let (exit, timed_out) = match timeout(self.timeout.0, child.wait()).await {
+            Ok(status) => {
+                let status = status.map_err(|e| RunnerError::new("wait for uv", e))?;
+                (status.code(), false)
+            }
+            Err(_elapsed) => {
+                // SIGKILL the whole process group so the python child uv launched
+                // is reaped, not leaked; then reap the leader.
+                child
+                    .kill()
+                    .await
+                    .map_err(|e| RunnerError::new("kill uv group", e))?;
+                let status = child
+                    .wait()
+                    .await
+                    .map_err(|e| RunnerError::new("reap uv group", e))?;
+                (status.code(), true)
+            }
+        };
+
+        // Every group process is gone, so both pipes have closed and the readers
+        // have finished; collect their bytes.
+        let stdout = join_capture(out_task, "collect stdout").await?;
+        let stderr = join_capture(err_task, "collect stderr").await?;
+
+        Ok(ExecutionResult::from_capture(
+            &stdout, &stderr, exit, timed_out,
+        ))
+        // `run_dir` drops here → the temp directory is removed.
+    }
+}
+
+/// Await a stream-reader task, flattening its join error and IO error into a
+/// [`RunnerError`].
+async fn join_capture(
+    task: JoinHandle<std::io::Result<Vec<u8>>>,
+    context: &'static str,
+) -> Result<Vec<u8>, RunnerError> {
+    match task.await {
+        Ok(Ok(bytes)) => Ok(bytes),
+        Ok(Err(io_err)) => Err(RunnerError::new(context, io_err)),
+        Err(join_err) => Err(RunnerError::new(context, std::io::Error::other(join_err))),
+    }
+}

--- a/crates/core/src/runner/python.rs
+++ b/crates/core/src/runner/python.rs
@@ -1,21 +1,27 @@
-//! Python execution mechanics: spawn the interpreter through `uv`, capture its
-//! streams separately, bound it with a timeout, and reap a runaway process tree.
+//! Python execution mechanics: the Python-specific half of a language run —
+//! launching the interpreter through `uv` — over the shared subprocess core in
+//! [`super::subprocess`].
 //!
-//! This module owns *only* the Python subprocess details (ADR-0005, §4.1);
-//! callers depend on the [`Runner`](super::Runner) trait, not on
-//! [`PythonRunner`]. It mirrors the R runner; the shared spawn/timeout/temp-cwd
-//! core is factored out of both in this slice's refactor step (§4.2).
+//! This module owns *only* the Python specifics (ADR-0005, §4.1); callers depend
+//! on the [`Runner`](super::Runner) trait, not on [`PythonRunner`]. It mirrors
+//! the R runner: both are a small `Interpreter` descriptor over the shared
+//! spawn/timeout/temp-cwd dance (§4.2) — adding a language is a descriptor, not a
+//! re-implementation.
 
-use std::process::Stdio;
 use std::time::Duration;
 
-use command_group::AsyncCommandGroup;
-use tokio::io::AsyncReadExt;
-use tokio::process::Command;
-use tokio::task::JoinHandle;
-use tokio::time::timeout;
-
+use super::subprocess::{self, Interpreter};
 use super::{ExecutionResult, Runner, RunnerError, Timeout};
+
+/// The Python invocation, launched through `uv` per the project's always-uv
+/// rule: `uv run --no-project --quiet python -I -c <code>`. `--no-project`
+/// ignores any surrounding pyproject; `--quiet` keeps uv's own output out of the
+/// captured streams; `-I` runs Python isolated (no user site, no `PYTHON*` env)
+/// — the analog of R's `--vanilla`.
+const PYTHON_INTERPRETER: Interpreter = Interpreter {
+    program: "uv",
+    code_args: &["run", "--no-project", "--quiet", "python", "-I", "-c"],
+};
 
 /// A [`Runner`] backed by a real Python subprocess spawned through `uv`.
 #[derive(Debug, Clone)]
@@ -43,87 +49,6 @@ impl Runner for PythonRunner {
         code: &str,
         _checks: &[String],
     ) -> Result<ExecutionResult, RunnerError> {
-        // Per-execute temp dir as CWD: file-writing code is isolated to it and
-        // the directory is removed when `run_dir` drops at the end of this fn.
-        let run_dir =
-            tempfile::TempDir::new().map_err(|e| RunnerError::new("create run directory", e))?;
-
-        // Spawn Python through `uv` (the project's always-uv rule). `--no-project`
-        // ignores any surrounding pyproject so capture is reproducible; `--quiet`
-        // keeps uv's own chatter out of the streams; `-I` runs Python isolated
-        // (no user site, no `PYTHON*` env), the analog of R's `--vanilla`.
-        // `group_spawn` puts the tree in its own process group so a timeout kills
-        // `uv` *and* the python child it launches, not just the leader.
-        let mut child = Command::new("uv")
-            .arg("run")
-            .arg("--no-project")
-            .arg("--quiet")
-            .arg("python")
-            .arg("-I")
-            .arg("-c")
-            .arg(code)
-            .current_dir(run_dir.path())
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .group_spawn()
-            .map_err(|e| RunnerError::new("spawn uv", e))?;
-
-        // Drain both pipes concurrently so a chatty program cannot deadlock the
-        // wait by filling a pipe buffer; the reads make progress while we await
-        // the process below.
-        let mut stdout = child.inner().stdout.take().expect("stdout piped above");
-        let mut stderr = child.inner().stderr.take().expect("stderr piped above");
-        let out_task: JoinHandle<std::io::Result<Vec<u8>>> = tokio::spawn(async move {
-            let mut buf = Vec::new();
-            stdout.read_to_end(&mut buf).await.map(|_| buf)
-        });
-        let err_task: JoinHandle<std::io::Result<Vec<u8>>> = tokio::spawn(async move {
-            let mut buf = Vec::new();
-            stderr.read_to_end(&mut buf).await.map(|_| buf)
-        });
-
-        let (exit, timed_out) = match timeout(self.timeout.0, child.wait()).await {
-            Ok(status) => {
-                let status = status.map_err(|e| RunnerError::new("wait for uv", e))?;
-                (status.code(), false)
-            }
-            Err(_elapsed) => {
-                // SIGKILL the whole process group so the python child uv launched
-                // is reaped, not leaked; then reap the leader.
-                child
-                    .kill()
-                    .await
-                    .map_err(|e| RunnerError::new("kill uv group", e))?;
-                let status = child
-                    .wait()
-                    .await
-                    .map_err(|e| RunnerError::new("reap uv group", e))?;
-                (status.code(), true)
-            }
-        };
-
-        // Every group process is gone, so both pipes have closed and the readers
-        // have finished; collect their bytes.
-        let stdout = join_capture(out_task, "collect stdout").await?;
-        let stderr = join_capture(err_task, "collect stderr").await?;
-
-        Ok(ExecutionResult::from_capture(
-            &stdout, &stderr, exit, timed_out,
-        ))
-        // `run_dir` drops here → the temp directory is removed.
-    }
-}
-
-/// Await a stream-reader task, flattening its join error and IO error into a
-/// [`RunnerError`].
-async fn join_capture(
-    task: JoinHandle<std::io::Result<Vec<u8>>>,
-    context: &'static str,
-) -> Result<Vec<u8>, RunnerError> {
-    match task.await {
-        Ok(Ok(bytes)) => Ok(bytes),
-        Ok(Err(io_err)) => Err(RunnerError::new(context, io_err)),
-        Err(join_err) => Err(RunnerError::new(context, std::io::Error::other(join_err))),
+        subprocess::run(&PYTHON_INTERPRETER, code, self.timeout).await
     }
 }

--- a/crates/core/src/runner/r.rs
+++ b/crates/core/src/runner/r.rs
@@ -1,19 +1,22 @@
-//! R execution mechanics: spawn `Rscript`, capture its streams separately,
-//! bound it with a timeout, and reap a runaway process tree.
+//! R execution mechanics: the R-specific half of a language run — which program
+//! and which flags — over the shared subprocess core in [`super::subprocess`].
 //!
-//! This module owns *only* the R subprocess details (ADR-0005, §4.1); callers
-//! depend on the [`Runner`](super::Runner) trait, not on [`RRunner`].
+//! This module owns *only* the R specifics (ADR-0005, §4.1); callers depend on
+//! the [`Runner`](super::Runner) trait, not on [`RRunner`], and the
+//! spawn/timeout/temp-cwd dance is shared with every other language (§4.2).
 
-use std::process::Stdio;
 use std::time::Duration;
 
-use command_group::AsyncCommandGroup;
-use tokio::io::AsyncReadExt;
-use tokio::process::Command;
-use tokio::task::JoinHandle;
-use tokio::time::timeout;
-
+use super::subprocess::{self, Interpreter};
 use super::{ExecutionResult, Runner, RunnerError, Timeout};
+
+/// The R invocation: `Rscript --vanilla -e <code>`. `--vanilla` skips user/site
+/// `.Rprofile`/`.Renviron`, so capture is deterministic across machines and no
+/// profile output bleeds into stdout.
+const R_INTERPRETER: Interpreter = Interpreter {
+    program: "Rscript",
+    code_args: &["--vanilla", "-e"],
+};
 
 /// A [`Runner`] backed by a real `Rscript` subprocess.
 #[derive(Debug, Clone)]
@@ -41,81 +44,6 @@ impl Runner for RRunner {
         code: &str,
         _checks: &[String],
     ) -> Result<ExecutionResult, RunnerError> {
-        // Per-execute temp dir as CWD: file-writing code is isolated to it and
-        // the directory is removed when `run_dir` drops at the end of this fn.
-        let run_dir =
-            tempfile::TempDir::new().map_err(|e| RunnerError::new("create run directory", e))?;
-
-        // `--vanilla` skips user/site `.Rprofile`/`.Renviron`, so capture is
-        // deterministic across machines and no profile output bleeds into stdout.
-        // `group_spawn` puts the child in its own process group so the whole tree
-        // can be killed on timeout, not just the leader.
-        let mut child = Command::new("Rscript")
-            .arg("--vanilla")
-            .arg("-e")
-            .arg(code)
-            .current_dir(run_dir.path())
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .group_spawn()
-            .map_err(|e| RunnerError::new("spawn Rscript", e))?;
-
-        // Drain both pipes concurrently so a chatty program cannot deadlock the
-        // wait by filling a pipe buffer; the reads make progress while we await
-        // the process below.
-        let mut stdout = child.inner().stdout.take().expect("stdout piped above");
-        let mut stderr = child.inner().stderr.take().expect("stderr piped above");
-        let out_task: JoinHandle<std::io::Result<Vec<u8>>> = tokio::spawn(async move {
-            let mut buf = Vec::new();
-            stdout.read_to_end(&mut buf).await.map(|_| buf)
-        });
-        let err_task: JoinHandle<std::io::Result<Vec<u8>>> = tokio::spawn(async move {
-            let mut buf = Vec::new();
-            stderr.read_to_end(&mut buf).await.map(|_| buf)
-        });
-
-        let (exit, timed_out) = match timeout(self.timeout.0, child.wait()).await {
-            Ok(status) => {
-                let status = status.map_err(|e| RunnerError::new("wait for Rscript", e))?;
-                (status.code(), false)
-            }
-            Err(_elapsed) => {
-                // SIGKILL the whole process group so an R child that spawned its
-                // own children is reaped, not leaked; then reap the leader.
-                child
-                    .kill()
-                    .await
-                    .map_err(|e| RunnerError::new("kill Rscript group", e))?;
-                let status = child
-                    .wait()
-                    .await
-                    .map_err(|e| RunnerError::new("reap Rscript group", e))?;
-                (status.code(), true)
-            }
-        };
-
-        // Every group process is gone, so both pipes have closed and the readers
-        // have finished; collect their bytes.
-        let stdout = join_capture(out_task, "collect stdout").await?;
-        let stderr = join_capture(err_task, "collect stderr").await?;
-
-        Ok(ExecutionResult::from_capture(
-            &stdout, &stderr, exit, timed_out,
-        ))
-        // `run_dir` drops here → the temp directory is removed.
-    }
-}
-
-/// Await a stream-reader task, flattening its join error and IO error into a
-/// [`RunnerError`].
-async fn join_capture(
-    task: JoinHandle<std::io::Result<Vec<u8>>>,
-    context: &'static str,
-) -> Result<Vec<u8>, RunnerError> {
-    match task.await {
-        Ok(Ok(bytes)) => Ok(bytes),
-        Ok(Err(io_err)) => Err(RunnerError::new(context, io_err)),
-        Err(join_err) => Err(RunnerError::new(context, std::io::Error::other(join_err))),
+        subprocess::run(&R_INTERPRETER, code, self.timeout).await
     }
 }

--- a/crates/core/src/runner/subprocess.rs
+++ b/crates/core/src/runner/subprocess.rs
@@ -1,0 +1,119 @@
+//! Shared subprocess mechanics for every language runner: spawn an interpreter
+//! in an isolated temp working directory, drain its streams without deadlocking,
+//! bound it with a timeout, and reap the whole process group on overrun.
+//!
+//! The language-specific part — which program to run and which flags precede the
+//! learner code — is the caller's, expressed as an [`Interpreter`]. This module
+//! owns the spawn/timeout/temp-cwd core so each `Runner` impl is a small
+//! descriptor over it rather than a per-language copy of the dance (§4.2 —
+//! factored, and deliberately not a "utils" grab-bag: it does one thing).
+
+use std::process::Stdio;
+
+use command_group::AsyncCommandGroup;
+use tokio::io::AsyncReadExt;
+use tokio::process::Command;
+use tokio::task::JoinHandle;
+use tokio::time::timeout;
+
+use super::{ExecutionResult, RunnerError, Timeout};
+
+/// How to launch one language's interpreter for a single run.
+///
+/// The only thing that differs between the R and Python runners: the program
+/// and the arguments that precede the code. Everything else (isolation, capture,
+/// timeout, process-group kill) is identical and lives in [`run`].
+pub(super) struct Interpreter {
+    /// The program to spawn, e.g. `"Rscript"` or `"uv"`.
+    pub program: &'static str,
+    /// The arguments that precede the learner code — e.g. `["--vanilla", "-e"]`
+    /// for R, or `["run", "--no-project", "--quiet", "python", "-I", "-c"]` for
+    /// Python via uv. The code itself is appended as the final argument.
+    pub code_args: &'static [&'static str],
+}
+
+/// Run `code` under `interpreter`, bounded by `bound`, and normalize what it did
+/// into an [`ExecutionResult`].
+///
+/// The whole effectful dance lives here: a per-run [`tempfile::TempDir`] as CWD
+/// (file-writing code is isolated to it and it is removed on return),
+/// `group_spawn` into a fresh process group, concurrent pipe drains so a chatty
+/// program cannot deadlock the wait by filling a pipe buffer, and a
+/// process-group SIGKILL on overrun so a child the interpreter spawned is reaped
+/// rather than leaked. An [`Err`] means the interpreter never ran.
+pub(super) async fn run(
+    interpreter: &Interpreter,
+    code: &str,
+    bound: Timeout,
+) -> Result<ExecutionResult, RunnerError> {
+    let run_dir =
+        tempfile::TempDir::new().map_err(|e| RunnerError::new("create run directory", e))?;
+
+    let mut child = Command::new(interpreter.program)
+        .args(interpreter.code_args)
+        .arg(code)
+        .current_dir(run_dir.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .group_spawn()
+        .map_err(|e| RunnerError::new(format!("spawn {}", interpreter.program), e))?;
+
+    // Drain both pipes concurrently so a chatty program cannot deadlock the wait
+    // by filling a pipe buffer; the reads make progress while we await the
+    // process below.
+    let mut stdout = child.inner().stdout.take().expect("stdout piped above");
+    let mut stderr = child.inner().stderr.take().expect("stderr piped above");
+    let out_task: JoinHandle<std::io::Result<Vec<u8>>> = tokio::spawn(async move {
+        let mut buf = Vec::new();
+        stdout.read_to_end(&mut buf).await.map(|_| buf)
+    });
+    let err_task: JoinHandle<std::io::Result<Vec<u8>>> = tokio::spawn(async move {
+        let mut buf = Vec::new();
+        stderr.read_to_end(&mut buf).await.map(|_| buf)
+    });
+
+    let (exit, timed_out) = match timeout(bound.0, child.wait()).await {
+        Ok(status) => {
+            let status = status
+                .map_err(|e| RunnerError::new(format!("wait for {}", interpreter.program), e))?;
+            (status.code(), false)
+        }
+        Err(_elapsed) => {
+            // SIGKILL the whole process group so a child the interpreter spawned
+            // is reaped, not leaked; then reap the leader.
+            child
+                .kill()
+                .await
+                .map_err(|e| RunnerError::new(format!("kill {} group", interpreter.program), e))?;
+            let status = child
+                .wait()
+                .await
+                .map_err(|e| RunnerError::new(format!("reap {} group", interpreter.program), e))?;
+            (status.code(), true)
+        }
+    };
+
+    // Every group process is gone, so both pipes have closed and the readers have
+    // finished; collect their bytes.
+    let stdout = join_capture(out_task, "collect stdout").await?;
+    let stderr = join_capture(err_task, "collect stderr").await?;
+
+    Ok(ExecutionResult::from_capture(
+        &stdout, &stderr, exit, timed_out,
+    ))
+    // `run_dir` drops here → the temp directory is removed.
+}
+
+/// Await a stream-reader task, flattening its join error and IO error into a
+/// [`RunnerError`].
+async fn join_capture(
+    task: JoinHandle<std::io::Result<Vec<u8>>>,
+    context: &'static str,
+) -> Result<Vec<u8>, RunnerError> {
+    match task.await {
+        Ok(Ok(bytes)) => Ok(bytes),
+        Ok(Err(io_err)) => Err(RunnerError::new(context, io_err)),
+        Err(join_err) => Err(RunnerError::new(context, std::io::Error::other(join_err))),
+    }
+}

--- a/crates/core/tests/runner.rs
+++ b/crates/core/tests/runner.rs
@@ -194,7 +194,9 @@ fn uv_python_absent() -> bool {
         .map(|out| out.status.success())
         .unwrap_or(false);
     if !present {
-        eprintln!("SKIP: `uv run python` unavailable — skipping real-interpreter python runner test");
+        eprintln!(
+            "SKIP: `uv run python` unavailable — skipping real-interpreter python runner test"
+        );
     }
     !present
 }

--- a/crates/core/tests/runner.rs
+++ b/crates/core/tests/runner.rs
@@ -9,7 +9,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use blendtutor_core::runner::{ExecutionResult, RRunner, Runner, Timeout};
+use blendtutor_core::runner::{ExecutionResult, PythonRunner, RRunner, Runner, Timeout};
 
 /// True (after printing a notice) when `Rscript` is not on `PATH`, so a test can
 /// `return` early instead of failing on machines without R installed.
@@ -178,5 +178,68 @@ async fn runs_in_isolated_temp_dir_cleaned_up() {
     assert!(
         marker.exists(),
         "the caller's pre-existing marker was disturbed by the run"
+    );
+}
+
+/// True (after printing a notice) when `uv run python` cannot run here, so a
+/// Python-runner test can `return` early instead of failing on machines without
+/// `uv` (or without a Python it can resolve). The `PythonRunner` spawns the
+/// interpreter through `uv` (per the project's always-`uv` rule), so this guards
+/// on exactly what the runner needs — not on a bare `python` that may be absent
+/// even where `uv run python` works.
+fn uv_python_absent() -> bool {
+    let present = std::process::Command::new("uv")
+        .args(["run", "--no-project", "--quiet", "python", "--version"])
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false);
+    if !present {
+        eprintln!("SKIP: `uv run python` unavailable — skipping real-interpreter python runner test");
+    }
+    !present
+}
+
+/// AC1 — a Python snippet's stdout, stderr, and exit status land in three
+/// distinct fields of a normalized [`ExecutionResult`], captured identically to
+/// the R runner through the same [`Runner`] trait; the streams do not bleed into
+/// one another.
+#[tokio::test]
+async fn python_captures_streams_distinctly() {
+    if uv_python_absent() {
+        return;
+    }
+
+    let runner = PythonRunner::new(Timeout(Duration::from_secs(30)));
+    // Write "OUT" to stdout and "ERR" to stderr, then exit 0. `execute` is
+    // fallible: an `Err` means the interpreter never ran (spawn/IO failure),
+    // categorically distinct from Python writing to stderr, so the two never
+    // collapse into one buffer.
+    let result: ExecutionResult = runner
+        .execute(
+            "import sys; sys.stdout.write('OUT'); sys.stderr.write('ERR')",
+            &[],
+        )
+        .await
+        .expect("python should spawn and run to completion");
+
+    assert!(
+        result.stdout.contains("OUT"),
+        "stdout should carry the stdout write, got {:?}",
+        result.stdout
+    );
+    assert!(
+        result.stderr.contains("ERR"),
+        "stderr should carry the stderr write, got {:?}",
+        result.stderr
+    );
+    assert!(
+        !result.stdout.contains("ERR"),
+        "stderr must not bleed into stdout, got {:?}",
+        result.stdout
+    );
+    assert_eq!(result.exit, Some(0), "a clean exit is Some(0), not a blob");
+    assert!(
+        !result.timed_out,
+        "a fast snippet must not be marked timed out"
     );
 }

--- a/crates/core/tests/runner.rs
+++ b/crates/core/tests/runner.rs
@@ -245,3 +245,38 @@ async fn python_captures_streams_distinctly() {
         "a fast snippet must not be marked timed out"
     );
 }
+
+/// A short wall-clock bound for the Python timeout test: long enough for the
+/// interpreter to start, short enough that a killed run returns well within the
+/// margin asserted below.
+const SHORT_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// AC2 — a Python infinite loop is killed when it exceeds its [`Timeout`] and
+/// returns a timeout result through the same [`Runner`] trait, rather than
+/// running forever. The two-sided wall-clock bound proves a *reaped
+/// still-running* process: `timed_out` rules out a natural exit, and the upper
+/// bound rules out a hang where the kill never fired.
+#[tokio::test]
+async fn python_infinite_loop_times_out() {
+    if uv_python_absent() {
+        return;
+    }
+
+    let runner = PythonRunner::new(Timeout(SHORT_TIMEOUT));
+    let start = std::time::Instant::now();
+    let result = runner
+        .execute("while True:\n    pass\n", &[])
+        .await
+        .expect("a runaway run is a timeout, not a runner error");
+    let elapsed = start.elapsed();
+
+    assert!(
+        result.timed_out,
+        "a run past its timeout must be marked timed out, not completed naturally"
+    );
+    assert!(
+        elapsed < SHORT_TIMEOUT + Duration::from_secs(2),
+        "execute must kill the run near its {SHORT_TIMEOUT:?} timeout, not hang on the \
+         infinite loop; took {elapsed:?}"
+    );
+}

--- a/docs/agent-notes/runner.md
+++ b/docs/agent-notes/runner.md
@@ -1,7 +1,7 @@
 ---
 topic: runner
 created: 2026-06-06
-slices: [7]
+slices: [7, 8]
 ---
 
 How `core::runner` runs learner code: the language-neutral seam and the R
@@ -64,3 +64,32 @@ subprocess mechanics. The Python runner (Slice 8) mirrors this design.
   `[dependencies]` — do **not** duplicate `tokio`/`tempfile` into
   `[dev-dependencies]` (roborev caught this on #7). Only test-exclusive crates
   (e.g. `serde_json`) belong in `[dev-dependencies]`.
+- 2026-06-06 (#8): **Python runs through `uv`, not a bare `python`.** Per the
+  project's always-`uv` rule, `PythonRunner` spawns
+  `uv run --no-project --quiet python -I -c <code>`. `--no-project` ignores any
+  surrounding pyproject so capture is reproducible; `--quiet` keeps uv's own
+  env-setup chatter out of the captured streams (without it, first-run messages
+  bleed into stdout/stderr); `-I` runs Python isolated (no user site, no
+  `PYTHON*` env) — the analog of R's `--vanilla`. The dev machine (and macOS
+  generally) has `python3` but no `python`, so the test skip-guard checks
+  `uv run --no-project --quiet python --version`, not a bare `python` — it gates
+  on exactly what the runner needs.
+- 2026-06-06 (#8): **uv adds a process layer the group-kill already handles.**
+  `uv run python` makes `uv` the group leader and `python` its child, so the
+  Slice-7 process-group SIGKILL reaps both — no extra work. AC2 (`while True:
+  pass` under a 500 ms `Timeout`) confirmed elapsed ≈ the timeout, i.e. the
+  python child is killed, not just uv. It is the same child-tree shape the group
+  kill was built for.
+- 2026-06-06 (#8): **Shared core factored into `runner::subprocess`.** The
+  spawn/drain/timeout/kill/temp-cwd dance is identical across languages; it lives
+  in the private `subprocess::run(&Interpreter, code, Timeout)`. A `Runner` impl
+  is now just an `Interpreter { program, code_args }` const (R: `Rscript` +
+  `["--vanilla", "-e"]`; Python: `uv` +
+  `["run", "--no-project", "--quiet", "python", "-I", "-c"]`) — adding a language
+  is a descriptor, not a re-implementation (§4.2). The core appends `code` as the
+  final arg.
+- 2026-06-06 (#8): `RunnerError`'s context is now `String` (was `&'static str`),
+  built via `impl Into<String>`, so the shared core can name the failing
+  interpreter — `format!("spawn {program}")` yields "spawn Rscript" / "spawn uv"
+  rather than a generic "spawn interpreter". Existing `&str` literal call sites
+  coerce unchanged.


### PR DESCRIPTION
## Summary
- Add `PythonRunner`, a second `impl Runner` that executes Python snippets through `uv run --no-project --quiet python -I -c <code>` — no trait or caller change, proving the `Runner` seam (§3.2, §3.4).
- Factor the spawn/drain/timeout/process-group-kill/temp-cwd dance out of `r.rs` into a shared private `runner::subprocess` core; each runner is now a small `Interpreter` descriptor (§4.2). Adding a language is a descriptor, not a re-implementation.
- The interpreter is launched via `uv` per the project's always-`uv` rule (not a bare `python3`); `--quiet` keeps uv's own chatter out of the captured streams, `--no-project` ignores any surrounding pyproject, and `-I` isolates Python — the analog of R's `--vanilla`.

## Issue
Closes #8

## Slices implemented
- **AC1 — streams captured distinctly** (`python_captures_streams_distinctly`): a snippet writing `OUT`→stdout, `ERR`→stderr, exit 0 yields `stdout.contains("OUT") && exit == Some(0) && !stdout.contains("ERR") && stderr.contains("ERR")` — five distinct `ExecutionResult` fields, no stream bleed.
- **AC2 — infinite loop times out** (`python_infinite_loop_times_out`): `while True: pass` under a 500 ms `Timeout` returns `timed_out == true` with a two-sided wall-clock bound (rules out both a faked timeout and a hang). First-run-green; a negative control is documented in the red commit (forced `timed_out = false` → test failed at the expected assertion → reverted).

Both real-interpreter tests skip-with-notice when `uv run python` is unavailable.

## Notes / decisions
- **Interpreter = `uv run python`, not a bare `python`.** The spec deferred the choice to the impl ("impl picks the interpreter name"); per the project's always-`uv` rule the runner launches Python via `uv`. The dev machine (macOS) has `python3` but no `python`, so the skip-guard checks `uv run --no-project --quiet python --version` — gating on exactly what the runner needs. The spec's `command -v python` probe is superseded by this uv-aware guard.
- **uv's extra process layer** (`uv` → `python`) is reaped by the existing Slice-7 process-group SIGKILL — same child-tree shape it was built for; AC2 confirms the python child is killed, not just uv.
- **No new ADR** — covered by the runner ADR (trait + subprocess model, Slice 7).
- **`RunnerError` context** widened `&'static str` → `String` so the shared core names the failing interpreter ("spawn uv" / "spawn Rscript") instead of a generic label; all `&str` literal call sites coerce unchanged.

## Test plan
- [x] All unit + integration tests pass — `cargo nextest run`: 42/42, 0 skipped (R AC1–3 + Python AC1–2)
- [x] `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `RUSTDOCFLAGS=-D warnings cargo doc --no-deps` all clean
- [x] Roborev findings resolved — clean on all five commits
- [x] ADRs written/updated (if applicable) — n/a (covered by the runner ADR)
- [ ] Rodney verification — n/a (not UI-touching)