### PR TITLE
[feature] run command — execute + LLM feedback end to end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tokio",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,3 +21,5 @@ assert_cmd = { workspace = true }
 insta = { workspace = true }
 predicates = { workspace = true }
 tempfile = { workspace = true }
+tokio = { workspace = true }
+wiremock = { workspace = true }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,6 +15,7 @@ blendtutor-core = { path = "../core" }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -5,4 +5,5 @@
 //! `core`'s responsibility (the dependency only ever points cli → core).
 
 pub mod list;
+pub mod run;
 pub mod validate;

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -1,10 +1,9 @@
 //! `blendtutor run <lesson> [--code <file>]` — the headline student loop.
 //!
 //! A thin orchestration shell (§4.1, §5.1): it gathers inputs (the lesson, the
-//! submission, the provider override), drives the pure-ish core
-//! [`run_lesson`](blendtutor_core::run::run_lesson) on a runtime, and renders the
-//! result through the [`output`](crate::output) seam. It contains no execution,
-//! grading, or HTTP logic — those live in `core`.
+//! submission, the provider override), drives the pure-ish core [`run_lesson`] on
+//! a runtime, and renders the result through the [`output`] seam. It contains no
+//! execution, grading, or HTTP logic — those live in `core`.
 
 use std::io::{self, IsTerminal};
 use std::path::Path;

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -11,14 +11,20 @@ use std::path::Path;
 use std::process::ExitCode;
 
 use blendtutor_core::lesson::read_lesson_file;
-use blendtutor_core::llm::{ProviderChoice, Submission};
-use blendtutor_core::run::run_lesson;
+use blendtutor_core::llm::{ProviderChoice, Submission, Verdict};
+use blendtutor_core::run::{RunReport, run_lesson};
 
 use crate::output::{self, OutputFormat};
 
 /// The environment variable that overrides the provider's base URL — the test
 /// seam pointing the rig client at a stub (ADR-0006). Unset in production.
 const PROVIDER_URL_VAR: &str = "BLENDTUTOR_PROVIDER_URL";
+
+/// The exit code reserved for a submission that ran and was graded "not yet
+/// correct". Distinct from success (0) and from the error code (1, returned via
+/// `main` when a run fails outright), so a submit loop can tell a retry-worthy
+/// verdict from a pass and from a crash.
+const NOT_YET_CORRECT: u8 = 2;
 
 /// Load the lesson and submission, run the student loop, and render the report.
 ///
@@ -47,7 +53,18 @@ pub fn run(
     ))?;
 
     output::emit_run(&report, format)?;
-    Ok(ExitCode::SUCCESS)
+    Ok(verdict_exit_code(&report))
+}
+
+/// The process exit code for a report's verdict — read off the typed result so it
+/// is identical across output formats (§3.4): a correct submission succeeds, an
+/// incorrect one returns the reserved "not yet correct" code. A run that fails
+/// outright never reaches here; it propagates as an error and exits 1 via `main`.
+fn verdict_exit_code(report: &RunReport) -> ExitCode {
+    match report.verdict() {
+        Verdict::Correct { .. } => ExitCode::SUCCESS,
+        Verdict::Incorrect { .. } => ExitCode::from(NOT_YET_CORRECT),
+    }
 }
 
 /// Read the student's submission from `code_path`, or from stdin when no file is

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -1,0 +1,72 @@
+//! `blendtutor run <lesson> [--code <file>]` — the headline student loop.
+//!
+//! A thin orchestration shell (§4.1, §5.1): it gathers inputs (the lesson, the
+//! submission, the provider override), drives the pure-ish core
+//! [`run_lesson`](blendtutor_core::run::run_lesson) on a runtime, and renders the
+//! result through the [`output`](crate::output) seam. It contains no execution,
+//! grading, or HTTP logic — those live in `core`.
+
+use std::io::{self, IsTerminal};
+use std::path::Path;
+use std::process::ExitCode;
+
+use blendtutor_core::lesson::read_lesson_file;
+use blendtutor_core::llm::{ProviderChoice, Submission};
+use blendtutor_core::run::run_lesson;
+
+use crate::output::{self, OutputFormat};
+
+/// The environment variable that overrides the provider's base URL — the test
+/// seam pointing the rig client at a stub (ADR-0006). Unset in production.
+const PROVIDER_URL_VAR: &str = "BLENDTUTOR_PROVIDER_URL";
+
+/// Load the lesson and submission, run the student loop, and render the report.
+///
+/// Reads the lesson (a read/parse failure propagates as an error → exit 1), reads
+/// the submission from `code_path` or stdin, then drives `run_lesson` on a
+/// current-thread runtime (the binary owns its async runtime; `core` stays a
+/// library). The report is rendered via [`output::emit_run`]; the exit code is
+/// the success code until the reserved verdict codes land with AC2.
+pub fn run(
+    lesson_path: &Path,
+    code_path: Option<&Path>,
+    format: OutputFormat,
+) -> anyhow::Result<ExitCode> {
+    let lesson = read_lesson_file(lesson_path)?;
+    let submission = Submission::new(read_submission(code_path)?);
+    let base_url = std::env::var(PROVIDER_URL_VAR).ok();
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    let report = runtime.block_on(run_lesson(
+        &lesson,
+        &submission,
+        ProviderChoice::default(),
+        base_url.as_deref(),
+    ))?;
+
+    output::emit_run(&report, format)?;
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Read the student's submission from `code_path`, or from stdin when no file is
+/// given.
+///
+/// A missing or unreadable `--code` file is a genuine IO error that propagates
+/// (→ exit 1), kept distinct from a "not yet correct" verdict. With no `--code`,
+/// piped stdin is read; an interactive terminal (no piped input) yields an empty
+/// submission rather than blocking on a TTY.
+fn read_submission(code_path: Option<&Path>) -> io::Result<String> {
+    match code_path {
+        Some(path) => std::fs::read_to_string(path),
+        None => {
+            let stdin = io::stdin();
+            if stdin.is_terminal() {
+                Ok(String::new())
+            } else {
+                io::read_to_string(stdin)
+            }
+        }
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -46,8 +46,17 @@ enum Commands {
         #[arg(long, value_enum, default_value_t = OutputFormat::Human)]
         format: OutputFormat,
     },
-    /// Run a lesson interactively with LLM feedback.
-    Run,
+    /// Run a lesson: execute a submission, grade it, and get LLM feedback.
+    Run {
+        /// Path to the lesson YAML file.
+        lesson: PathBuf,
+        /// Path to the student's submission. Read from stdin when omitted.
+        #[arg(long)]
+        code: Option<PathBuf>,
+        /// Output format: `human` (default) or `json`.
+        #[arg(long, value_enum, default_value_t = OutputFormat::Human)]
+        format: OutputFormat,
+    },
     /// Run feedback-quality evals for a lesson.
     Eval,
     /// Build a browser-deployable lesson site.
@@ -63,7 +72,7 @@ impl Commands {
             Commands::New => "new",
             Commands::Validate { .. } => "validate",
             Commands::List { .. } => "list",
-            Commands::Run => "run",
+            Commands::Run { .. } => "run",
             Commands::Eval => "eval",
             Commands::Build => "build",
         }
@@ -75,6 +84,11 @@ fn main() -> anyhow::Result<ExitCode> {
     match cli.command {
         Commands::Validate { path, format } => commands::validate::run(&path, format),
         Commands::List { path, format } => commands::list::run(&path, format),
+        Commands::Run {
+            lesson,
+            code,
+            format,
+        } => commands::run::run(&lesson, code.as_deref(), format),
         other => Err(blendtutor_core::NotYetImplemented::new(other.name()).into()),
     }
 }

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -14,6 +14,8 @@ use serde::Serialize;
 
 use blendtutor_core::course::{DiscoveryError, LessonSummary};
 use blendtutor_core::lesson::Language;
+use blendtutor_core::llm::Verdict;
+use blendtutor_core::run::RunReport;
 
 /// How a command's result is rendered for the user.
 ///
@@ -330,6 +332,37 @@ fn render_list_human(report: &ListReport) -> String {
 /// listing reaches the terminal (§2.4, §5.1).
 pub fn emit_list(report: &ListReport, format: OutputFormat) -> io::Result<()> {
     writeln!(io::stdout(), "{}", render_list(report, format))
+}
+
+/// The human rendering of a [`RunReport`]: a verdict headline (`Correct!` /
+/// `Incorrect.`) followed by the learner-facing feedback.
+///
+/// Pure (§2.1): it reads the report and returns text, performing no I/O. The
+/// verdict word is matched off the typed [`Verdict`], so it cannot drift from the
+/// graded result. "Incorrect" deliberately starts the line so a `\bcorrect\b`
+/// word-boundary match cannot mistake an incorrect verdict for a pass.
+fn render_run(report: &RunReport) -> String {
+    match report.verdict() {
+        Verdict::Correct { message } => format!("Correct!\n\n{message}"),
+        Verdict::Incorrect { message } => format!("Incorrect.\n\n{message}"),
+    }
+}
+
+/// Render `report` in `format` and write it to stdout — the single place a run
+/// result reaches the terminal (§2.4, §5.1).
+///
+/// JSON is the report's canonical machine document (defined in `core`); human is
+/// the verdict + feedback. Both are the command's data, so both go to stdout —
+/// diagnostics (a load or provider failure) are errors that reach stderr via
+/// `main`, never mixed into this stream.
+pub fn emit_run(report: &RunReport, format: OutputFormat) -> io::Result<()> {
+    let text = match format {
+        OutputFormat::Json => {
+            serde_json::to_string(report).expect("a RunReport serializes to JSON infallibly")
+        }
+        OutputFormat::Human => render_run(report),
+    };
+    writeln!(io::stdout(), "{text}")
 }
 
 #[cfg(test)]

--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -1,0 +1,100 @@
+//! Shared helpers for the `blendtutor run` integration tests.
+//!
+//! `run` executes learner code through the real interpreter and asks the LLM
+//! provider for a verdict. The interpreter is real (so these tests skip-with-
+//! notice when `Rscript` is absent, per the Slice-1 convention). The provider is
+//! a `wiremock` server bound to a real localhost port and pointed at via the
+//! `BLENDTUTOR_PROVIDER_URL` base-URL override (ADR-0006) — the spawned binary
+//! connects to it exactly as it would a real provider, so the request/extract/
+//! verdict path is exercised end to end without a real API.
+//!
+//! `assert_cmd::Command` is synchronous, so a test spawns the binary inside
+//! `tokio::task::spawn_blocking`: that frees the test's async runtime to keep
+//! serving the wiremock mock while the child's HTTP request is in flight (a
+//! direct blocking call on a single-threaded runtime would deadlock).
+
+use assert_cmd::Command;
+use serde_json::json;
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// True (after printing a notice) when `Rscript` is not on `PATH`, so a
+/// real-interpreter test can `return` early instead of failing on machines
+/// without R installed (mirrors `core/tests/runner.rs`).
+pub fn rscript_absent() -> bool {
+    let present = std::process::Command::new("Rscript")
+        .arg("--version")
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false);
+    if !present {
+        eprintln!("SKIP: Rscript absent — skipping real-interpreter run test");
+    }
+    !present
+}
+
+/// Mount a 200 returning a real OpenAI chat-completions envelope whose single
+/// tool call carries `arguments` as a JSON-**encoded string** — the shape rig's
+/// openai client parses. The tool is named `submit`, the name rig's `Extractor`
+/// forces. Mirrors `core/tests/llm.rs::mount_tool_call` so the CLI exercises the
+/// same wire contract the provider layer is unit-tested against.
+pub async fn mount_tool_call(server: &MockServer, arguments: &str) {
+    let body = json!({
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "test-model",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": { "name": "submit", "arguments": arguments }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 }
+    });
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
+/// The ported example lesson (R, no checks — LLM-graded), under `core`'s fixtures.
+pub const LESSON: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../core/tests/fixtures/lessons/add_two_numbers.yaml"
+);
+
+/// A correct `add_two` submission (valid R that runs cleanly).
+pub const CORRECT_CODE: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/runs/add_two_numbers_correct.R"
+);
+
+/// A wrong-but-runnable `add_two` submission (valid R, wrong arithmetic).
+pub const WRONG_CODE: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/runs/add_two_numbers_wrong.R"
+);
+
+/// Run the `blendtutor` binary with `args`, supplying a dummy Fireworks key and
+/// pointing the provider seam at `provider_url`, and capture its output.
+///
+/// Synchronous (`assert_cmd`); call inside `spawn_blocking` so the wiremock
+/// server on the test runtime keeps serving while this blocks. The key is set on
+/// the **child** (never the test process), so tests need no serialization.
+pub fn blendtutor_output(args: Vec<String>, provider_url: String) -> std::process::Output {
+    Command::cargo_bin("blendtutor")
+        .expect("binary `blendtutor` should be built")
+        .args(&args)
+        .env("FIREWORKS_API_KEY", "test-key")
+        .env("BLENDTUTOR_PROVIDER_URL", provider_url)
+        .output()
+        .expect("running `blendtutor run` should produce output")
+}

--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -84,6 +84,28 @@ pub const CORRECT_CODE: &str = concat!(
     "/tests/fixtures/runs/add_two_numbers_correct.R"
 );
 
+/// A wrong-but-runnable `add_two` submission (valid R, wrong arithmetic) — runs
+/// cleanly, so the verdict comes from the provider, not a launch failure.
+pub const WRONG_CODE: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/runs/add_two_numbers_wrong.R"
+);
+
+/// A localhost URL whose port has no listener, so a request to it is refused.
+/// Drives the provider-error path (transport failure → exit 1) deterministically
+/// without standing up a server. The bound port is freed before returning; the OS
+/// will not immediately reuse it.
+pub fn dead_provider_url() -> String {
+    let listener =
+        std::net::TcpListener::bind("127.0.0.1:0").expect("bind an ephemeral localhost port");
+    let port = listener
+        .local_addr()
+        .expect("read the bound port")
+        .port();
+    drop(listener);
+    format!("http://127.0.0.1:{port}")
+}
+
 /// Run the `blendtutor` binary with `args`, supplying a dummy Fireworks key and
 /// pointing the provider seam at `provider_url`, and capture its output.
 ///

--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -91,10 +91,16 @@ pub const WRONG_CODE: &str = concat!(
     "/tests/fixtures/runs/add_two_numbers_wrong.R"
 );
 
-/// A localhost URL whose port has no listener, so a request to it is refused.
-/// Drives the provider-error path (transport failure → exit 1) deterministically
-/// without standing up a server. The bound port is freed before returning; the OS
-/// will not immediately reuse it.
+/// A localhost URL whose port has no listener, so a request to it is refused —
+/// drives the provider-error path (a failed feedback request → exit 1) without
+/// standing up a server.
+///
+/// The port is obtained by binding an ephemeral port and freeing it; the tiny
+/// window before the child connects does not threaten the assertion, because the
+/// test only asserts exit 1: a connection refused, a non-200, or any response
+/// that is not a valid `submit` tool call all map to a feedback error. The single
+/// way to flip it would be an unrelated process grabbing that exact freed port
+/// *and* serving a well-formed OpenAI verdict — which cannot happen.
 pub fn dead_provider_url() -> String {
     let listener =
         std::net::TcpListener::bind("127.0.0.1:0").expect("bind an ephemeral localhost port");

--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -104,10 +104,7 @@ pub const WRONG_CODE: &str = concat!(
 pub fn dead_provider_url() -> String {
     let listener =
         std::net::TcpListener::bind("127.0.0.1:0").expect("bind an ephemeral localhost port");
-    let port = listener
-        .local_addr()
-        .expect("read the bound port")
-        .port();
+    let port = listener.local_addr().expect("read the bound port").port();
     drop(listener);
     format!("http://127.0.0.1:{port}")
 }
@@ -130,7 +127,8 @@ pub fn blendtutor_output_env(
     provider_url: String,
     extra_env: Vec<(&'static str, &'static str)>,
 ) -> std::process::Output {
-    let mut command = Command::cargo_bin("blendtutor").expect("binary `blendtutor` should be built");
+    let mut command =
+        Command::cargo_bin("blendtutor").expect("binary `blendtutor` should be built");
     command
         .args(&args)
         .env("FIREWORKS_API_KEY", "test-key")

--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -119,11 +119,26 @@ pub fn dead_provider_url() -> String {
 /// server on the test runtime keeps serving while this blocks. The key is set on
 /// the **child** (never the test process), so tests need no serialization.
 pub fn blendtutor_output(args: Vec<String>, provider_url: String) -> std::process::Output {
-    Command::cargo_bin("blendtutor")
-        .expect("binary `blendtutor` should be built")
+    blendtutor_output_env(args, provider_url, Vec::new())
+}
+
+/// Like [`blendtutor_output`], but also sets `extra_env` on the child — used to
+/// drive the diagnostics path (e.g. `RUST_LOG`) while asserting stdout stays a
+/// clean machine document.
+pub fn blendtutor_output_env(
+    args: Vec<String>,
+    provider_url: String,
+    extra_env: Vec<(&'static str, &'static str)>,
+) -> std::process::Output {
+    let mut command = Command::cargo_bin("blendtutor").expect("binary `blendtutor` should be built");
+    command
         .args(&args)
         .env("FIREWORKS_API_KEY", "test-key")
-        .env("BLENDTUTOR_PROVIDER_URL", provider_url)
+        .env("BLENDTUTOR_PROVIDER_URL", provider_url);
+    for (key, value) in extra_env {
+        command.env(key, value);
+    }
+    command
         .output()
         .expect("running `blendtutor run` should produce output")
 }

--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -34,11 +34,18 @@ pub fn rscript_absent() -> bool {
 }
 
 /// Mount a 200 returning a real OpenAI chat-completions envelope whose single
-/// tool call carries `arguments` as a JSON-**encoded string** — the shape rig's
-/// openai client parses. The tool is named `submit`, the name rig's `Extractor`
-/// forces. Mirrors `core/tests/llm.rs::mount_tool_call` so the CLI exercises the
-/// same wire contract the provider layer is unit-tested against.
-pub async fn mount_tool_call(server: &MockServer, arguments: &str) {
+/// tool call carries the `submit` feedback (`is_correct` + `feedback_message`) as
+/// a JSON-**encoded string** — the shape rig's openai client parses, with the
+/// tool name rig's `Extractor` forces. The arguments are built via `serde_json`
+/// so a feedback string containing quotes, backslashes, or newlines can never
+/// corrupt the mock body (§1.3). Mirrors the wire contract `core/tests/llm.rs`
+/// unit-tests the provider layer against.
+pub async fn mount_feedback(server: &MockServer, is_correct: bool, feedback: &str) {
+    let arguments = serde_json::to_string(&json!({
+        "is_correct": is_correct,
+        "feedback_message": feedback,
+    }))
+    .expect("the feedback arguments serialize infallibly");
     let body = json!({
         "id": "chatcmpl-test",
         "object": "chat.completion",
@@ -52,7 +59,7 @@ pub async fn mount_tool_call(server: &MockServer, arguments: &str) {
                 "tool_calls": [{
                     "id": "call_1",
                     "type": "function",
-                    "function": { "name": "submit", "arguments": arguments }
+                    "function": { "name": "submit", "arguments": &arguments }
                 }]
             },
             "finish_reason": "tool_calls"
@@ -75,12 +82,6 @@ pub const LESSON: &str = concat!(
 pub const CORRECT_CODE: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/tests/fixtures/runs/add_two_numbers_correct.R"
-);
-
-/// A wrong-but-runnable `add_two` submission (valid R, wrong arithmetic).
-pub const WRONG_CODE: &str = concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/tests/fixtures/runs/add_two_numbers_wrong.R"
 );
 
 /// Run the `blendtutor` binary with `args`, supplying a dummy Fireworks key and

--- a/crates/cli/tests/fixtures/runs/add_two_numbers_correct.R
+++ b/crates/cli/tests/fixtures/runs/add_two_numbers_correct.R
@@ -1,0 +1,5 @@
+add_two <- function(x, y) {
+  x + y
+}
+
+cat(add_two(3, 5), "\n")

--- a/crates/cli/tests/fixtures/runs/add_two_numbers_wrong.R
+++ b/crates/cli/tests/fixtures/runs/add_two_numbers_wrong.R
@@ -1,0 +1,5 @@
+add_two <- function(x, y) {
+  x - y
+}
+
+cat(add_two(3, 5), "\n")

--- a/crates/cli/tests/fixtures/runs/add_two_numbers_wrong.R
+++ b/crates/cli/tests/fixtures/runs/add_two_numbers_wrong.R
@@ -1,5 +1,0 @@
-add_two <- function(x, y) {
-  x - y
-}
-
-cat(add_two(3, 5), "\n")

--- a/crates/cli/tests/run.rs
+++ b/crates/cli/tests/run.rs
@@ -8,9 +8,35 @@
 
 mod common;
 
-use common::{CORRECT_CODE, LESSON, blendtutor_output, mount_feedback, rscript_absent};
+use common::{
+    CORRECT_CODE, LESSON, WRONG_CODE, blendtutor_output, dead_provider_url, mount_feedback,
+    rscript_absent,
+};
 use predicates::prelude::*;
 use wiremock::MockServer;
+
+/// Run `blendtutor run` with `args`, serving `server` as the provider, inside
+/// `spawn_blocking` so the test runtime keeps answering the child's request.
+async fn run_against(server: &MockServer, args: Vec<String>) -> std::process::Output {
+    let uri = server.uri();
+    tokio::task::spawn_blocking(move || blendtutor_output(args, uri))
+        .await
+        .expect("the blocking command task should join")
+}
+
+/// The argument vector for `run <LESSON> --code <code>`.
+fn run_args(code: &str) -> Vec<String> {
+    vec![
+        "run".to_string(),
+        LESSON.to_string(),
+        "--code".to_string(),
+        code.to_string(),
+    ]
+}
+
+fn matches(pattern: &str, haystack: &str) -> bool {
+    predicate::str::is_match(pattern).unwrap().eval(haystack)
+}
 
 /// AC1 — a correct submission with a mock `is_correct=true` yields a "correct"
 /// verdict, surfaces the model's feedback, and exits 0.
@@ -27,21 +53,8 @@ async fn run_correct_code_reports_correct_and_exit_zero() {
     let feedback = "Nicely done — your function returns the sum.";
     let server = MockServer::start().await;
     mount_feedback(&server, true, feedback).await;
-    let uri = server.uri();
 
-    let output = tokio::task::spawn_blocking(move || {
-        blendtutor_output(
-            vec![
-                "run".to_string(),
-                LESSON.to_string(),
-                "--code".to_string(),
-                CORRECT_CODE.to_string(),
-            ],
-            uri,
-        )
-    })
-    .await
-    .expect("the blocking command task should join");
+    let output = run_against(&server, run_args(CORRECT_CODE)).await;
 
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
@@ -51,13 +64,116 @@ async fn run_correct_code_reports_correct_and_exit_zero() {
         "a correct submission exits 0; stdout={stdout:?} stderr={stderr:?}"
     );
     assert!(
-        predicate::str::is_match(r"(?i)\bcorrect\b")
-            .unwrap()
-            .eval(stdout.as_str()),
+        matches(r"(?i)\bcorrect\b", &stdout),
         "stdout should report a `correct` verdict, got: {stdout:?}"
+    );
+    // Boundary (disjointness): a correct verdict must not also read as incorrect,
+    // catching a stuck "always incorrect" rendering.
+    assert!(
+        !matches(r"(?i)\bincorrect\b", &stdout),
+        "a correct verdict must not read as incorrect, got: {stdout:?}"
     );
     assert!(
         stdout.contains(feedback),
         "the model's feedback must reach stdout, got: {stdout:?}"
+    );
+}
+
+/// AC2 — an incorrect submission (mock `is_correct=false`) reports an "incorrect"
+/// verdict with feedback and exits 2, the code reserved for "not yet correct".
+///
+/// Exit 2 is disjoint from both 0 (correct) and 1 (error): a not-yet-correct
+/// submission must drive the retry loop, never be mistaken for a pass or a crash.
+#[tokio::test]
+async fn run_incorrect_submission_exits_two_with_feedback() {
+    if rscript_absent() {
+        return;
+    }
+    let feedback = "Not yet — your function subtracts instead of adding.";
+    let server = MockServer::start().await;
+    mount_feedback(&server, false, feedback).await;
+
+    let output = run_against(&server, run_args(WRONG_CODE)).await;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let code = output.status.code();
+    assert_eq!(
+        code,
+        Some(2),
+        "an incorrect submission exits 2 (reserved 'not yet correct'); \
+         stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert_ne!(code, Some(0), "exit 2 is disjoint from the correct code (0)");
+    assert_ne!(code, Some(1), "exit 2 is disjoint from the error code (1)");
+    assert!(
+        matches(r"(?i)\bincorrect\b", &stdout),
+        "stdout should report an `incorrect` verdict, got: {stdout:?}"
+    );
+    assert!(
+        !matches(r"(?i)\bcorrect\b", &stdout),
+        "a word-bounded `correct` must not match an incorrect verdict, got: {stdout:?}"
+    );
+    assert!(
+        stdout.contains(feedback),
+        "the model's feedback must reach stdout, got: {stdout:?}"
+    );
+}
+
+/// AC2 — a missing/unreadable `--code` file is an error (exit 1), distinct from
+/// the not-yet-correct code (2): a bad input must not leak the retry code, which
+/// would make a submit loop never terminate.
+///
+/// A live provider isolates the read path: the read must fail *before* any
+/// provider call, so the mock records zero requests. A regression that swallowed
+/// the read error would reach the mock and exit 0/2 — the request count is the
+/// built-in negative control. The interpreter is never reached either.
+#[tokio::test]
+async fn run_missing_code_exits_one() {
+    let server = MockServer::start().await;
+    mount_feedback(&server, true, "should never be requested").await;
+
+    let output = run_against(&server, run_args("/no/such/submission.R")).await;
+
+    let code = output.status.code();
+    assert_eq!(
+        code,
+        Some(1),
+        "an unreadable --code file exits 1; stderr={:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_ne!(
+        code,
+        Some(2),
+        "a bad input must not leak the 'not yet correct' retry code"
+    );
+    assert_eq!(
+        server.received_requests().await.unwrap().len(),
+        0,
+        "the read fails before any provider call is made"
+    );
+}
+
+/// AC2 — an unreachable provider is a transport error (exit 1), distinct from the
+/// not-yet-correct code (2): a dead endpoint is a failure to grade, not a verdict.
+/// The submission runs before the provider call, so this needs a real interpreter.
+#[test]
+fn run_provider_error_exits_one() {
+    if rscript_absent() {
+        return;
+    }
+    let output = blendtutor_output(run_args(CORRECT_CODE), dead_provider_url());
+
+    let code = output.status.code();
+    assert_eq!(
+        code,
+        Some(1),
+        "an unreachable provider exits 1; stderr={:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_ne!(
+        code,
+        Some(2),
+        "a transport failure is an error (1), not a 'not yet correct' verdict (2)"
     );
 }

--- a/crates/cli/tests/run.rs
+++ b/crates/cli/tests/run.rs
@@ -8,7 +8,7 @@
 
 mod common;
 
-use common::{CORRECT_CODE, LESSON, blendtutor_output, mount_tool_call, rscript_absent};
+use common::{CORRECT_CODE, LESSON, blendtutor_output, mount_feedback, rscript_absent};
 use predicates::prelude::*;
 use wiremock::MockServer;
 
@@ -26,11 +26,7 @@ async fn run_correct_code_reports_correct_and_exit_zero() {
     }
     let feedback = "Nicely done — your function returns the sum.";
     let server = MockServer::start().await;
-    mount_tool_call(
-        &server,
-        &format!(r#"{{"is_correct":true,"feedback_message":"{feedback}"}}"#),
-    )
-    .await;
+    mount_feedback(&server, true, feedback).await;
     let uri = server.uri();
 
     let output = tokio::task::spawn_blocking(move || {

--- a/crates/cli/tests/run.rs
+++ b/crates/cli/tests/run.rs
@@ -113,7 +113,11 @@ async fn run_incorrect_submission_exits_two_with_feedback() {
         "an incorrect submission exits 2 (reserved 'not yet correct'); \
          stdout={stdout:?} stderr={stderr:?}"
     );
-    assert_ne!(code, Some(0), "exit 2 is disjoint from the correct code (0)");
+    assert_ne!(
+        code,
+        Some(0),
+        "exit 2 is disjoint from the correct code (0)"
+    );
     assert_ne!(code, Some(1), "exit 2 is disjoint from the error code (1)");
     assert!(
         matches(r"(?i)\bincorrect\b", &stdout),
@@ -232,12 +236,27 @@ async fn run_format_json_emits_one_typed_report() {
             String::from_utf8_lossy(&output.stdout)
         )
     });
-    assert!(value.is_object(), "the report is a JSON object, got {value}");
+    assert!(
+        value.is_object(),
+        "the report is a JSON object, got {value}"
+    );
     assert_eq!(value["verdict"], "correct", "verdict is the string tag");
-    assert!(value["verdict"].is_string(), "verdict is a string, got {value}");
-    assert_eq!(value["feedback"], feedback, "feedback is the model's message");
-    assert!(value["feedback"].is_string(), "feedback is a string, got {value}");
-    assert!(value["checks"].is_array(), "checks is an array, got {value}");
+    assert!(
+        value["verdict"].is_string(),
+        "verdict is a string, got {value}"
+    );
+    assert_eq!(
+        value["feedback"], feedback,
+        "feedback is the model's message"
+    );
+    assert!(
+        value["feedback"].is_string(),
+        "feedback is a string, got {value}"
+    );
+    assert!(
+        value["checks"].is_array(),
+        "checks is an array, got {value}"
+    );
     assert!(
         value["checks"].as_array().expect("checks array").is_empty(),
         "a checkless lesson serializes checks as [], not a stringified list, got {value}"

--- a/crates/cli/tests/run.rs
+++ b/crates/cli/tests/run.rs
@@ -9,8 +9,8 @@
 mod common;
 
 use common::{
-    CORRECT_CODE, LESSON, WRONG_CODE, blendtutor_output, dead_provider_url, mount_feedback,
-    rscript_absent,
+    CORRECT_CODE, LESSON, WRONG_CODE, blendtutor_output, blendtutor_output_env, dead_provider_url,
+    mount_feedback, rscript_absent,
 };
 use predicates::prelude::*;
 use wiremock::MockServer;
@@ -18,8 +18,17 @@ use wiremock::MockServer;
 /// Run `blendtutor run` with `args`, serving `server` as the provider, inside
 /// `spawn_blocking` so the test runtime keeps answering the child's request.
 async fn run_against(server: &MockServer, args: Vec<String>) -> std::process::Output {
+    run_against_env(server, args, Vec::new()).await
+}
+
+/// Like [`run_against`], but also sets `extra_env` on the child.
+async fn run_against_env(
+    server: &MockServer,
+    args: Vec<String>,
+    extra_env: Vec<(&'static str, &'static str)>,
+) -> std::process::Output {
     let uri = server.uri();
-    tokio::task::spawn_blocking(move || blendtutor_output(args, uri))
+    tokio::task::spawn_blocking(move || blendtutor_output_env(args, uri, extra_env))
         .await
         .expect("the blocking command task should join")
 }
@@ -175,5 +184,130 @@ fn run_provider_error_exits_one() {
         code,
         Some(2),
         "a transport failure is an error (1), not a 'not yet correct' verdict (2)"
+    );
+}
+
+/// The argument vector for `run <LESSON> --code <code> --format json`.
+fn run_json_args(code: &str) -> Vec<String> {
+    let mut args = run_args(code);
+    args.push("--format".to_string());
+    args.push("json".to_string());
+    args
+}
+
+/// True when `bytes` are exactly one parseable JSON document (the whole buffer
+/// parses; trailing log/prose bytes would make this `false`).
+fn is_one_json_document(bytes: &[u8]) -> bool {
+    serde_json::from_slice::<serde_json::Value>(bytes).is_ok()
+}
+
+/// AC3 — `--format json` emits exactly one JSON document on stdout with the four
+/// well-typed keys, and keeps diagnostics off stdout.
+///
+/// Parsing the whole stdout buffer is the "exactly one document" check: any
+/// interleaved log line or trailing prose would make it fail. Each key is typed
+/// (verdict/feedback strings, checks an array, output a string or object), so a
+/// stringified `"[]"` or a missing key is caught.
+#[tokio::test]
+async fn run_format_json_emits_one_typed_report() {
+    if rscript_absent() {
+        return;
+    }
+    let feedback = "Looks right — the sum is returned.";
+    let server = MockServer::start().await;
+    mount_feedback(&server, true, feedback).await;
+
+    let output = run_against(&server, run_json_args(CORRECT_CODE)).await;
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "a correct submission in json mode exits 0; stderr={:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout must be exactly one JSON document, parse failed: {e}; stdout={:?}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert!(value.is_object(), "the report is a JSON object, got {value}");
+    assert_eq!(value["verdict"], "correct", "verdict is the string tag");
+    assert!(value["verdict"].is_string(), "verdict is a string, got {value}");
+    assert_eq!(value["feedback"], feedback, "feedback is the model's message");
+    assert!(value["feedback"].is_string(), "feedback is a string, got {value}");
+    assert!(value["checks"].is_array(), "checks is an array, got {value}");
+    assert!(
+        value["checks"].as_array().expect("checks array").is_empty(),
+        "a checkless lesson serializes checks as [], not a stringified list, got {value}"
+    );
+    let output_kind = &value["output"];
+    assert!(
+        output_kind.is_string() || output_kind.is_object(),
+        "output is a string or object, got {value}"
+    );
+
+    // Diagnostics belong on stderr: stdout is the machine document alone.
+    let stderr_is_json_object = serde_json::from_slice::<serde_json::Value>(&output.stderr)
+        .map(|v| v.is_object())
+        .unwrap_or(false);
+    assert!(
+        !stderr_is_json_object,
+        "stdout carries the only JSON document; stderr must not, got: {:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// AC3 (negative) — the default human format is NOT JSON, so a consumer cannot
+/// accidentally parse human text as a machine document.
+#[tokio::test]
+async fn run_human_format_is_not_json() {
+    if rscript_absent() {
+        return;
+    }
+    let server = MockServer::start().await;
+    mount_feedback(&server, true, "Looks right.").await;
+
+    let output = run_against(&server, run_args(CORRECT_CODE)).await;
+
+    assert!(
+        output.status.success(),
+        "the human run still succeeds; stderr={:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !is_one_json_document(&output.stdout),
+        "human output must not parse as JSON, got: {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+/// AC3 — requesting logs (`RUST_LOG`) does not contaminate the json document:
+/// diagnostics stay off stdout, so the whole stdout buffer still re-parses clean.
+#[tokio::test]
+async fn run_format_json_stays_clean_under_logging() {
+    if rscript_absent() {
+        return;
+    }
+    let server = MockServer::start().await;
+    mount_feedback(&server, true, "Looks right.").await;
+
+    let output = run_against_env(
+        &server,
+        run_json_args(CORRECT_CODE),
+        vec![("RUST_LOG", "debug")],
+    )
+    .await;
+
+    assert!(
+        output.status.success(),
+        "the json run still succeeds under RUST_LOG; stderr={:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        is_one_json_document(&output.stdout),
+        "stdout must stay one clean JSON document even with logging on, got: {:?}",
+        String::from_utf8_lossy(&output.stdout)
     );
 }

--- a/crates/cli/tests/run.rs
+++ b/crates/cli/tests/run.rs
@@ -1,0 +1,67 @@
+//! Integration tests for `blendtutor run <lesson> --code <file>` — the headline
+//! student loop: execute the submission, grade its checks, ask the LLM provider
+//! for a verdict, and report verdict + feedback with a reserved exit code.
+//!
+//! The provider is a `wiremock` stub reached through the `BLENDTUTOR_PROVIDER_URL`
+//! base-URL override; the interpreter is the real `Rscript`, so these skip-with-
+//! notice when R is absent. See `tests/common/mod.rs`.
+
+mod common;
+
+use common::{CORRECT_CODE, LESSON, blendtutor_output, mount_tool_call, rscript_absent};
+use predicates::prelude::*;
+use wiremock::MockServer;
+
+/// AC1 — a correct submission with a mock `is_correct=true` yields a "correct"
+/// verdict, surfaces the model's feedback, and exits 0.
+///
+/// The feedback-body assertion (not bare "correct") is load-bearing: it forces
+/// `RunReport.feedback` to flow from the provider through the rig pipeline into
+/// stdout, defeating a stub that hardcodes exit 0 and prints "correct". The
+/// verdict derives from the mock's `is_correct=true`, not a rendered literal.
+#[tokio::test]
+async fn run_correct_code_reports_correct_and_exit_zero() {
+    if rscript_absent() {
+        return;
+    }
+    let feedback = "Nicely done — your function returns the sum.";
+    let server = MockServer::start().await;
+    mount_tool_call(
+        &server,
+        &format!(r#"{{"is_correct":true,"feedback_message":"{feedback}"}}"#),
+    )
+    .await;
+    let uri = server.uri();
+
+    let output = tokio::task::spawn_blocking(move || {
+        blendtutor_output(
+            vec![
+                "run".to_string(),
+                LESSON.to_string(),
+                "--code".to_string(),
+                CORRECT_CODE.to_string(),
+            ],
+            uri,
+        )
+    })
+    .await
+    .expect("the blocking command task should join");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "a correct submission exits 0; stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        predicate::str::is_match(r"(?i)\bcorrect\b")
+            .unwrap()
+            .eval(stdout.as_str()),
+        "stdout should report a `correct` verdict, got: {stdout:?}"
+    );
+    assert!(
+        stdout.contains(feedback),
+        "the model's feedback must reach stdout, got: {stdout:?}"
+    );
+}

--- a/crates/core/src/grade.rs
+++ b/crates/core/src/grade.rs
@@ -8,6 +8,8 @@
 //! effectful (§2.1, §2.2). This module classifies outcomes; it does NOT build
 //! prompts or call LLMs — that is the provider layer's job (§4.1).
 
+use serde::{Deserialize, Serialize};
+
 use crate::lesson::Language;
 use crate::runner::{ExecutionResult, PythonRunner, RRunner, Runner, RunnerError};
 
@@ -18,7 +20,11 @@ use crate::runner::{ExecutionResult, PythonRunner, RRunner, Runner, RunnerError}
 /// passed, the submission ran and violated it, and — kept deliberately separate
 /// from a failure (§3.3) — the submission could not run at all, so no check ever
 /// got a verdict.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// Serializable so the `run` command's [`RunReport`](crate::run::RunReport) can
+/// carry the per-check outcomes into its JSON form; the externally-tagged shape
+/// round-trips each variant losslessly.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CheckOutcome {
     /// The submission satisfied the check.
     Pass,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod course;
 pub mod grade;
 pub mod lesson;
 pub mod llm;
+pub mod run;
 pub mod runner;
 
 use std::error::Error;

--- a/crates/core/src/run.rs
+++ b/crates/core/src/run.rs
@@ -38,6 +38,8 @@ use crate::runner::Runner;
 pub struct RunReport {
     verdict: Verdict,
     checks: Vec<CheckOutcome>,
+    /// The submission's captured standard output, from running it on its own (see
+    /// [`run_lesson`]).
     output: String,
 }
 
@@ -150,11 +152,22 @@ impl Error for RunError {
 /// Run `submission` against `lesson` and produce a [`RunReport`].
 ///
 /// The orchestrator (§2.4): it selects the lesson's runner, executes the
-/// submission once to capture its output, grades the lesson's checks, builds the
-/// feedback prompt, and asks `provider` for a verdict — composing each layer
-/// through its public type and adding no domain logic of its own. `base_url_override`
-/// points the provider at a stub in tests (the [`request_feedback`] seam) and is
-/// `None` in production. Short and linear: the only branch is error propagation.
+/// submission **on its own** to capture the output the report carries and the
+/// prompt shows, grades the lesson's checks, builds the feedback prompt, and asks
+/// `provider` for a verdict — composing each layer through its public type and
+/// adding no domain logic of its own. `base_url_override` points the provider at
+/// a stub in tests (the [`request_feedback`] seam) and is `None` in production.
+/// Short and linear: the only branch is error propagation.
+///
+/// The output-capturing run is separate from grading: when the lesson has checks,
+/// [`run_checks`] runs the submission again as its own gate (see
+/// [`grade`](crate::grade)), so a submission with side-effecting or
+/// nondeterministic output could in principle diverge between the captured output
+/// and what the checks graded against. This is benign under v0's trusted-local,
+/// deterministic-submission model, and the common LLM-only lesson has no checks —
+/// so the submission runs exactly once. Folding the gate's output back into
+/// grading (to run once even with checks) is a `grade`-layer change left to a
+/// later slice.
 pub async fn run_lesson(
     lesson: &Lesson,
     submission: &Submission,

--- a/crates/core/src/run.rs
+++ b/crates/core/src/run.rs
@@ -280,4 +280,36 @@ mod tests {
         let value: serde_json::Value = serde_json::from_str(&json).expect("the json parses");
         assert_eq!(value["verdict"], "incorrect");
     }
+
+    #[test]
+    fn run_error_labels_each_stage_and_exposes_its_source() {
+        use crate::runner::RunnerError;
+
+        // The Run arm labels itself as a run failure and keeps the underlying
+        // RunnerError reachable as its source — so the cli can report what failed.
+        let run = RunError::Run(RunnerError::new(
+            "spawn Rscript",
+            std::io::Error::new(std::io::ErrorKind::NotFound, "boom"),
+        ));
+        assert!(
+            run.to_string().contains("could not run the submission"),
+            "Run labels itself a run failure, got: {run}"
+        );
+        assert!(
+            Error::source(&run).is_some(),
+            "Run exposes the RunnerError as its source"
+        );
+
+        // The Feedback arm defers to the FeedbackError's own message (no prefix)
+        // and exposes it as the source.
+        let feedback = RunError::Feedback(FeedbackError::Client("bad client".to_string()));
+        assert!(
+            feedback.to_string().contains("bad client"),
+            "Feedback surfaces the inner message, got: {feedback}"
+        );
+        assert!(
+            Error::source(&feedback).is_some(),
+            "Feedback exposes the FeedbackError as its source"
+        );
+    }
 }

--- a/crates/core/src/run.rs
+++ b/crates/core/src/run.rs
@@ -31,7 +31,7 @@ use crate::runner::Runner;
 /// "correct with no feedback" or contradictory state is unrepresentable; the
 /// JSON consumer's flat `{verdict, feedback}` pair is a serialization detail, not
 /// a second source of truth. Its JSON form is defined once here (via the private
-/// [`RunDocument`]), so `core` owns the report's canonical wire shape the way it
+/// `RunDocument`), so `core` owns the report's canonical wire shape the way it
 /// owns the lesson's; the cli only chooses human-vs-json and the output stream.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(into = "RunDocument", from = "RunDocument")]
@@ -251,12 +251,18 @@ mod tests {
 
         assert_eq!(value["verdict"], "correct", "verdict is a string tag");
         assert_eq!(value["feedback"], "well done", "feedback is the message");
-        assert!(value["checks"].is_array(), "checks is an array, got {value}");
+        assert!(
+            value["checks"].is_array(),
+            "checks is an array, got {value}"
+        );
         assert!(
             value["checks"].as_array().expect("array").is_empty(),
             "no checks serializes to [], not a stringified empty list"
         );
-        assert!(value["output"].is_string(), "output is a string, got {value}");
+        assert!(
+            value["output"].is_string(),
+            "output is a string, got {value}"
+        );
     }
 
     #[test]

--- a/crates/core/src/run.rs
+++ b/crates/core/src/run.rs
@@ -1,0 +1,264 @@
+//! The student run loop: execute a submission, grade it, ask the LLM for a
+//! verdict, and bundle the result into a typed [`RunReport`].
+//!
+//! This is the effect-shell that composes the [`runner`](crate::runner),
+//! [`grade`](crate::grade), and [`llm`](crate::llm) layers through their public
+//! types only (§2.4, §3.3): it executes the submission for its captured output,
+//! grades the lesson's checks, builds the prompt, and requests a verdict. It adds
+//! no domain logic of its own — it neither builds prompts nor talks to a provider
+//! directly (those are the `llm` layer's), and it does not render output or map
+//! exit codes (those belong to the `cli` edge). The result is a [`RunReport`], a
+//! typed value carrying the [`Verdict`], the per-check outcomes, and the captured
+//! output, with a stable JSON form for `--format json`.
+
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::grade::{CheckOutcome, run_checks, select_runner};
+use crate::lesson::Lesson;
+use crate::llm::{
+    ExecResults, FeedbackError, ProviderChoice, Submission, Verdict, build_prompt, request_feedback,
+};
+use crate::runner::Runner;
+
+/// The result of running one submission against a lesson: the graded verdict, the
+/// per-check outcomes, and the submission's captured output.
+///
+/// A typed value (§1.1) the `run` command computes and then renders. The verdict
+/// is the [`Verdict`] sum type — carrying its learner-facing message — so a
+/// "correct with no feedback" or contradictory state is unrepresentable; the
+/// JSON consumer's flat `{verdict, feedback}` pair is a serialization detail, not
+/// a second source of truth. Its JSON form is defined once here (via the private
+/// [`RunDocument`]), so `core` owns the report's canonical wire shape the way it
+/// owns the lesson's; the cli only chooses human-vs-json and the output stream.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(into = "RunDocument", from = "RunDocument")]
+pub struct RunReport {
+    verdict: Verdict,
+    checks: Vec<CheckOutcome>,
+    output: String,
+}
+
+impl RunReport {
+    /// The graded verdict — what the renderer reads to report correct/incorrect
+    /// and the feedback message. The exit-code mapping reads it too, so "what
+    /// happened" stays one typed value rather than a stringly-typed field.
+    pub fn verdict(&self) -> &Verdict {
+        &self.verdict
+    }
+}
+
+/// The stable JSON shape of a [`RunReport`]: a flat document with a string
+/// `verdict` discriminant, the `feedback` message split out of the verdict, the
+/// `checks` array, and the captured `output`.
+///
+/// Kept separate from the domain type (the [`Verdict`] sum type) so the wire
+/// shape — what `--format json` and its consumers depend on — is decoupled from
+/// the internal representation. The conversions are total and inverse, so a
+/// [`RunReport`] round-trips through this document losslessly.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RunDocument {
+    verdict: VerdictTag,
+    feedback: String,
+    checks: Vec<CheckOutcome>,
+    output: String,
+}
+
+/// The verdict discriminant as it appears in JSON: the variant tag without the
+/// message (which travels in `feedback`). Lowercase on the wire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum VerdictTag {
+    Correct,
+    Incorrect,
+}
+
+impl From<RunReport> for RunDocument {
+    fn from(report: RunReport) -> Self {
+        let RunReport {
+            verdict,
+            checks,
+            output,
+        } = report;
+        let (verdict, feedback) = match verdict {
+            Verdict::Correct { message } => (VerdictTag::Correct, message),
+            Verdict::Incorrect { message } => (VerdictTag::Incorrect, message),
+        };
+        Self {
+            verdict,
+            feedback,
+            checks,
+            output,
+        }
+    }
+}
+
+impl From<RunDocument> for RunReport {
+    fn from(doc: RunDocument) -> Self {
+        let RunDocument {
+            verdict,
+            feedback,
+            checks,
+            output,
+        } = doc;
+        let verdict = match verdict {
+            VerdictTag::Correct => Verdict::Correct { message: feedback },
+            VerdictTag::Incorrect => Verdict::Incorrect { message: feedback },
+        };
+        Self {
+            verdict,
+            checks,
+            output,
+        }
+    }
+}
+
+/// Why a run could not produce a report.
+///
+/// A typed error (§1.2) keeping the two failure stages distinct: the submission
+/// could not be executed at all, or the feedback request failed. `core` stays
+/// `anyhow`-free (ADR-0001); the cli maps this to its exit code at the edge.
+#[derive(Debug)]
+pub enum RunError {
+    /// The interpreter could not run the submission to capture its output (a
+    /// spawn or IO failure — not a program that ran and exited non-zero).
+    Run(crate::runner::RunnerError),
+    /// The LLM feedback request failed — see [`FeedbackError`] for the kind.
+    Feedback(FeedbackError),
+}
+
+impl fmt::Display for RunError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RunError::Run(e) => write!(f, "could not run the submission: {e}"),
+            RunError::Feedback(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl Error for RunError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            RunError::Run(e) => Some(e),
+            RunError::Feedback(e) => Some(e),
+        }
+    }
+}
+
+/// Run `submission` against `lesson` and produce a [`RunReport`].
+///
+/// The orchestrator (§2.4): it selects the lesson's runner, executes the
+/// submission once to capture its output, grades the lesson's checks, builds the
+/// feedback prompt, and asks `provider` for a verdict — composing each layer
+/// through its public type and adding no domain logic of its own. `base_url_override`
+/// points the provider at a stub in tests (the [`request_feedback`] seam) and is
+/// `None` in production. Short and linear: the only branch is error propagation.
+pub async fn run_lesson(
+    lesson: &Lesson,
+    submission: &Submission,
+    provider: ProviderChoice,
+    base_url_override: Option<&str>,
+) -> Result<RunReport, RunError> {
+    let runner = select_runner(&lesson.language);
+    // Run the submission on its own to capture what the learner's code produced;
+    // that output feeds both the feedback prompt and the report. A launch failure
+    // is a `RunError::Run`, never a verdict.
+    let output = runner
+        .execute(&submission.code, &[])
+        .await
+        .map_err(RunError::Run)?;
+    let outcomes = run_checks(runner, &submission.code, &lesson.checks).await;
+
+    let results = ExecResults { output, outcomes };
+    let prompt = build_prompt(lesson, submission, &results);
+    let verdict = request_feedback(provider, &prompt, base_url_override)
+        .await
+        .map_err(RunError::Feedback)?;
+
+    let ExecResults { output, outcomes } = results;
+    Ok(RunReport {
+        verdict,
+        checks: outcomes,
+        output: output.stdout,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report(verdict: Verdict, checks: Vec<CheckOutcome>, output: &str) -> RunReport {
+        RunReport {
+            verdict,
+            checks,
+            output: output.to_string(),
+        }
+    }
+
+    #[test]
+    fn run_report_json_roundtrip_preserves_value() {
+        // The report survives a JSON round-trip unchanged — the flat wire document
+        // and the typed domain value are inverse, so neither the verdict/feedback
+        // split nor the checks array loses information (pattern from
+        // `lesson::lesson_json_roundtrip_preserves_value`).
+        let original = report(
+            Verdict::Incorrect {
+                message: "Not quite — check the return value.".to_string(),
+            },
+            vec![
+                CheckOutcome::Pass,
+                CheckOutcome::Fail {
+                    detail: "expected 5".to_string(),
+                },
+            ],
+            "8 \n",
+        );
+        let json = serde_json::to_string(&original).expect("a report serializes to JSON");
+        let roundtripped: RunReport =
+            serde_json::from_str(&json).expect("a report deserializes from JSON");
+        assert_eq!(roundtripped, original);
+    }
+
+    #[test]
+    fn json_splits_the_verdict_into_a_string_tag_and_feedback() {
+        // The wire shape the `--format json` consumers depend on: a string
+        // `verdict` discriminant (not the nested enum), the message in `feedback`,
+        // and `checks` as an array — pinned independently of the round-trip.
+        let json = serde_json::to_string(&report(
+            Verdict::Correct {
+                message: "well done".to_string(),
+            },
+            vec![],
+            "",
+        ))
+        .expect("a report serializes to JSON");
+        let value: serde_json::Value = serde_json::from_str(&json).expect("the json parses");
+
+        assert_eq!(value["verdict"], "correct", "verdict is a string tag");
+        assert_eq!(value["feedback"], "well done", "feedback is the message");
+        assert!(value["checks"].is_array(), "checks is an array, got {value}");
+        assert!(
+            value["checks"].as_array().expect("array").is_empty(),
+            "no checks serializes to [], not a stringified empty list"
+        );
+        assert!(value["output"].is_string(), "output is a string, got {value}");
+    }
+
+    #[test]
+    fn json_tags_an_incorrect_verdict_distinctly() {
+        // The twin of the correct tag: an incorrect verdict serializes to the
+        // `"incorrect"` discriminant, so the two are never conflated on the wire.
+        let json = serde_json::to_string(&report(
+            Verdict::Incorrect {
+                message: "try again".to_string(),
+            },
+            vec![],
+            "",
+        ))
+        .expect("a report serializes to JSON");
+        let value: serde_json::Value = serde_json::from_str(&json).expect("the json parses");
+        assert_eq!(value["verdict"], "incorrect");
+    }
+}

--- a/docs/agent-notes/run.md
+++ b/docs/agent-notes/run.md
@@ -1,0 +1,76 @@
+---
+topic: run
+created: 2026-06-07
+slices: [11]
+---
+
+The `run` command and `core::run` — the headline student loop that composes
+execute → grade → LLM feedback into a typed report. See [[llm]], [[grade]],
+[[runner]], [[output]] for the layers it joins.
+
+- 2026-06-07 (#11): `core::run::run_lesson` is the effect-shell (§2.4, §3.3): it
+  `select_runner` → `execute` (capture output) → `run_checks` → `build_prompt` →
+  `request_feedback`, composing the runner/grade/llm layers through their public
+  types only. It adds no domain logic, renders nothing, and maps no exit codes.
+  Short and linear — the only branch is error propagation (`RunError::{Run,
+  Feedback}`, anyhow-free per ADR-0001).
+- 2026-06-07 (#11): **`RunReport` is typed but owns its canonical JSON.** It holds
+  the `Verdict` sum type (message included, so "correct with no feedback" is
+  unrepresentable), `Vec<CheckOutcome>`, and the captured `output: String`. The
+  flat wire shape `{verdict, feedback, checks, output}` is a **private
+  `RunDocument`** wired via `#[serde(into = "RunDocument", from = "RunDocument")]`
+  — the two `From` impls are total inverses, so a report round-trips losslessly.
+  `verdict` serializes to a lowercase string tag (`VerdictTag`) with the message
+  split into `feedback`. core owns the report's JSON the way it owns `Lesson`'s;
+  the cli only chooses format + stream. `CheckOutcome` gained Serialize/Deserialize
+  for the `checks` array.
+- 2026-06-07 (#11): **Exit codes 0/2/1 are disjoint and mapped at the cli edge.**
+  correct = 0, incorrect = 2 (reserved "not yet correct", const `NOT_YET_CORRECT`
+  in `cli::commands::run`), error = 1. The error code is *not* part of the verdict
+  map — it comes from `main` returning `Err` (a failed load/read/feedback), so it
+  can never collide with the verdict codes. `verdict_exit_code` reads the typed
+  `report.verdict()`; it lives in the cli (not on `RunReport`) so `core` stays
+  free of `std::process::ExitCode`, which a future GUI would not want (§3.1).
+- 2026-06-07 (#11): **`--code` is optional.** Given → read the file (a missing/
+  unreadable file is an IO error → exit 1, distinct from a "not yet correct"
+  verdict — so a bad input never leaks the retry code). Omitted → read piped
+  stdin, falling back to an empty submission on a TTY (`io::stdin().is_terminal()`)
+  rather than blocking. This reconciles AC2 (missing `--code` → 1) with AC3
+  (omitted flag still runs) without a clap-level required arg (clap's own missing-
+  arg exit is 2, which would collide with the retry code).
+- 2026-06-07 (#11): **The binary owns the async runtime; `core` stays a library.**
+  `cli::commands::run` builds a `tokio::runtime::Builder::new_current_thread()
+  .enable_all()` runtime and `block_on`s `run_lesson`. current_thread + enable_all
+  drives both the runner subprocess (tokio::process, drained on spawned tasks) and
+  the rig/reqwest HTTP call — the same flavor `#[tokio::test]` uses for the runner
+  tests. cli gained `tokio` as a direct dep for this.
+- 2026-06-07 (#11): **Known double-run.** `run_lesson` executes the submission on
+  its own to capture `output`, and `run_checks` runs it *again* as its grade gate
+  when the lesson has checks — so a side-effecting/nondeterministic submission
+  could diverge between the captured output and what checks graded. Benign under
+  v0's trusted-local deterministic model, and the common LLM-only lesson has no
+  checks (one run). Deduping needs `grade::run_checks` to surface the gate's
+  output — a `grade`-layer change deferred to a later slice.
+- 2026-06-07 (#11): **CLI integration test pattern (reusable).** Point the spawned
+  binary at an in-test `wiremock::MockServer` (a real localhost port) via the
+  `BLENDTUTOR_PROVIDER_URL` base-URL override. `assert_cmd::Command` is
+  synchronous, so run it inside `tokio::task::spawn_blocking`: that frees the
+  current_thread runtime to keep serving the mock while the child's request is in
+  flight (a direct blocking call deadlocks). The provider key is set on the
+  **child** (`.env`), never the test process, so these tests need no `#[serial]`
+  (unlike the env-mutating `core/tests/llm.rs`). They run the real `Rscript`, so
+  they skip-with-notice via `rscript_absent()`. Helpers live in
+  `crates/cli/tests/common/mod.rs` (`mount_feedback`, `blendtutor_output`,
+  `dead_provider_url`).
+- 2026-06-07 (#11): **Spec reconciliation — no `blendtutor-test-support`/`mockd`
+  crate.** The issue planned a separate `mockd` binary; in-test wiremock (above)
+  covers the same `BLENDTUTOR_PROVIDER_URL` seam with far less infrastructure and
+  reuses the proven OpenAI tool-call envelope from `core/tests/llm.rs` (tool name
+  `submit`, `arguments` as a JSON-encoded string). No new workspace crate; cli
+  gained only `wiremock` + `tokio` dev-deps. The real-provider boundary keeps its
+  `live`-profile coverage from Slice 10.
+- 2026-06-07 (#11): **Diagnostics on stderr, machine doc on stdout.** `emit_run`
+  writes both human and json to stdout (both are the command's data); a failed
+  load/provider call is an error that reaches stderr via `main`. No `tracing`
+  subscriber is installed, so `RUST_LOG` produces no stdout bytes — the json
+  document stays a clean single parse even with logging requested.


### PR DESCRIPTION
## Summary
- Adds `blendtutor run <lesson> [--code <file>]` — the headline student loop: execute the submission, grade its checks, ask the LLM for a verdict, and report verdict + feedback.
- New `core::run` effect-shell (`run_lesson`) composes the runner/grade/llm layers into a typed `RunReport`; the cli command is a thin shell that drives it on a runtime it owns and renders through the Slice-5 output seam.
- Reserved, disjoint exit codes: correct = 0, not-yet-correct = 2, error = 1.

## Issue
Closes #11

## Slices implemented
- **AC1 — correct → exit 0 + feedback.** `run_correct_code_reports_correct_and_exit_zero`: mock `is_correct=true` → exit 0, stdout matches `\bcorrect\b` (not `\bincorrect\b`), and contains the model's feedback verbatim (forcing it to flow provider → rig → stdout).
- **AC2 — disjoint exit codes.** `run_incorrect_submission_exits_two_with_feedback` (exit 2, `\bincorrect\b` + feedback, ≠ 0/1), `run_missing_code_exits_one` (unreadable `--code` → 1, ≠ 2, with a live provider asserting **zero requests** as a built-in negative control), `run_provider_error_exits_one` (unreachable provider → 1, ≠ 2).
- **AC3 — `--format json` is one typed document.** `run_format_json_emits_one_typed_report` (whole-stdout parses as one object with verdict/feedback strings, checks array `[]`, output string; stderr carries no JSON), `run_human_format_is_not_json`, `run_format_json_stays_clean_under_logging` (RUST_LOG doesn't contaminate stdout).

## Design notes / reconciliations
- **`RunReport` is typed but owns its JSON.** It holds the `Verdict` sum type (message included → "correct with no feedback" unrepresentable); the flat `{verdict, feedback, checks, output}` wire shape is a private `RunDocument` serde view wired via total-inverse `From` impls (lossless round-trip). core owns the canonical JSON the way it owns `Lesson`'s.
- **Exit-code mapping lives at the cli edge**, driven by the typed verdict, so `core::RunReport` stays free of `std::process` for a future GUI. The error code (1) comes from `main`'s `Err` path, never the verdict map, so the three codes can't collide.
- **`--code` is optional**: a missing/unreadable file is an IO error → exit 1 (distinct from a verdict); an omitted flag reads piped stdin and falls back to empty on a TTY (no hang). This reconciles AC2's "missing `--code` → 1" with AC3's "omitted flag still runs".
- **Test seam — in-test wiremock instead of a separate `mockd` crate.** The CLI tests point the spawned binary at a `wiremock::MockServer` (real localhost port) via `BLENDTUTOR_PROVIDER_URL`, reusing the proven OpenAI tool-call envelope from `core/tests/llm.rs` (driven inside `spawn_blocking` so the runtime keeps serving). This covers the same seam with far less infrastructure than a standalone `mockd` binary (no new workspace crate); the real-provider boundary keeps its `live`-profile coverage from Slice 10.
- **Known double-run** (documented): `run_lesson` executes the submission standalone for its captured output, and `run_checks` re-runs it as its gate for *checked* lessons — benign under v0's deterministic trusted-local model, and the common LLM-only lesson has no checks (one run). Deduping needs a `grade`-layer change, deferred.
- ADR: none (composes existing layers via their public types; no new boundary — per the issue).
- Knowledge captured in `docs/agent-notes/run.md`.

## Test plan
- [x] All unit + integration tests pass (`cargo nextest run --locked` — 87 passed)
- [x] fmt / clippy (`-D warnings`) / rustdoc (`-D warnings`) clean
- [x] `cargo mutants --in-diff` clean (2 caught, 5 unviable, 0 missed)
- [x] Roborev findings resolved (gated after every commit)
- [x] ADRs written/updated (if applicable) — N/A
- [ ] Rodney verification completed (if UI-touching) — N/A (CLI slice)