### PR TITLE
[feature] Runner dispatch + lesson checks to pass/fail

### DIFF
--- a/crates/core/src/grade.rs
+++ b/crates/core/src/grade.rs
@@ -39,7 +39,7 @@ pub enum CheckOutcome {
 /// takes `impl Runner` and never names `RRunner`/`PythonRunner` (§3.4). The
 /// `match` over it is exhaustive: adding a [`Language`] variant forces a new arm
 /// both here and in [`select_runner`], so a language can never be silently
-/// dropped (§1.2).
+/// dropped.
 #[derive(Debug, Clone)]
 pub enum RunnerKind {
     /// The R runner.
@@ -103,35 +103,55 @@ pub async fn run_checks(
 mod tests {
     use super::*;
 
-    /// A [`Runner`] that fabricates a fixed result instead of spawning an
-    /// interpreter, so `run_checks`'s classification — exit code → outcome, and
-    /// the spawn-failure arm a real interpreter never reaches — is exercised
-    /// deterministically with no `Rscript`/`uv` on `PATH`. It impls the real
-    /// [`Runner`] trait (so the signature can't drift) and returns the real
-    /// [`ExecutionResult`]/[`RunnerError`] built through their own constructors,
-    /// honouring the seam contract: a program that *ran* (any exit) is `Ok`; a
-    /// failure to launch is `Err`.
-    enum FakeRunner {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// One scripted interpreter outcome for [`ScriptedRunner`] to replay.
+    enum Reply {
         /// The program ran and exited with `code`, writing `stderr`.
         Exited { code: i32, stderr: String },
         /// The interpreter could not be launched at all.
         FailedToSpawn,
     }
 
-    impl Runner for FakeRunner {
+    /// A [`Runner`] that replays a fixed script of replies in call order instead
+    /// of spawning an interpreter, so `run_checks`'s classification (exit code →
+    /// outcome, plus the spawn-failure arm a real interpreter never reaches) *and*
+    /// its element-wise ordering are pinned deterministically with no
+    /// `Rscript`/`uv` on `PATH`. It impls the real [`Runner`] trait (so the
+    /// signature can't drift) and returns the real
+    /// [`ExecutionResult`]/[`RunnerError`] through their own constructors,
+    /// honouring the seam contract: a program that *ran* (any exit) is `Ok`; a
+    /// failure to launch is `Err`. The call cursor is an [`AtomicUsize`] — not a
+    /// `Cell` — so `&self` stays `Sync` and the `execute` future stays `Send`.
+    struct ScriptedRunner {
+        script: Vec<Reply>,
+        next: AtomicUsize,
+    }
+
+    impl ScriptedRunner {
+        fn new(script: Vec<Reply>) -> Self {
+            Self {
+                script,
+                next: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl Runner for ScriptedRunner {
         async fn execute(
             &self,
             _code: &str,
             _checks: &[String],
         ) -> Result<ExecutionResult, RunnerError> {
-            match self {
-                FakeRunner::Exited { code, stderr } => Ok(ExecutionResult::from_capture(
+            let turn = self.next.fetch_add(1, Ordering::SeqCst);
+            match &self.script[turn] {
+                Reply::Exited { code, stderr } => Ok(ExecutionResult::from_capture(
                     b"",
                     stderr.as_bytes(),
                     Some(*code),
                     false,
                 )),
-                FakeRunner::FailedToSpawn => Err(RunnerError::new(
+                Reply::FailedToSpawn => Err(RunnerError::new(
                     "spawn fake",
                     std::io::Error::new(std::io::ErrorKind::NotFound, "no such interpreter"),
                 )),
@@ -139,8 +159,8 @@ mod tests {
         }
     }
 
-    fn checks(one: &str) -> Vec<String> {
-        vec![one.to_string()]
+    fn check_strings(n: usize) -> Vec<String> {
+        (0..n).map(|i| format!("check_{i}")).collect()
     }
 
     #[test]
@@ -160,28 +180,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_check_whose_program_exits_cleanly_is_a_pass() {
-        let runner = FakeRunner::Exited {
-            code: 0,
-            stderr: String::new(),
-        };
-        let outcomes = run_checks(runner, "submission", &checks("check")).await;
-        assert_eq!(outcomes, vec![CheckOutcome::Pass]);
-    }
-
-    #[tokio::test]
-    async fn a_check_whose_program_exits_nonzero_is_a_fail_carrying_stderr() {
-        let runner = FakeRunner::Exited {
-            code: 1,
-            stderr: "assertion failed".to_string(),
-        };
-        let outcomes = run_checks(runner, "submission", &checks("check")).await;
+    async fn checks_are_classified_element_wise_in_order() {
+        // First check exits clean → Pass; second exits non-zero → Fail carrying
+        // its stderr. Replaying distinct replies in call order means a grader that
+        // reversed, folded, or mis-paired the results cannot reproduce this exact
+        // ordered vector — pinning both the per-exit-code classification and the
+        // element-wise order off any live interpreter.
+        let runner = ScriptedRunner::new(vec![
+            Reply::Exited {
+                code: 0,
+                stderr: String::new(),
+            },
+            Reply::Exited {
+                code: 1,
+                stderr: "assertion failed".to_string(),
+            },
+        ]);
+        let outcomes = run_checks(runner, "submission", &check_strings(2)).await;
         assert_eq!(
             outcomes,
-            vec![CheckOutcome::Fail {
-                detail: "assertion failed".to_string()
-            }],
-            "a non-zero exit fails the check and the interpreter's stderr is the detail"
+            vec![
+                CheckOutcome::Pass,
+                CheckOutcome::Fail {
+                    detail: "assertion failed".to_string()
+                },
+            ],
+            "a clean exit then a non-zero exit must be [Pass, Fail{{stderr}}] in order"
         );
     }
 
@@ -189,8 +213,8 @@ mod tests {
     async fn a_check_whose_interpreter_cannot_launch_is_a_fail() {
         // The spawn-failure arm: a real interpreter present on `PATH` never
         // produces it, so only this fake reaches the `Err` branch of run_checks.
-        let runner = FakeRunner::FailedToSpawn;
-        let outcomes = run_checks(runner, "submission", &checks("check")).await;
+        let runner = ScriptedRunner::new(vec![Reply::FailedToSpawn]);
+        let outcomes = run_checks(runner, "submission", &check_strings(1)).await;
         assert!(
             matches!(outcomes.as_slice(), [CheckOutcome::Fail { .. }]),
             "a launch failure cannot leave the check unclassified, got {outcomes:?}"

--- a/crates/core/src/grade.rs
+++ b/crates/core/src/grade.rs
@@ -92,11 +92,20 @@ pub fn select_runner(language: &Language) -> RunnerKind {
 /// runs cleanly, each check is the submission followed by the check code-string;
 /// the check passes when that program exits cleanly and fails otherwise.
 /// Outcomes are element-wise — never folded into a single aggregate verdict.
+///
+/// With no checks there is nothing to classify, so the submission is not run at
+/// all — an LLM-only lesson (the common case) never pays for a subprocess here.
 pub async fn run_checks(
     runner: impl Runner,
     submission: &str,
     checks: &[String],
 ) -> Vec<CheckOutcome> {
+    // Guard before the gate's subprocess (§1.3.1): with nothing to classify there
+    // is no reason to run the submission at all.
+    if checks.is_empty() {
+        return Vec::new();
+    }
+
     if let Some(reason) = submission_run_failure(&runner, submission).await {
         return checks
             .iter()
@@ -226,6 +235,19 @@ mod tests {
             code: 0,
             stderr: String::new(),
         }
+    }
+
+    #[tokio::test]
+    async fn no_checks_runs_nothing_and_returns_empty() {
+        // The script is empty, so any execute call would panic indexing it. This
+        // passes only if run_checks short-circuits before touching the runner —
+        // the LLM-only path must not spawn the submission.
+        let runner = ScriptedRunner::new(vec![]);
+        let outcomes = run_checks(runner, "submission", &check_strings(0)).await;
+        assert!(
+            outcomes.is_empty(),
+            "no checks yields no outcomes, got {outcomes:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/grade.rs
+++ b/crates/core/src/grade.rs
@@ -14,9 +14,10 @@ use crate::runner::{ExecutionResult, PythonRunner, RRunner, Runner, RunnerError}
 /// The verdict for a single lesson check.
 ///
 /// A sum type, not a `bool`, so per-check verdicts stay distinct and the grader
-/// never folds them into one aggregate (§1.2). Slice 9 begins with the two
-/// states a *running* submission produces; a submission that cannot run at all
-/// gains its own variant in AC3 rather than masquerading as a failure.
+/// never folds them into one aggregate (§1.2). Three real states: the check
+/// passed, the submission ran and violated it, and — kept deliberately separate
+/// from a failure (§3.3) — the submission could not run at all, so no check ever
+/// got a verdict.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CheckOutcome {
     /// The submission satisfied the check.
@@ -26,6 +27,14 @@ pub enum CheckOutcome {
         /// What the interpreter wrote when the check failed — typically the
         /// failing assertion on stderr.
         detail: String,
+    },
+    /// The submission could not be executed at all (a syntax error, or the
+    /// interpreter failed to launch), so this check never ran. Distinct from
+    /// [`Fail`](CheckOutcome::Fail): the submission was never even evaluated.
+    NotRun {
+        /// Why the submission could not run — the interpreter's diagnostic, or
+        /// the launch error.
+        reason: String,
     },
 }
 
@@ -73,15 +82,30 @@ pub fn select_runner(language: &Language) -> RunnerKind {
 /// Run each `check` against `submission` through `runner`, returning one
 /// [`CheckOutcome`] per check, in order.
 ///
-/// Effectful: each check is the `submission` followed by the check code-string,
-/// executed in the runner; the check passes when that program exits cleanly and
-/// fails otherwise (§2.2). Outcomes are element-wise — never folded into a single
-/// aggregate verdict — so a caller sees exactly which checks held.
+/// Effectful (§2.2). The submission is first run **on its own**: if it cannot
+/// execute — a syntax error, or a launch failure — every check is
+/// [`NotRun`](CheckOutcome::NotRun), because no check could have a verdict
+/// (§3.3). This standalone gate is load-bearing: concatenating the submission
+/// with a check and reading the combined exit code cannot tell a broken
+/// submission from a violated check (and some interpreters, R among them, would
+/// even splice an unterminated submission into the check). Once the submission
+/// runs cleanly, each check is the submission followed by the check code-string;
+/// the check passes when that program exits cleanly and fails otherwise.
+/// Outcomes are element-wise — never folded into a single aggregate verdict.
 pub async fn run_checks(
     runner: impl Runner,
     submission: &str,
     checks: &[String],
 ) -> Vec<CheckOutcome> {
+    if let Some(reason) = submission_run_failure(&runner, submission).await {
+        return checks
+            .iter()
+            .map(|_| CheckOutcome::NotRun {
+                reason: reason.clone(),
+            })
+            .collect();
+    }
+
     let mut outcomes = Vec::with_capacity(checks.len());
     for check in checks {
         let program = format!("{submission}\n{check}");
@@ -97,6 +121,22 @@ pub async fn run_checks(
         outcomes.push(outcome);
     }
     outcomes
+}
+
+/// Run `submission` on its own and report why it could not run, or `None` if it
+/// ran cleanly.
+///
+/// The gate that makes "errored before checks" distinct from a check verdict
+/// (§3.3, §5.1): a non-zero exit means the submission ran and failed (a syntax
+/// error surfaces here), and an [`Err`] means the interpreter never launched —
+/// both are reasons no check can run. A clean exit is `None`, so the caller
+/// proceeds to the checks.
+async fn submission_run_failure(runner: &impl Runner, submission: &str) -> Option<String> {
+    match runner.execute(submission, &[]).await {
+        Ok(result) if result.exit == Some(0) => None,
+        Ok(result) => Some(result.stderr),
+        Err(error) => Some(error.to_string()),
+    }
 }
 
 #[cfg(test)]
@@ -179,14 +219,25 @@ mod tests {
         );
     }
 
+    /// A reply for a submission that ran cleanly on its own — the gate's
+    /// pass-through, so a test's script can focus on the checks that follow it.
+    fn clean() -> Reply {
+        Reply::Exited {
+            code: 0,
+            stderr: String::new(),
+        }
+    }
+
     #[tokio::test]
     async fn checks_are_classified_element_wise_in_order() {
-        // First check exits clean → Pass; second exits non-zero → Fail carrying
-        // its stderr. Replaying distinct replies in call order means a grader that
-        // reversed, folded, or mis-paired the results cannot reproduce this exact
-        // ordered vector — pinning both the per-exit-code classification and the
-        // element-wise order off any live interpreter.
+        // The submission passes the gate, then the first check exits clean → Pass
+        // and the second exits non-zero → Fail carrying its stderr. Replaying
+        // distinct replies in call order means a grader that reversed, folded, or
+        // mis-paired the results cannot reproduce this exact ordered vector —
+        // pinning the per-exit-code classification and the element-wise order off
+        // any live interpreter.
         let runner = ScriptedRunner::new(vec![
+            clean(),
             Reply::Exited {
                 code: 0,
                 stderr: String::new(),
@@ -210,14 +261,51 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_check_whose_interpreter_cannot_launch_is_a_fail() {
-        // The spawn-failure arm: a real interpreter present on `PATH` never
-        // produces it, so only this fake reaches the `Err` branch of run_checks.
+    async fn a_submission_that_exits_nonzero_makes_every_check_notrun() {
+        // The submission runs but exits non-zero on its own (e.g. a syntax error):
+        // the gate fails, so every check is NotRun carrying the submission's
+        // stderr — never Fail — and no check is executed at all.
+        let runner = ScriptedRunner::new(vec![Reply::Exited {
+            code: 1,
+            stderr: "could not parse submission".to_string(),
+        }]);
+        let outcomes = run_checks(runner, "broken submission", &check_strings(2)).await;
+        assert_eq!(
+            outcomes,
+            vec![
+                CheckOutcome::NotRun {
+                    reason: "could not parse submission".to_string()
+                },
+                CheckOutcome::NotRun {
+                    reason: "could not parse submission".to_string()
+                },
+            ],
+            "a submission that cannot run makes every check NotRun, not Fail"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_submission_whose_interpreter_cannot_launch_makes_checks_notrun() {
+        // The gate's other failure arm: the interpreter never launched for the
+        // submission, so the checks are NotRun, distinct from a check failure.
         let runner = ScriptedRunner::new(vec![Reply::FailedToSpawn]);
         let outcomes = run_checks(runner, "submission", &check_strings(1)).await;
         assert!(
+            matches!(outcomes.as_slice(), [CheckOutcome::NotRun { .. }]),
+            "a submission launch failure is NotRun, got {outcomes:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_check_whose_interpreter_cannot_launch_is_a_fail() {
+        // After the submission passes the gate, a per-check launch failure is a
+        // Fail — the check could not produce a verdict — NOT a NotRun, which is
+        // reserved for the submission itself failing to run.
+        let runner = ScriptedRunner::new(vec![clean(), Reply::FailedToSpawn]);
+        let outcomes = run_checks(runner, "submission", &check_strings(1)).await;
+        assert!(
             matches!(outcomes.as_slice(), [CheckOutcome::Fail { .. }]),
-            "a launch failure cannot leave the check unclassified, got {outcomes:?}"
+            "a per-check launch failure after a clean submission is a Fail, got {outcomes:?}"
         );
     }
 }

--- a/crates/core/src/grade.rs
+++ b/crates/core/src/grade.rs
@@ -31,11 +31,15 @@ pub enum CheckOutcome {
 
 /// A runner chosen for a lesson's language.
 ///
-/// A closed enum rather than a `Box<dyn Runner>`: [`Runner::execute`] returns
-/// `impl Future` (an RPITIT), which is not object-safe, so dispatch is a fixed
-/// set of concrete runners matched exhaustively (§1.2). Adding a language adds a
-/// variant here and an arm in [`select_runner`]; the compiler then forces every
-/// `match` to account for it.
+/// A closed enum holding one concrete runner. [`Runner::execute`] returns
+/// `impl Future` (an RPITIT), so the trait is not object-safe and a
+/// runtime-chosen runner cannot be a `Box<dyn Runner>`; an enum is how we carry
+/// that choice instead. Consumers still depend on the [`Runner`] trait, not on
+/// these concrete variants — `RunnerKind` itself impls it, so [`run_checks`]
+/// takes `impl Runner` and never names `RRunner`/`PythonRunner` (§3.4). The
+/// `match` over it is exhaustive: adding a [`Language`] variant forces a new arm
+/// both here and in [`select_runner`], so a language can never be silently
+/// dropped (§1.2).
 #[derive(Debug, Clone)]
 pub enum RunnerKind {
     /// The R runner.
@@ -99,11 +103,97 @@ pub async fn run_checks(
 mod tests {
     use super::*;
 
+    /// A [`Runner`] that fabricates a fixed result instead of spawning an
+    /// interpreter, so `run_checks`'s classification — exit code → outcome, and
+    /// the spawn-failure arm a real interpreter never reaches — is exercised
+    /// deterministically with no `Rscript`/`uv` on `PATH`. It impls the real
+    /// [`Runner`] trait (so the signature can't drift) and returns the real
+    /// [`ExecutionResult`]/[`RunnerError`] built through their own constructors,
+    /// honouring the seam contract: a program that *ran* (any exit) is `Ok`; a
+    /// failure to launch is `Err`.
+    enum FakeRunner {
+        /// The program ran and exited with `code`, writing `stderr`.
+        Exited { code: i32, stderr: String },
+        /// The interpreter could not be launched at all.
+        FailedToSpawn,
+    }
+
+    impl Runner for FakeRunner {
+        async fn execute(
+            &self,
+            _code: &str,
+            _checks: &[String],
+        ) -> Result<ExecutionResult, RunnerError> {
+            match self {
+                FakeRunner::Exited { code, stderr } => Ok(ExecutionResult::from_capture(
+                    b"",
+                    stderr.as_bytes(),
+                    Some(*code),
+                    false,
+                )),
+                FakeRunner::FailedToSpawn => Err(RunnerError::new(
+                    "spawn fake",
+                    std::io::Error::new(std::io::ErrorKind::NotFound, "no such interpreter"),
+                )),
+            }
+        }
+    }
+
+    fn checks(one: &str) -> Vec<String> {
+        vec![one.to_string()]
+    }
+
     #[test]
     fn select_runner_dispatches_an_r_lesson_to_the_r_runner() {
         assert!(
             matches!(select_runner(&Language::R), RunnerKind::R(_)),
             "an R lesson must select the R runner"
+        );
+    }
+
+    #[test]
+    fn select_runner_dispatches_a_python_lesson_to_the_python_runner() {
+        assert!(
+            matches!(select_runner(&Language::Python), RunnerKind::Python(_)),
+            "a Python lesson must select the Python runner"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_check_whose_program_exits_cleanly_is_a_pass() {
+        let runner = FakeRunner::Exited {
+            code: 0,
+            stderr: String::new(),
+        };
+        let outcomes = run_checks(runner, "submission", &checks("check")).await;
+        assert_eq!(outcomes, vec![CheckOutcome::Pass]);
+    }
+
+    #[tokio::test]
+    async fn a_check_whose_program_exits_nonzero_is_a_fail_carrying_stderr() {
+        let runner = FakeRunner::Exited {
+            code: 1,
+            stderr: "assertion failed".to_string(),
+        };
+        let outcomes = run_checks(runner, "submission", &checks("check")).await;
+        assert_eq!(
+            outcomes,
+            vec![CheckOutcome::Fail {
+                detail: "assertion failed".to_string()
+            }],
+            "a non-zero exit fails the check and the interpreter's stderr is the detail"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_check_whose_interpreter_cannot_launch_is_a_fail() {
+        // The spawn-failure arm: a real interpreter present on `PATH` never
+        // produces it, so only this fake reaches the `Err` branch of run_checks.
+        let runner = FakeRunner::FailedToSpawn;
+        let outcomes = run_checks(runner, "submission", &checks("check")).await;
+        assert!(
+            matches!(outcomes.as_slice(), [CheckOutcome::Fail { .. }]),
+            "a launch failure cannot leave the check unclassified, got {outcomes:?}"
         );
     }
 }

--- a/crates/core/src/grade.rs
+++ b/crates/core/src/grade.rs
@@ -1,0 +1,109 @@
+//! The lesson↔runner grading join: pick a language's runner and turn each lesson
+//! check code-string into a typed pass/fail outcome.
+//!
+//! This is where [`lesson`](crate::lesson) meets [`runner`](crate::runner). It
+//! depends on both only through their public types — a [`Language`] to choose a
+//! runner, the [`Runner`] trait to execute, and a lesson's check code-strings to
+//! grade against (§3.1). Selecting the runner is pure; running checks is
+//! effectful (§2.1, §2.2). This module classifies outcomes; it does NOT build
+//! prompts or call LLMs — that is the provider layer's job (§4.1).
+
+use crate::lesson::Language;
+use crate::runner::{ExecutionResult, PythonRunner, RRunner, Runner, RunnerError};
+
+/// The verdict for a single lesson check.
+///
+/// A sum type, not a `bool`, so per-check verdicts stay distinct and the grader
+/// never folds them into one aggregate (§1.2). Slice 9 begins with the two
+/// states a *running* submission produces; a submission that cannot run at all
+/// gains its own variant in AC3 rather than masquerading as a failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckOutcome {
+    /// The submission satisfied the check.
+    Pass,
+    /// The check ran and the submission violated it.
+    Fail {
+        /// What the interpreter wrote when the check failed — typically the
+        /// failing assertion on stderr.
+        detail: String,
+    },
+}
+
+/// A runner chosen for a lesson's language.
+///
+/// A closed enum rather than a `Box<dyn Runner>`: [`Runner::execute`] returns
+/// `impl Future` (an RPITIT), which is not object-safe, so dispatch is a fixed
+/// set of concrete runners matched exhaustively (§1.2). Adding a language adds a
+/// variant here and an arm in [`select_runner`]; the compiler then forces every
+/// `match` to account for it.
+#[derive(Debug, Clone)]
+pub enum RunnerKind {
+    /// The R runner.
+    R(RRunner),
+    /// The Python runner.
+    Python(PythonRunner),
+}
+
+impl Runner for RunnerKind {
+    async fn execute(&self, code: &str, checks: &[String]) -> Result<ExecutionResult, RunnerError> {
+        match self {
+            RunnerKind::R(r) => r.execute(code, checks).await,
+            RunnerKind::Python(p) => p.execute(code, checks).await,
+        }
+    }
+}
+
+/// Select the runner for a lesson's `language`.
+///
+/// Pure: it maps a [`Language`] to a runner with no I/O (§2.1). The `match` is
+/// exhaustive with no wildcard arm, so a new [`Language`] variant fails to
+/// compile here until it is dispatched explicitly — a language can never
+/// silently fall through to the wrong runner.
+pub fn select_runner(language: &Language) -> RunnerKind {
+    match language {
+        Language::R => RunnerKind::R(RRunner::default()),
+        Language::Python => RunnerKind::Python(PythonRunner::default()),
+    }
+}
+
+/// Run each `check` against `submission` through `runner`, returning one
+/// [`CheckOutcome`] per check, in order.
+///
+/// Effectful: each check is the `submission` followed by the check code-string,
+/// executed in the runner; the check passes when that program exits cleanly and
+/// fails otherwise (§2.2). Outcomes are element-wise — never folded into a single
+/// aggregate verdict — so a caller sees exactly which checks held.
+pub async fn run_checks(
+    runner: impl Runner,
+    submission: &str,
+    checks: &[String],
+) -> Vec<CheckOutcome> {
+    let mut outcomes = Vec::with_capacity(checks.len());
+    for check in checks {
+        let program = format!("{submission}\n{check}");
+        let outcome = match runner.execute(&program, &[]).await {
+            Ok(result) if result.exit == Some(0) => CheckOutcome::Pass,
+            Ok(result) => CheckOutcome::Fail {
+                detail: result.stderr,
+            },
+            Err(error) => CheckOutcome::Fail {
+                detail: error.to_string(),
+            },
+        };
+        outcomes.push(outcome);
+    }
+    outcomes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn select_runner_dispatches_an_r_lesson_to_the_r_runner() {
+        assert!(
+            matches!(select_runner(&Language::R), RunnerKind::R(_)),
+            "an R lesson must select the R runner"
+        );
+    }
+}

--- a/crates/core/src/lesson.rs
+++ b/crates/core/src/lesson.rs
@@ -97,9 +97,11 @@ pub struct Lesson {
     /// The exercise the lesson poses. Required.
     pub exercise: Exercise,
     /// Executable check code-strings, run against a submission in the lesson's
-    /// language to grade it (Slice 9). Optional and defaulting to empty: a lesson
-    /// with no checks is graded by the LLM alone (the R package's model), so an
-    /// author need not write checks and every existing lesson stays valid (§1.2).
+    /// language to grade it (Slice 9). A `Vec` defaulting to empty, not an
+    /// `Option<Vec>`: "no checks" is just the empty list, so there is no
+    /// redundant null state forcing absence-handling downstream (§1.1). A lesson
+    /// graded by the LLM alone (the R package's model) therefore needs no
+    /// `checks` key, and every existing lesson stays valid.
     #[serde(default)]
     pub checks: Vec<String>,
     /// Optional one-line summary.

--- a/crates/core/src/lesson.rs
+++ b/crates/core/src/lesson.rs
@@ -96,6 +96,12 @@ pub struct Lesson {
     pub language: Language,
     /// The exercise the lesson poses. Required.
     pub exercise: Exercise,
+    /// Executable check code-strings, run against a submission in the lesson's
+    /// language to grade it (Slice 9). Optional and defaulting to empty: a lesson
+    /// with no checks is graded by the LLM alone (the R package's model), so an
+    /// author need not write checks and every existing lesson stays valid (§1.2).
+    #[serde(default)]
+    pub checks: Vec<String>,
     /// Optional one-line summary.
     pub description: Option<String>,
     /// Optional pointer to a textbook section.
@@ -242,6 +248,43 @@ exercise:
         // The snake_case `type` value maps to the enum; the round-trip test then
         // confirms this populated optional survives JSON unchanged.
         assert_eq!(lesson.exercise.kind, Some(ExerciseKind::FunctionWriting));
+    }
+
+    const LESSON_WITH_CHECKS_YAML: &str = r#"
+lesson_name: "Adder"
+language: R
+checks:
+  - "stopifnot(add_two(2, 3) == 5)"
+  - "stopifnot(is.function(add_two))"
+exercise:
+  prompt: "Write a function add_two(x, y)."
+  llm_evaluation_prompt: "Grade this: {student_code}"
+"#;
+
+    #[test]
+    fn parse_reads_checks_as_ordered_code_strings() {
+        let lesson = Lesson::parse(LESSON_WITH_CHECKS_YAML).expect("a lesson with checks is valid");
+        assert_eq!(
+            lesson.checks,
+            vec![
+                "stopifnot(add_two(2, 3) == 5)".to_string(),
+                "stopifnot(is.function(add_two))".to_string(),
+            ],
+            "checks parse in document order as raw code-strings"
+        );
+    }
+
+    #[test]
+    fn parse_defaults_checks_to_empty_when_absent() {
+        // A lesson with no `checks` key is graded by the LLM alone (the R
+        // package's model); checks must default to empty rather than be required,
+        // so every existing lesson stays valid.
+        let lesson = Lesson::parse(VALID_YAML).expect("valid lesson should parse");
+        assert!(
+            lesson.checks.is_empty(),
+            "a lesson without a checks key has no checks, got {:?}",
+            lesson.checks
+        );
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -15,6 +15,7 @@
 #![deny(missing_docs)]
 
 pub mod course;
+pub mod grade;
 pub mod lesson;
 pub mod runner;
 

--- a/crates/core/tests/grade.rs
+++ b/crates/core/tests/grade.rs
@@ -99,3 +99,48 @@ fn python_lesson_selects_python_runner() {
         "a language: Python lesson must select the Python runner"
     );
 }
+
+/// An R lesson with a single check, for the submission-error case.
+const LESSON_R_ONE_CHECK: &str = r#"
+lesson_name: "Adder"
+language: R
+checks:
+  - "stopifnot(add_two(2, 3) == 5)"
+exercise:
+  prompt: "Write a function add_two(x, y)."
+  llm_evaluation_prompt: "Grade this submission: {student_code}"
+"#;
+
+/// An un-parseable R submission: `x <-` has no right-hand side, so it is a syntax
+/// error that cannot execute at all — categorically different from a submission
+/// that runs and violates a check.
+const SUBMISSION_R_SYNTAX_ERROR: &str = "x <- ";
+
+/// AC3 — a submission that errors *before* any check can run is reported as
+/// `NotRun`, distinct from a check the submission ran and failed. Both halves are
+/// pinned: the outcome is `NotRun{..}` AND it is not `Fail{..}`, so an impl that
+/// maps "interpreter exited non-zero" onto `Fail` (the bug this AC guards
+/// against) is caught — "not Pass" alone would let a `Fail` through.
+#[tokio::test]
+async fn submission_error_is_notrun_not_fail() {
+    if rscript_absent() {
+        return;
+    }
+
+    let lesson = Lesson::parse(LESSON_R_ONE_CHECK).expect("fixture lesson is valid");
+    let runner = select_runner(&lesson.language);
+
+    let outcomes = run_checks(runner, SUBMISSION_R_SYNTAX_ERROR, &lesson.checks).await;
+
+    assert_eq!(outcomes.len(), 1, "one outcome for the single check");
+    assert!(
+        matches!(outcomes[0], CheckOutcome::NotRun { .. }),
+        "a submission that cannot execute is NotRun, got {:?}",
+        outcomes[0]
+    );
+    assert!(
+        !matches!(outcomes[0], CheckOutcome::Fail { .. }),
+        "a submission error must not be reported as a check failure, got {:?}",
+        outcomes[0]
+    );
+}

--- a/crates/core/tests/grade.rs
+++ b/crates/core/tests/grade.rs
@@ -7,7 +7,7 @@
 //! `docs/agent-notes/workspace-and-ci.md`). The pure runner-selection test needs
 //! no interpreter and always runs.
 
-use blendtutor_core::grade::{CheckOutcome, run_checks, select_runner};
+use blendtutor_core::grade::{CheckOutcome, RunnerKind, run_checks, select_runner};
 use blendtutor_core::lesson::Lesson;
 
 /// True (after printing a notice) when `Rscript` is not on `PATH`, so a
@@ -70,5 +70,32 @@ async fn r_runner_reports_per_check_pass_fail() {
         matches!(outcomes[1], CheckOutcome::Fail { .. }),
         "check 2 (a property the submission lacks) must fail, got {:?}",
         outcomes[1]
+    );
+}
+
+/// A minimal `language: Python` lesson with one trivial check and the required
+/// valid exercise. Parsing it (rather than hand-building a `Language`) proves the
+/// real lesson field drives selection.
+const LESSON_PYTHON_MINIMAL: &str = r#"
+lesson_name: "Py Adder"
+language: Python
+checks:
+  - "assert True"
+exercise:
+  prompt: "Write a function add_two(x, y)."
+  llm_evaluation_prompt: "Grade this submission: {student_code}"
+"#;
+
+/// AC2 — a `language: Python` lesson auto-selects the Python runner. The
+/// assertion is on the *selected runner's identity*, not on any executed output,
+/// so it needs no interpreter on `PATH`. `select_runner` matches the language
+/// exhaustively with no wildcard arm, so an R-hardcoded or `_`-defaulting impl
+/// would return the R runner here and fail the `RunnerKind::Python` match.
+#[test]
+fn python_lesson_selects_python_runner() {
+    let lesson = Lesson::parse(LESSON_PYTHON_MINIMAL).expect("fixture lesson is valid");
+    assert!(
+        matches!(select_runner(&lesson.language), RunnerKind::Python(_)),
+        "a language: Python lesson must select the Python runner"
     );
 }

--- a/crates/core/tests/grade.rs
+++ b/crates/core/tests/grade.rs
@@ -111,9 +111,12 @@ exercise:
   llm_evaluation_prompt: "Grade this submission: {student_code}"
 "#;
 
-/// An un-parseable R submission: `x <-` has no right-hand side, so it is a syntax
-/// error that cannot execute at all — categorically different from a submission
-/// that runs and violates a check.
+/// An un-parseable R submission: `x <-` has no right-hand side, so run *on its
+/// own* it is a syntax error (`Rscript` exits non-zero with "unexpected end of
+/// input"). This pins the standalone-gate mechanism: the grader must evaluate the
+/// submission alone, not concatenated with a check — R would splice `x <-` onto
+/// the next line and the failure would surface as a check-style "could not find
+/// function" error, masquerading as a `Fail`.
 const SUBMISSION_R_SYNTAX_ERROR: &str = "x <- ";
 
 /// AC3 — a submission that errors *before* any check can run is reported as

--- a/crates/core/tests/grade.rs
+++ b/crates/core/tests/grade.rs
@@ -7,7 +7,7 @@
 //! `docs/agent-notes/workspace-and-ci.md`). The pure runner-selection test needs
 //! no interpreter and always runs.
 
-use blendtutor_core::grade::{run_checks, select_runner, CheckOutcome};
+use blendtutor_core::grade::{CheckOutcome, run_checks, select_runner};
 use blendtutor_core::lesson::Lesson;
 
 /// True (after printing a notice) when `Rscript` is not on `PATH`, so a

--- a/crates/core/tests/grade.rs
+++ b/crates/core/tests/grade.rs
@@ -1,0 +1,74 @@
+//! Integration tests for the lesson↔runner grading join: selecting a runner by
+//! language and turning each lesson check code-string into a typed
+//! pass/fail/not-run outcome, exercised against a real interpreter.
+//!
+//! The check-running tests spawn a real `Rscript`, so they skip-with-notice when
+//! it is absent (the Slice-1 convention; see
+//! `docs/agent-notes/workspace-and-ci.md`). The pure runner-selection test needs
+//! no interpreter and always runs.
+
+use blendtutor_core::grade::{run_checks, select_runner, CheckOutcome};
+use blendtutor_core::lesson::Lesson;
+
+/// True (after printing a notice) when `Rscript` is not on `PATH`, so a
+/// real-interpreter test can `return` early instead of failing on machines
+/// without R installed.
+fn rscript_absent() -> bool {
+    let present = std::process::Command::new("Rscript")
+        .arg("--version")
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false);
+    if !present {
+        eprintln!("SKIP: Rscript absent — skipping real-interpreter grade test");
+    }
+    !present
+}
+
+/// An R lesson whose two checks split on the submission: the first asserts a
+/// property the submission has, the second asserts one it lacks. A grader that
+/// folds the checks into one aggregate bool, or always passes, cannot reproduce
+/// the ordered `[Pass, Fail]` this fixture forces.
+const LESSON_R_TWO_CHECKS_SPLIT: &str = r#"
+lesson_name: "Adder"
+language: R
+checks:
+  - "stopifnot(add_two(2, 3) == 5)"
+  - "stopifnot(add_two(2, 3) == 6)"
+exercise:
+  prompt: "Write a function add_two(x, y)."
+  llm_evaluation_prompt: "Grade this submission: {student_code}"
+"#;
+
+/// A correct `add_two`: it satisfies check 1 (`add_two(2, 3) == 5`) and violates
+/// check 2 (`add_two(2, 3) == 6`).
+const SUBMISSION_PASSES_C1_FAILS_C2: &str = "add_two <- function(x, y) x + y";
+
+/// AC1 — each lesson check runs through the selected R runner and reports
+/// pass/fail independently and in order. The correct submission satisfies the
+/// first check and violates the second, so the outcomes are exactly
+/// `[Pass, Fail]` — position 1 pinned to `Pass` and position 2 to `Fail` so an
+/// aggregate-bool, single-outcome, or always-pass impl cannot pass.
+#[tokio::test]
+async fn r_runner_reports_per_check_pass_fail() {
+    if rscript_absent() {
+        return;
+    }
+
+    let lesson = Lesson::parse(LESSON_R_TWO_CHECKS_SPLIT).expect("fixture lesson is valid");
+    let runner = select_runner(&lesson.language);
+
+    let outcomes = run_checks(runner, SUBMISSION_PASSES_C1_FAILS_C2, &lesson.checks).await;
+
+    assert_eq!(outcomes.len(), 2, "one outcome per check, in order");
+    assert_eq!(
+        outcomes[0],
+        CheckOutcome::Pass,
+        "check 1 (a property the submission has) must pass"
+    );
+    assert!(
+        matches!(outcomes[1], CheckOutcome::Fail { .. }),
+        "check 2 (a property the submission lacks) must fail, got {:?}",
+        outcomes[1]
+    );
+}

--- a/docs/agent-notes/grade.md
+++ b/docs/agent-notes/grade.md
@@ -1,0 +1,54 @@
+---
+topic: grade
+created: 2026-06-06
+slices: [9]
+---
+
+How student submissions are graded against a lesson's checks: the `core::grade`
+join between `lesson` and `runner`, and how a per-check verdict is produced.
+
+- 2026-06-06 (#9): `core::grade` is the lesson↔runner join (§3.1). It exposes two
+  functions: `select_runner(&Language) -> RunnerKind` (pure — maps a language to a
+  runner, §2.1) and `async run_checks(impl Runner, submission, &[String]) ->
+  Vec<CheckOutcome>` (effectful, §2.2). It depends on `lesson` and `runner` only
+  through their public types and does NOT build prompts or call LLMs (§4.1) — that
+  is Slice 10's provider layer.
+- 2026-06-06 (#9): `CheckOutcome` is a sum type `{ Pass, Fail{detail}, NotRun{reason} }`,
+  one per check, never folded into an aggregate bool (§1.2). `NotRun` is the
+  load-bearing variant: a submission that could not run at all is kept distinct
+  from a check the submission ran and violated (§3.3), so "errored before checks"
+  never masquerades as a `Fail`.
+- 2026-06-06 (#9): **The submission is run on its own first (the gate).** A check
+  is graded by running `submission + "\n" + check` and reading the exit code
+  (0 = `Pass`, non-zero = `Fail{stderr}`). But to tell `NotRun` from `Fail` you
+  MUST execute the submission *alone* before any check: a non-zero exit or a
+  launch failure there makes every check `NotRun`. Concatenating submission+check
+  and reading the combined exit cannot distinguish them — and R in particular
+  splices an unterminated submission onto the check line (`x <-` + a check parses
+  as `x <- stopifnot(...)` and fails as "could not find function", a Fail-shaped
+  error). Verified by AC3 against real Rscript.
+- 2026-06-06 (#9): `run_checks` short-circuits to `vec![]` when `checks` is empty,
+  before the gate's subprocess (§1.3.1). This is the common path: an LLM-only
+  lesson (the R package's model) has no code-checks, so it must not pay for a
+  submission spawn.
+- 2026-06-06 (#9): **`select_runner` returns a `RunnerKind` enum, not a
+  `Box<dyn Runner>`.** `Runner::execute` returns `impl Future` (an RPITIT, see
+  `runner.md`), so the trait is not object-safe and a runtime-chosen runner cannot
+  be boxed. `RunnerKind { R(RRunner), Python(PythonRunner) }` impls `Runner` by
+  delegating, so consumers still depend on the trait (`run_checks` takes
+  `impl Runner`, never names a concrete runner — §3.4). The `match` over
+  `Language` is exhaustive with no `_` arm, so a new language forces a new dispatch
+  arm at compile time.
+- 2026-06-06 (#9): Checks live on the lesson as `Lesson.checks: Vec<String>`
+  (`#[serde(default)]`, see `lesson-model.md`) — code-strings in the lesson's
+  language. Empty by default so every existing (checkless, LLM-graded) lesson stays
+  valid; the field is a `Vec`, not an `Option<Vec>`, so "no checks" is just the
+  empty list (§1.1).
+- 2026-06-06 (#9): Unit tests drive the classification with a `#[cfg(test)]`
+  `ScriptedRunner` that impls the real `Runner` trait and replays a fixed script of
+  results in call order — so `run_checks`'s exit-code→outcome mapping, the
+  spawn-failure (`Err`) arm a real interpreter never reaches, and element-wise
+  ordering are all pinned with no `Rscript`/`uv` on `PATH`. Its call cursor is an
+  `AtomicUsize` (NOT a `Cell`) so `&self` stays `Sync` and the `execute` future
+  stays `Send` under the RPITIT `+ Send` bound. Real-interpreter behaviour is the
+  separate skip-guarded integration test in `tests/grade.rs`.

--- a/docs/agent-notes/grade.md
+++ b/docs/agent-notes/grade.md
@@ -52,3 +52,11 @@ join between `lesson` and `runner`, and how a per-check verdict is produced.
   `AtomicUsize` (NOT a `Cell`) so `&self` stays `Sync` and the `execute` future
   stays `Send` under the RPITIT `+ Send` bound. Real-interpreter behaviour is the
   separate skip-guarded integration test in `tests/grade.rs`.
+- 2026-06-06 (#9): **Known gap — timeouts produce an empty message.** `run_checks`
+  classifies a timed-out submission as `NotRun` and a timed-out check as `Fail`
+  (both defensible), but neither it nor `submission_run_failure` inspects
+  `ExecutionResult.timed_out`, so the `reason`/`detail` is the empty post-SIGKILL
+  stderr. Giving timeouts an informative message (or a dedicated outcome), plus a
+  `ScriptedRunner::TimedOut` reply to pin it, is deferred — surfaced by the
+  adversarial review on PR #34; no AC in #9 covers it. Grep `timed_out` here when
+  that slice starts.


### PR DESCRIPTION
## Summary
- Adds `core::grade`, the lesson↔runner join: `select_runner(&Language)` (pure dispatch) and `run_checks(impl Runner, submission, &[checks])` (effectful), producing one typed `CheckOutcome` per check.
- `CheckOutcome { Pass, Fail{detail}, NotRun{reason} }` keeps "submission couldn't run" distinct from "check violated": the submission is gated by running it on its own first, so a syntax error is `NotRun`, not a `Fail`.
- Lessons gain an optional, default-empty `checks: Vec<String>` of code-strings; an LLM-only lesson (no checks) stays valid and never spawns a subprocess.

## Issue
Closes #9 — base is the `staging/rewrite-in-rust-lol` integration branch (not `main`), per the issue.

## Slices implemented
- **AC1** — an R lesson's checks each run through the selected R runner and report pass/fail in order. `r_runner_reports_per_check_pass_fail` asserts `[Pass, Fail{..}]` against real Rscript (positions pinned, not an aggregate bool).
- **AC2** — a `language: Python` lesson auto-selects the Python runner. `python_lesson_selects_python_runner` asserts the selected runner's identity (pure, no interpreter); `select_runner`'s match is exhaustive with no wildcard arm.
- **AC3** — a submission that errors before checks is `NotRun`, distinct from a check failure. `submission_error_is_notrun_not_fail` pins `NotRun{..}` AND not `Fail{..}` against real Rscript.

Deterministic unit tests (no interpreter, via a `ScriptedRunner` that impls the real `Runner` trait) additionally pin: element-wise ordering, the spawn-failure arm a real interpreter never reaches, gate-failure → every check `NotRun`, per-check failure vs gate failure, and the empty-checks short-circuit.

## Design notes
- Dispatch is a `RunnerKind` enum, not `Box<dyn Runner>`: `Runner::execute` returns `impl Future` (an RPITIT), which is not object-safe. Consumers still depend on the `Runner` trait via `impl Runner` (§3.4).
- The standalone gate is load-bearing: concatenating submission+check and reading the combined exit cannot tell a broken submission from a violated check — R in particular splices an unterminated submission (`x <-`) onto the check line. See `docs/agent-notes/grade.md`.
- No ADR — a consequence of ADR-0003 (lesson schema: check bodies as code-strings) + ADR-0005 (runner trait).

## Test plan
- [x] All unit + integration tests pass (`cargo nextest run`: 54 passed; `cargo clippy -D warnings` clean; `cargo fmt --check` clean; docs build clean)
- [x] Roborev findings resolved (gate clean on HEAD)
- [x] ADRs written/updated — N/A (consequence of ADR-0003 + ADR-0005)
- [ ] Rodney verification — N/A (core grading logic, no UI surface)