### PR TITLE
[feature] eval command — score feedback quality

### DIFF
--- a/crates/cli/src/commands/eval.rs
+++ b/crates/cli/src/commands/eval.rs
@@ -1,0 +1,61 @@
+//! `blendtutor eval <lesson>` — score the feedback pipeline against a suite.
+//!
+//! A thin orchestration shell (§4.1, §5.1): it loads the lesson and its sibling
+//! `eval_<lesson>.yaml` suite, drives the pure-cored [`run_eval`] on a runtime —
+//! the *same* pipeline `run` uses, so the feedback scored is the feedback
+//! shipped (§3.2) — and renders the report through the [`output`] seam. No
+//! scoring, execution, or HTTP logic lives here; those are `core`'s.
+
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use anyhow::Context;
+use blendtutor_core::eval::{parse_eval_suite, run_eval};
+use blendtutor_core::lesson::read_lesson_file;
+use blendtutor_core::llm::ProviderChoice;
+
+use crate::commands::PROVIDER_URL_VAR;
+use crate::output::{self, OutputFormat};
+
+/// Load the lesson and its sibling eval suite, score every case through the run
+/// pipeline, and render the report.
+///
+/// A lesson read/parse failure, a missing or malformed suite, or a pipeline
+/// failure on any case propagates as an error (→ exit 1). The command itself
+/// always succeeds (exit 0) when it produces a report: `eval` measures feedback
+/// quality, it is not a pass/fail gate, so a low accuracy is still a successful
+/// run. The provider is driven on a current-thread runtime (the binary owns its
+/// async runtime; `core` stays a library).
+pub fn run(lesson_path: &Path, format: OutputFormat) -> anyhow::Result<ExitCode> {
+    let lesson = read_lesson_file(lesson_path)?;
+    let suite_path = sibling_suite_path(lesson_path);
+    let suite_yaml = std::fs::read_to_string(&suite_path)
+        .with_context(|| format!("reading eval suite {}", suite_path.display()))?;
+    let suite = parse_eval_suite(&suite_yaml)?;
+    let base_url = std::env::var(PROVIDER_URL_VAR).ok();
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    let report = runtime.block_on(run_eval(
+        &lesson,
+        &suite,
+        ProviderChoice::default(),
+        base_url.as_deref(),
+    ))?;
+
+    output::emit_eval(&report, format)?;
+    Ok(ExitCode::SUCCESS)
+}
+
+/// The eval suite that sits beside `lesson_path`: the lesson's file name prefixed
+/// with `eval_`, so `lessons/foo.yaml` pairs with `lessons/eval_foo.yaml`. This
+/// is the instructor-only sibling convention — the suite is authored next to its
+/// lesson and is never bundled into a built site.
+fn sibling_suite_path(lesson_path: &Path) -> PathBuf {
+    let file_name = lesson_path.file_name().unwrap_or_else(|| OsStr::new(""));
+    let mut suite_name = OsString::from("eval_");
+    suite_name.push(file_name);
+    lesson_path.with_file_name(suite_name)
+}

--- a/crates/cli/src/commands/eval.rs
+++ b/crates/cli/src/commands/eval.rs
@@ -59,3 +59,32 @@ fn sibling_suite_path(lesson_path: &Path) -> PathBuf {
     suite_name.push(file_name);
     lesson_path.with_file_name(suite_name)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sibling_suite_prefixes_the_lesson_file_name_with_eval() {
+        assert_eq!(
+            sibling_suite_path(Path::new("courses/intro/lesson_one.yaml")),
+            PathBuf::from("courses/intro/eval_lesson_one.yaml")
+        );
+    }
+
+    #[test]
+    fn sibling_suite_keeps_a_bare_file_name_in_the_current_directory() {
+        assert_eq!(
+            sibling_suite_path(Path::new("lesson_one.yaml")),
+            PathBuf::from("eval_lesson_one.yaml")
+        );
+    }
+
+    #[test]
+    fn sibling_suite_of_a_path_without_a_file_name_is_the_prefix_alone() {
+        // A degenerate path (a bare root) has no file name to pair with; the
+        // result is the `eval_` prefix alone, so the subsequent read fails with a
+        // path-named error rather than silently scoring nothing.
+        assert_eq!(sibling_suite_path(Path::new("/")), PathBuf::from("/eval_"));
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -4,6 +4,12 @@
 //! renders the result for the terminal. No domain logic lives here — that is
 //! `core`'s responsibility (the dependency only ever points cli → core).
 
+pub mod eval;
 pub mod list;
 pub mod run;
 pub mod validate;
+
+/// The environment variable that overrides the provider's base URL — the test
+/// seam pointing the rig client at a stub (ADR-0006). Shared by every command
+/// that drives the provider pipeline (`run`, `eval`); unset in production.
+pub(crate) const PROVIDER_URL_VAR: &str = "BLENDTUTOR_PROVIDER_URL";

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -13,11 +13,8 @@ use blendtutor_core::lesson::read_lesson_file;
 use blendtutor_core::llm::{ProviderChoice, Submission, Verdict};
 use blendtutor_core::run::{RunReport, run_lesson};
 
+use crate::commands::PROVIDER_URL_VAR;
 use crate::output::{self, OutputFormat};
-
-/// The environment variable that overrides the provider's base URL — the test
-/// seam pointing the rig client at a stub (ADR-0006). Unset in production.
-const PROVIDER_URL_VAR: &str = "BLENDTUTOR_PROVIDER_URL";
 
 /// The exit code reserved for a submission that ran and was graded "not yet
 /// correct". Distinct from success (0) and from the error code (1, returned via

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -58,7 +58,14 @@ enum Commands {
         format: OutputFormat,
     },
     /// Run feedback-quality evals for a lesson.
-    Eval,
+    Eval {
+        /// Path to the lesson YAML file; its sibling `eval_<lesson>.yaml`
+        /// supplies the eval cases.
+        lesson: PathBuf,
+        /// Output format: `human` (default) or `json`.
+        #[arg(long, value_enum, default_value_t = OutputFormat::Human)]
+        format: OutputFormat,
+    },
     /// Build a browser-deployable lesson site.
     Build,
 }
@@ -73,7 +80,7 @@ impl Commands {
             Commands::Validate { .. } => "validate",
             Commands::List { .. } => "list",
             Commands::Run { .. } => "run",
-            Commands::Eval => "eval",
+            Commands::Eval { .. } => "eval",
             Commands::Build => "build",
         }
     }
@@ -89,6 +96,7 @@ fn main() -> anyhow::Result<ExitCode> {
             code,
             format,
         } => commands::run::run(&lesson, code.as_deref(), format),
+        Commands::Eval { lesson, format } => commands::eval::run(&lesson, format),
         other => Err(blendtutor_core::NotYetImplemented::new(other.name()).into()),
     }
 }

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -534,4 +534,27 @@ mod tests {
         );
         assert_eq!(render_list(&empty, OutputFormat::Json), "[]");
     }
+
+    /// Pin the human rendering of an eval report — the accuracy headline and the
+    /// 1-based per-case rows with their `[match]`/`[mismatch]` markers — so any
+    /// drift in wording, numbering, or the fraction/percentage fails loudly. The
+    /// fixture is the AC1 shape (two matches, one mismatch → 2/3).
+    #[test]
+    fn eval_human_matches_snapshot() {
+        use blendtutor_core::eval::{CaseResult, EvalReport, ExpectedVerdict};
+
+        let correct = Verdict::Correct {
+            message: "well done".to_string(),
+        };
+        let incorrect = Verdict::Incorrect {
+            message: "try again".to_string(),
+        };
+        let report = EvalReport::new(vec![
+            CaseResult::score(ExpectedVerdict::Correct, &correct),
+            CaseResult::score(ExpectedVerdict::Incorrect, &incorrect),
+            CaseResult::score(ExpectedVerdict::Correct, &incorrect),
+        ]);
+
+        insta::assert_snapshot!(render_eval(&report));
+    }
 }

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -13,6 +13,7 @@ use clap::ValueEnum;
 use serde::Serialize;
 
 use blendtutor_core::course::{DiscoveryError, LessonSummary};
+use blendtutor_core::eval::EvalReport;
 use blendtutor_core::lesson::Language;
 use blendtutor_core::llm::Verdict;
 use blendtutor_core::run::RunReport;
@@ -361,6 +362,59 @@ pub fn emit_run(report: &RunReport, format: OutputFormat) -> io::Result<()> {
             serde_json::to_string(report).expect("a RunReport serializes to JSON infallibly")
         }
         OutputFormat::Human => render_run(report),
+    };
+    writeln!(io::stdout(), "{text}")
+}
+
+/// The human rendering of an [`EvalReport`]: an accuracy headline followed by one
+/// row per case showing the expected and actual polarity and whether they
+/// matched.
+///
+/// Pure (§2.1): it reads the report and returns text, performing no I/O. The
+/// match marker is derived from the typed `matched` flag, so it cannot drift from
+/// the score; accuracy is shown as both the exact `matched/total` fraction and a
+/// rounded percentage. Each polarity word is the report's own canonical token, so
+/// the rendering cannot drift from the accepted set.
+fn render_eval(report: &EvalReport) -> String {
+    let total = report.cases().len();
+    let matched = report.cases().iter().filter(|case| case.matched()).count();
+    let mut lines = vec![
+        format!(
+            "Accuracy: {matched}/{total} ({percent:.1}%)",
+            percent = report.accuracy() * 100.0
+        ),
+        String::new(),
+    ];
+    for (position, case) in report.cases().iter().enumerate() {
+        let marker = if case.matched() {
+            "[match]"
+        } else {
+            "[mismatch]"
+        };
+        lines.push(format!(
+            "case {number}: expected {expected}, got {actual} {marker}",
+            number = position + 1,
+            expected = case.expected().token(),
+            actual = case.actual().token(),
+        ));
+    }
+    lines.join("\n")
+}
+
+/// Render `report` in `format` and write it to stdout — the single place an eval
+/// result reaches the terminal (§2.4, §5.1).
+///
+/// JSON is the report's canonical machine document (defined in `core`), the
+/// artifact a built site embeds without re-scoring; human is the accuracy
+/// headline plus per-case rows. Both are the command's data, so both go to
+/// stdout — a load or pipeline failure is an error that reaches stderr via
+/// `main`, never mixed into this stream.
+pub fn emit_eval(report: &EvalReport, format: OutputFormat) -> io::Result<()> {
+    let text = match format {
+        OutputFormat::Json => {
+            serde_json::to_string(report).expect("an EvalReport serializes to JSON infallibly")
+        }
+        OutputFormat::Human => render_eval(report),
     };
     writeln!(io::stdout(), "{text}")
 }

--- a/crates/cli/src/snapshots/blendtutor__output__tests__eval_human_matches_snapshot.snap
+++ b/crates/cli/src/snapshots/blendtutor__output__tests__eval_human_matches_snapshot.snap
@@ -1,0 +1,9 @@
+---
+source: crates/cli/src/output.rs
+expression: render_eval(&report)
+---
+Accuracy: 2/3 (66.7%)
+
+case 1: expected correct, got correct [match]
+case 2: expected incorrect, got incorrect [match]
+case 3: expected correct, got incorrect [mismatch]

--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -12,6 +12,11 @@
 //! `tokio::task::spawn_blocking`: that frees the test's async runtime to keep
 //! serving the wiremock mock while the child's HTTP request is in flight (a
 //! direct blocking call on a single-threaded runtime would deadlock).
+//!
+//! Compiled afresh into each integration-test binary, every one of which uses a
+//! subset of these helpers — so an unused-helper warning here is expected, not a
+//! defect.
+#![allow(dead_code)]
 
 use assert_cmd::Command;
 use serde_json::json;

--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -15,7 +15,7 @@
 
 use assert_cmd::Command;
 use serde_json::json;
-use wiremock::matchers::method;
+use wiremock::matchers::{body_string_contains, method};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// True (after printing a notice) when `Rscript` is not on `PATH`, so a
@@ -41,12 +41,42 @@ pub fn rscript_absent() -> bool {
 /// corrupt the mock body (§1.3). Mirrors the wire contract `core/tests/llm.rs`
 /// unit-tests the provider layer against.
 pub async fn mount_feedback(server: &MockServer, is_correct: bool, feedback: &str) {
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(feedback_body(is_correct, feedback)))
+        .mount(server)
+        .await;
+}
+
+/// Like [`mount_feedback`], but only answers requests whose body contains
+/// `needle` — so one server can return a distinct verdict per submission when a
+/// command (e.g. `eval`) makes several feedback calls. `needle` is a token from
+/// the submission, which `build_prompt` fences verbatim into the request body, so
+/// each case's request is routed to its own scripted verdict regardless of order.
+pub async fn mount_feedback_for(
+    server: &MockServer,
+    needle: &str,
+    is_correct: bool,
+    feedback: &str,
+) {
+    Mock::given(method("POST"))
+        .and(body_string_contains(needle))
+        .respond_with(ResponseTemplate::new(200).set_body_json(feedback_body(is_correct, feedback)))
+        .mount(server)
+        .await;
+}
+
+/// Build the OpenAI chat-completions envelope whose single `submit` tool call
+/// carries the feedback (`is_correct` + `feedback_message`) as a JSON-**encoded
+/// string** — the wire shape rig's openai client parses. Arguments are built via
+/// `serde_json` so quotes, backslashes, or newlines in `feedback` cannot corrupt
+/// the body (§1.3). Shared by the single- and per-submission mock mounts.
+fn feedback_body(is_correct: bool, feedback: &str) -> serde_json::Value {
     let arguments = serde_json::to_string(&json!({
         "is_correct": is_correct,
         "feedback_message": feedback,
     }))
     .expect("the feedback arguments serialize infallibly");
-    let body = json!({
+    json!({
         "id": "chatcmpl-test",
         "object": "chat.completion",
         "created": 0,
@@ -65,11 +95,7 @@ pub async fn mount_feedback(server: &MockServer, is_correct: bool, feedback: &st
             "finish_reason": "tool_calls"
         }],
         "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 }
-    });
-    Mock::given(method("POST"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(body))
-        .mount(server)
-        .await;
+    })
 }
 
 /// The ported example lesson (R, no checks — LLM-graded), under `core`'s fixtures.

--- a/crates/cli/tests/eval.rs
+++ b/crates/cli/tests/eval.rs
@@ -1,0 +1,87 @@
+//! Integration tests for `blendtutor eval <lesson>` — scoring feedback quality.
+//!
+//! `eval` loads a lesson and its sibling `eval_<lesson>.yaml` suite, runs every
+//! synthetic submission through the exact `run` pipeline (execute → grade → ask
+//! the LLM for a verdict), and scores each verdict's polarity against the case's
+//! expected polarity, reporting an aggregate accuracy and per-case results.
+//!
+//! Like the `run` tests, the provider is a `wiremock` stub reached through the
+//! `BLENDTUTOR_PROVIDER_URL` override and the interpreter is the real `Rscript`,
+//! so these skip-with-notice when R is absent. One server returns a distinct
+//! verdict per submission via [`mount_feedback_for`], keyed on a token the
+//! submission fences into the request body.
+
+mod common;
+
+use common::{blendtutor_output, mount_feedback_for, rscript_absent};
+use wiremock::MockServer;
+
+/// The demo lesson and its sibling eval suite (three cases: alpha/beta/gamma).
+const EVAL_LESSON: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../core/tests/fixtures/eval_command/demo_lesson.yaml"
+);
+
+/// Mount the three scripted verdicts that, against the suite's expected
+/// polarities `[correct, incorrect, correct]`, yield two matches and one
+/// mismatch (accuracy 2/3): alpha→correct (match), beta→incorrect (match),
+/// gamma→incorrect (mismatch).
+async fn mount_three_case_provider(server: &MockServer) {
+    mount_feedback_for(server, "alpha", true, "alpha looks right").await;
+    mount_feedback_for(server, "beta", false, "beta is off").await;
+    mount_feedback_for(server, "gamma", false, "gamma is off").await;
+}
+
+/// Run `blendtutor eval <lesson> [extra args]` against `server`, inside
+/// `spawn_blocking` so the test runtime keeps serving the mock while the child's
+/// requests are in flight.
+async fn eval_against(server: &MockServer, extra: &[&str]) -> std::process::Output {
+    let uri = server.uri();
+    let mut args = vec!["eval".to_string(), EVAL_LESSON.to_string()];
+    args.extend(extra.iter().map(|s| s.to_string()));
+    tokio::task::spawn_blocking(move || blendtutor_output(args, uri))
+        .await
+        .expect("the blocking command task should join")
+}
+
+/// AC1 — `eval` scores each case match/mismatch and reports the aggregate
+/// accuracy.
+///
+/// Three cases, two of whose verdicts match their expected polarity and one of
+/// which does not, must report `2/3` and surface exactly one mismatch in the
+/// per-case rows. Asserting the fraction *and* the single mismatch row is
+/// load-bearing: a stub that prints a constant accuracy or omits per-case
+/// results cannot pass, because the mismatch is driven by the mock's mixed
+/// verdicts flowing through the real scoring path.
+#[tokio::test]
+async fn eval_reports_aggregate_accuracy_and_per_case_results() {
+    if rscript_absent() {
+        return;
+    }
+    let server = MockServer::start().await;
+    mount_three_case_provider(&server).await;
+
+    let output = eval_against(&server, &[]).await;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "eval should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        stdout.contains("2/3"),
+        "stdout should report the aggregate accuracy 2/3, got: {stdout:?}"
+    );
+    assert_eq!(
+        stdout.matches("[match]").count(),
+        2,
+        "two cases should be reported as matches, got: {stdout:?}"
+    );
+    assert_eq!(
+        stdout.matches("[mismatch]").count(),
+        1,
+        "exactly one case should be reported as a mismatch, got: {stdout:?}"
+    );
+}

--- a/crates/cli/tests/eval.rs
+++ b/crates/cli/tests/eval.rs
@@ -85,3 +85,66 @@ async fn eval_reports_aggregate_accuracy_and_per_case_results() {
         "exactly one case should be reported as a mismatch, got: {stdout:?}"
     );
 }
+
+/// AC2 — `eval --format json` emits one JSON document carrying per-case
+/// verdicts, their expected polarity, the derived `matched` flag, and the
+/// aggregate accuracy — the artifact a built site embeds without re-scoring.
+///
+/// The whole stdout must parse as a *single* JSON value (so no log line or
+/// second document interleaves), `accuracy` must be the number `2/3` (not a
+/// string), and each case must carry non-null `expected`/`actual` strings and a
+/// boolean `matched` consistent with `expected == actual` — pinning the array to
+/// `[true, true, false]` proves the serialized flags are the real derived scores.
+#[tokio::test]
+async fn eval_json_emits_per_case_verdicts_and_aggregate() {
+    if rscript_absent() {
+        return;
+    }
+    let server = MockServer::start().await;
+    mount_three_case_provider(&server).await;
+
+    let output = eval_against(&server, &["--format", "json"]).await;
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "eval --format json should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let doc: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be exactly one JSON document");
+
+    let accuracy = doc["accuracy"]
+        .as_f64()
+        .expect("accuracy should be a JSON number, not a string");
+    assert!(
+        (accuracy - 2.0 / 3.0).abs() < 1e-12,
+        "accuracy should be 2/3, got {accuracy}"
+    );
+
+    let cases = doc["cases"].as_array().expect("cases should be an array");
+    assert_eq!(cases.len(), 3, "one entry per case");
+    let matched: Vec<bool> = cases
+        .iter()
+        .map(|case| {
+            assert!(
+                case["expected"].is_string(),
+                "expected should be a non-null string: {case}"
+            );
+            assert!(
+                case["actual"].is_string(),
+                "actual should be a non-null string: {case}"
+            );
+            let matched = case["matched"]
+                .as_bool()
+                .expect("matched should be a boolean");
+            assert_eq!(
+                matched,
+                case["expected"] == case["actual"],
+                "matched must reflect expected == actual: {case}"
+            );
+            matched
+        })
+        .collect();
+    assert_eq!(matched, vec![true, true, false]);
+}

--- a/crates/core/src/eval.rs
+++ b/crates/core/src/eval.rs
@@ -13,15 +13,22 @@
 //! `Feedback` → `Verdict` split (ADR-0006). That two-phase parse is what lets a
 //! bad verdict be reported against its *case index* rather than a YAML line.
 //!
-//! This module owns the eval *data shape* only. It does not read files (the
-//! caller's concern, so the parse stays pure — §2.1), does not run cases
-//! against a model (that is the `eval` command, Slice 13), and does not depend
-//! on `llm::Verdict`.
+//! The module owns two responsibilities at different altitudes. The *data shape*
+//! and its parse are pure: reading files is the caller's concern (§2.1). Scoring
+//! ([`score_case`], [`aggregate`], [`CaseResult`], [`EvalReport`]) is the pure
+//! core (§2.3) — exact polarity equality with no model in sight. [`run_eval`] is
+//! the thin effectful shell (§2.4) that drives the suite through the same
+//! pipeline `run` uses (so the feedback evaluated is the feedback shipped, §3.2)
+//! and hands each verdict to the pure scorer.
 
 use std::error::Error;
 use std::fmt;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize, Serializer};
+
+use crate::lesson::Lesson;
+use crate::llm::{ProviderChoice, Submission, Verdict};
+use crate::run::{RunError, run_lesson};
 
 /// The verdict an eval case expects the grader to return: a polarity, with no
 /// learner-facing message.
@@ -54,6 +61,36 @@ impl ExpectedVerdict {
             Self::CORRECT_TOKEN => Some(ExpectedVerdict::Correct),
             Self::INCORRECT_TOKEN => Some(ExpectedVerdict::Incorrect),
             _ => None,
+        }
+    }
+
+    /// The canonical lowercase spelling of this polarity — the single source for
+    /// the YAML `expected` token, the serialized JSON form, and the human
+    /// rendering, so none can drift from the accepted set.
+    pub const fn token(&self) -> &'static str {
+        match self {
+            ExpectedVerdict::Correct => Self::CORRECT_TOKEN,
+            ExpectedVerdict::Incorrect => Self::INCORRECT_TOKEN,
+        }
+    }
+}
+
+impl Serialize for ExpectedVerdict {
+    /// Serialize to the same canonical token the parser accepts, so a scored
+    /// report's JSON spells a polarity exactly as an author writes it.
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.token())
+    }
+}
+
+impl From<&Verdict> for ExpectedVerdict {
+    /// Reduce a runtime verdict to its scoring polarity, dropping the
+    /// learner-facing message: eval scores *whether* the grader agreed, not the
+    /// words it chose (v0 — richer grading is deferred).
+    fn from(verdict: &Verdict) -> Self {
+        match verdict {
+            Verdict::Correct { .. } => ExpectedVerdict::Correct,
+            Verdict::Incorrect { .. } => ExpectedVerdict::Incorrect,
         }
     }
 }
@@ -170,6 +207,156 @@ pub fn parse_eval_suite(yaml: &str) -> Result<EvalSuite, EvalParseError> {
     Ok(EvalSuite { cases })
 }
 
+/// Score one case: whether the grader's `actual` polarity matched the `expected`
+/// one.
+///
+/// Pure and total (§2.3, §5.1): exact equality of the two polarities, so a wrong
+/// verdict can never be scored a match — no substring or contains slack that
+/// would let a near-miss pass.
+pub fn score_case(expected: &ExpectedVerdict, actual: &ExpectedVerdict) -> bool {
+    expected == actual
+}
+
+/// The aggregate accuracy of scored `cases`: the fraction whose polarity matched.
+///
+/// Pure and total (§2.3): an empty suite scores `0.0`, not a `0/0` NaN, so the
+/// value always serializes to a real JSON number.
+pub fn aggregate(cases: &[CaseResult]) -> f64 {
+    if cases.is_empty() {
+        return 0.0;
+    }
+    let matched = cases.iter().filter(|case| case.matched).count();
+    matched as f64 / cases.len() as f64
+}
+
+/// One scored eval case: the expected polarity, the polarity the grader actually
+/// returned, and whether they matched.
+///
+/// `matched` is derived at construction from the two polarities ([`score_case`]),
+/// never set independently (§1.1): a result cannot claim a match its polarities
+/// contradict. The serialized shape — `expected`, `actual`, `matched` — is the
+/// per-case artifact a built site embeds without re-scoring.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CaseResult {
+    expected: ExpectedVerdict,
+    actual: ExpectedVerdict,
+    matched: bool,
+}
+
+impl CaseResult {
+    /// Score a case: reduce the runtime `actual` verdict to its polarity and
+    /// derive `matched` from it and `expected`. The only constructor, so a
+    /// `matched` flag inconsistent with the polarities is unrepresentable.
+    pub fn score(expected: ExpectedVerdict, actual: &Verdict) -> Self {
+        let actual = ExpectedVerdict::from(actual);
+        let matched = score_case(&expected, &actual);
+        Self {
+            expected,
+            actual,
+            matched,
+        }
+    }
+
+    /// The polarity the case's author expected the grader to return.
+    pub fn expected(&self) -> &ExpectedVerdict {
+        &self.expected
+    }
+
+    /// The polarity the grader actually returned for the submission.
+    pub fn actual(&self) -> &ExpectedVerdict {
+        &self.actual
+    }
+
+    /// Whether the actual polarity matched the expected one.
+    pub fn matched(&self) -> bool {
+        self.matched
+    }
+}
+
+/// The result of scoring an eval suite: every [`CaseResult`] in suite order plus
+/// the aggregate accuracy.
+///
+/// `accuracy` is derived at construction from the cases ([`aggregate`]), never
+/// set independently (§1.1). The serialized shape — `cases`, `accuracy` — is the
+/// eval artifact a built site embeds without re-scoring.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct EvalReport {
+    cases: Vec<CaseResult>,
+    accuracy: f64,
+}
+
+impl EvalReport {
+    /// Assemble a report from scored `cases`, deriving the aggregate accuracy so
+    /// it cannot disagree with the per-case results.
+    pub fn new(cases: Vec<CaseResult>) -> Self {
+        let accuracy = aggregate(&cases);
+        Self { cases, accuracy }
+    }
+
+    /// The scored cases, in suite order.
+    pub fn cases(&self) -> &[CaseResult] {
+        &self.cases
+    }
+
+    /// The fraction of cases whose verdict polarity matched the expected one.
+    pub fn accuracy(&self) -> f64 {
+        self.accuracy
+    }
+}
+
+/// Why scoring an eval suite failed: a case's submission could not be run through
+/// the pipeline — the interpreter failed to launch or the provider call failed.
+///
+/// Names the offending case so an instructor can find it; a scoring run is
+/// all-or-nothing, since a missing verdict cannot be scored as either polarity.
+#[derive(Debug)]
+pub struct EvalRunError {
+    /// The zero-based index of the case whose run failed, in suite order.
+    pub index: usize,
+    /// The underlying pipeline failure.
+    pub source: RunError,
+}
+
+impl fmt::Display for EvalRunError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "eval case {} failed to run: {}", self.index, self.source)
+    }
+}
+
+impl Error for EvalRunError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+/// Run every case in `suite` through the same pipeline `run` uses and score each
+/// verdict against its expected polarity.
+///
+/// The thin effectful shell over the pure scorer (§2.4): for each case it runs
+/// the submission through [`run_lesson`] — execute, grade, ask `provider` for a
+/// verdict — then pairs the verdict's polarity with the expected one as a
+/// [`CaseResult`]. Driving the *same* `run_lesson` is what keeps the evaluated
+/// feedback identical to the shipped feedback (§3.2). A run failure stops scoring
+/// and names the offending case ([`EvalRunError`]); `base_url_override` points
+/// the provider at a stub in tests, exactly as `run` does, and is `None` in
+/// production.
+pub async fn run_eval(
+    lesson: &Lesson,
+    suite: &EvalSuite,
+    provider: ProviderChoice,
+    base_url_override: Option<&str>,
+) -> Result<EvalReport, EvalRunError> {
+    let mut cases = Vec::with_capacity(suite.cases.len());
+    for (index, case) in suite.cases.iter().enumerate() {
+        let submission = Submission::new(case.submission.clone());
+        let report = run_lesson(lesson, &submission, provider, base_url_override)
+            .await
+            .map_err(|source| EvalRunError { index, source })?;
+        cases.push(CaseResult::score(case.expected.clone(), report.verdict()));
+    }
+    Ok(EvalReport::new(cases))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -233,6 +420,110 @@ mod tests {
         assert!(
             err.to_string().contains("submision"),
             "error should name the unknown key, got: {err}"
+        );
+    }
+
+    use crate::llm::Verdict;
+
+    fn correct() -> Verdict {
+        Verdict::Correct {
+            message: "well done".to_string(),
+        }
+    }
+
+    fn incorrect() -> Verdict {
+        Verdict::Incorrect {
+            message: "try again".to_string(),
+        }
+    }
+
+    #[test]
+    fn score_case_matches_same_polarity_and_rejects_the_opposite() {
+        // Exact polarity equality both ways, so a one-directional or constant
+        // implementation cannot pass.
+        assert!(score_case(&ExpectedVerdict::Correct, &ExpectedVerdict::Correct));
+        assert!(score_case(
+            &ExpectedVerdict::Incorrect,
+            &ExpectedVerdict::Incorrect
+        ));
+        assert!(!score_case(
+            &ExpectedVerdict::Correct,
+            &ExpectedVerdict::Incorrect
+        ));
+        assert!(!score_case(
+            &ExpectedVerdict::Incorrect,
+            &ExpectedVerdict::Correct
+        ));
+    }
+
+    #[test]
+    fn verdict_polarity_drops_the_feedback_message() {
+        // The runtime verdict's message is irrelevant to scoring; both polarities
+        // map so a constant mapping (always Correct/Incorrect) is caught.
+        assert_eq!(ExpectedVerdict::from(&correct()), ExpectedVerdict::Correct);
+        assert_eq!(
+            ExpectedVerdict::from(&incorrect()),
+            ExpectedVerdict::Incorrect
+        );
+    }
+
+    #[test]
+    fn case_result_derives_matched_from_score_case() {
+        // `matched` is computed at construction from the scored polarities, never
+        // set independently (§1.1): an expected-correct case graded incorrect is a
+        // mismatch, and `matched` equals `score_case` of the stored polarities.
+        let result = CaseResult::score(ExpectedVerdict::Correct, &incorrect());
+        assert_eq!(result.expected(), &ExpectedVerdict::Correct);
+        assert_eq!(result.actual(), &ExpectedVerdict::Incorrect);
+        assert!(!result.matched());
+        assert_eq!(
+            result.matched(),
+            score_case(result.expected(), result.actual())
+        );
+    }
+
+    #[test]
+    fn aggregate_is_matched_over_total_and_zero_for_an_empty_suite() {
+        let cases = vec![
+            CaseResult::score(ExpectedVerdict::Correct, &correct()),
+            CaseResult::score(ExpectedVerdict::Incorrect, &incorrect()),
+            CaseResult::score(ExpectedVerdict::Correct, &incorrect()),
+        ];
+        assert_eq!(aggregate(&cases), 2.0 / 3.0);
+        // No cases means no NaN (0/0) — an empty suite is a real, serializable 0.0.
+        assert_eq!(aggregate(&[]), 0.0);
+    }
+
+    #[test]
+    fn scores_two_of_three_and_aggregates() {
+        // The AC1 probe: two matches and one mismatch give exactly 2/3, the
+        // per-case `matched` flags are [true, true, false], and each is the
+        // derived `score_case` of its stored polarities.
+        let report = EvalReport::new(vec![
+            CaseResult::score(ExpectedVerdict::Correct, &correct()),
+            CaseResult::score(ExpectedVerdict::Incorrect, &incorrect()),
+            CaseResult::score(ExpectedVerdict::Correct, &incorrect()),
+        ]);
+
+        assert_eq!(report.accuracy(), 2.0 / 3.0);
+        let matched: Vec<bool> = report.cases().iter().map(CaseResult::matched).collect();
+        assert_eq!(matched, vec![true, true, false]);
+        for case in report.cases() {
+            assert_eq!(case.matched(), score_case(case.expected(), case.actual()));
+        }
+    }
+
+    #[test]
+    fn expected_verdict_serializes_to_its_canonical_token() {
+        // The JSON spelling is the same single-sourced token as the YAML one, so
+        // the wire form cannot drift from the accepted set.
+        assert_eq!(
+            serde_json::to_string(&ExpectedVerdict::Correct).unwrap(),
+            format!("{:?}", ExpectedVerdict::CORRECT_TOKEN)
+        );
+        assert_eq!(
+            serde_json::to_string(&ExpectedVerdict::Incorrect).unwrap(),
+            format!("{:?}", ExpectedVerdict::INCORRECT_TOKEN)
         );
     }
 }

--- a/crates/core/src/eval.rs
+++ b/crates/core/src/eval.rs
@@ -526,6 +526,35 @@ mod tests {
     }
 
     #[test]
+    fn eval_run_error_names_the_one_based_case_and_chains_its_source() {
+        use crate::llm::FeedbackError;
+        use crate::run::RunError;
+
+        let err = EvalRunError {
+            index: 2,
+            source: RunError::Feedback(FeedbackError::MissingApiKey {
+                var: "FIREWORKS_API_KEY",
+            }),
+        };
+
+        let message = err.to_string();
+        // Zero-based index 2 reads as the instructor's "case 3".
+        assert!(
+            message.contains("eval case 3 failed to run"),
+            "should name the 1-based case and the failure: {message}"
+        );
+        assert!(
+            message.contains("FIREWORKS_API_KEY"),
+            "should surface the underlying pipeline failure: {message}"
+        );
+        // The pipeline failure is chained as the error source, not swallowed.
+        assert!(
+            std::error::Error::source(&err).is_some(),
+            "the RunError must be reachable via Error::source"
+        );
+    }
+
+    #[test]
     fn expected_verdict_serializes_to_its_canonical_token() {
         // The JSON spelling is the same single-sourced token as the YAML one, so
         // the wire form cannot drift from the accepted set.

--- a/crates/core/src/eval.rs
+++ b/crates/core/src/eval.rs
@@ -319,7 +319,16 @@ pub struct EvalRunError {
 
 impl fmt::Display for EvalRunError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "eval case {} failed to run: {}", self.index, self.source)
+        // One-based for the instructor, matching the report's `case N` rows; the
+        // field stays a zero-based index. (Slice-12's `EvalParseError` reports the
+        // zero-based logical index instead — a parse-time developer concern, its
+        // tested contract left untouched here.)
+        write!(
+            f,
+            "eval case {} failed to run: {}",
+            self.index + 1,
+            self.source
+        )
     }
 }
 
@@ -441,7 +450,10 @@ mod tests {
     fn score_case_matches_same_polarity_and_rejects_the_opposite() {
         // Exact polarity equality both ways, so a one-directional or constant
         // implementation cannot pass.
-        assert!(score_case(&ExpectedVerdict::Correct, &ExpectedVerdict::Correct));
+        assert!(score_case(
+            &ExpectedVerdict::Correct,
+            &ExpectedVerdict::Correct
+        ));
         assert!(score_case(
             &ExpectedVerdict::Incorrect,
             &ExpectedVerdict::Incorrect

--- a/crates/core/tests/fixtures/eval_command/demo_lesson.yaml
+++ b/crates/core/tests/fixtures/eval_command/demo_lesson.yaml
@@ -1,0 +1,28 @@
+lesson_name: "Eval Command Demo"
+language: R
+description: "A tiny LLM-graded lesson used to exercise the eval command end to end"
+textbook_reference: "Just Enough Software Engineering - Appendix: Evals"
+
+exercise:
+  type: "function_writing"
+  code_template: |
+    # Print a single lowercase word to standard output
+    cat("word\n")
+  prompt: |
+    Print a single lowercase word to standard output with cat().
+  example_usage: |
+    cat("alpha\n")  # prints alpha
+  success_criteria: |
+    - Prints exactly one lowercase word
+    - Uses cat()
+  llm_evaluation_prompt: |
+    You are evaluating student code for a software engineering course.
+
+    Exercise: print a single lowercase word to standard output.
+
+    Student submitted this code:
+    {student_code}
+
+    Evaluate the code and call the respond_with_feedback function with your assessment.
+    Set is_correct to true if the code meets all requirements, false otherwise.
+    Provide brief, encouraging feedback (2-3 sentences) in feedback_message.

--- a/crates/core/tests/fixtures/eval_command/eval_demo_lesson.yaml
+++ b/crates/core/tests/fixtures/eval_command/eval_demo_lesson.yaml
@@ -1,0 +1,17 @@
+# Eval suite for demo_lesson.yaml — three synthetic submissions whose expected
+# polarity, paired with the mock provider's verdicts, yields two matches and one
+# mismatch (accuracy 2/3). Each submission is valid, cleanly-running R so the
+# verdict comes from the provider, not a launch failure. Instructor-only.
+cases:
+  # mock grades this correct → matches expected → MATCH
+  - submission: |-
+      cat("alpha\n")
+    expected: correct
+  # mock grades this incorrect → matches expected → MATCH
+  - submission: |-
+      cat("beta\n")
+    expected: incorrect
+  # mock grades this incorrect → differs from expected → MISMATCH
+  - submission: |-
+      cat("gamma\n")
+    expected: correct

--- a/docs/agent-notes/eval.md
+++ b/docs/agent-notes/eval.md
@@ -1,7 +1,7 @@
 ---
 topic: eval
 created: 2026-06-07
-slices: [12]
+slices: [12, 13]
 ---
 
 The eval-case model (`core::eval`): the typed shape the `eval` command will later
@@ -46,3 +46,47 @@ ADR-0007 for the verdict-representation decision.
 - 2026-06-07 (#12): **Deferred to Slice 13** — `parse_eval_suite` accepts an
   empty `cases:` list (structurally valid). Whether a suite must have ≥1 case is
   a semantic rule for the scoring slice, not modeled here.
+- 2026-06-07 (#13): **`eval` drives the *full* `run_lesson`, not just
+  `request_feedback`.** Decided with the user against the lighter feedback-only
+  path: each case's submission is executed through the real interpreter, graded,
+  then sent for a verdict — the exact pipeline `run` uses, so "feedback evaluated
+  is feedback shipped" holds literally (§3.2). Consequence: eval (and its
+  integration tests) need `Rscript`, so the cli tests skip via `rscript_absent()`
+  and the demo-lesson eval cases must be **cleanly-running** R (`cat("alpha\n")`,
+  not pseudocode), or a launch failure becomes `EvalRunError` instead of a
+  verdict. The original `eval_fireworks_vitals.R` was text-only; v0 here is not.
+- 2026-06-07 (#13): **Scoring is the pure core, `run_eval` the thin shell**
+  (§2.3/§2.4), both in `core::eval`. `score_case(&ExpectedVerdict,
+  &ExpectedVerdict) -> bool` is exact polarity equality (no substring slack);
+  `aggregate(&[CaseResult]) -> f64` is matched/total and returns **0.0 for an
+  empty suite** (not `0/0` NaN — serde_json cannot serialize NaN, so the artifact
+  would otherwise fail to emit). `CaseResult::score(expected, &Verdict)` is the
+  *only* constructor — it maps the runtime verdict to polarity and derives
+  `matched`, so a `matched` flag inconsistent with the polarities is
+  unrepresentable (§1.1). `EvalReport::new` likewise derives `accuracy`.
+- 2026-06-07 (#13): **`ExpectedVerdict` reconciliation realized.** Slice 12 left
+  the `llm::Verdict` → polarity mapping to this slice; it lands as
+  `impl From<&Verdict> for ExpectedVerdict` (message dropped — v0 scores polarity
+  only). `ExpectedVerdict` gained a hand-written `Serialize` (→ the canonical
+  `token()`, now `pub`) so the JSON spelling can't drift from the YAML/accepted
+  set, and `token()` is the single source for YAML + JSON + the human render.
+- 2026-06-07 (#13): **Case numbering split is intentional.** The human report and
+  `EvalRunError` Display are **1-based** (`case N`, matching how an author counts
+  their YAML); Slice-12's `EvalParseError::UnknownVerdict` stays **0-based** (a
+  parse-time logical index, its tested contract untouched). The `index` field is
+  zero-based throughout; only Display adds `+1`. Commented inline so it reads as a
+  choice, not a bug. A future slice could unify on 1-based (would change #12's
+  error test).
+- 2026-06-07 (#13): **No `mockd` crate (still).** The issue's executable-spec
+  probes invoked `cargo run -p blendtutor-test-support --bin mockd`; that crate
+  was never built (Slice 11 chose in-test wiremock — see [[run]]). Eval reuses the
+  same seam: `mount_feedback_for(server, needle, …)` routes a distinct scripted
+  verdict per submission by `body_string_contains(needle)`, where `needle` is a
+  token `build_prompt` fences verbatim into the request body. The
+  `BLENDTUTOR_PROVIDER_URL` const moved from `commands::run` to `commands::mod`
+  (`PROVIDER_URL_VAR`) so `run` and `eval` share one source.
+- 2026-06-07 (#13): **Sibling-suite convention is realized in the cli, not core.**
+  `eval <lesson.yaml>` reads `eval_<file_name>` next to the lesson
+  (`commands::eval::sibling_suite_path`, prefix the whole file name with
+  `eval_`). core::eval still never touches the filesystem (§2.1); the path
+  derivation + read live at the cli edge.


### PR DESCRIPTION
## Summary
- Add `blendtutor eval <lesson>`: load the lesson and its sibling `eval_<lesson>.yaml` suite, run every synthetic submission through the **same** `run_lesson` pipeline `run` uses (execute → grade → LLM verdict), score each verdict's polarity against the expected polarity, and report aggregate accuracy + per-case results.
- Pure scorer in `core::eval` (`score_case`, `aggregate`, `CaseResult`, `EvalReport`) with `matched`/`accuracy` derived at construction (§1.1) and an empty suite scoring `0.0` (no NaN); `run_eval` is the thin effectful shell (§2.4). Rendering lives in `cli` (`output::emit_eval`).
- `--format json` emits the canonical report artifact a built site embeds without re-scoring.

## Issue
Closes #13

## Slices implemented
- **AC1** — `eval` scores each case match/mismatch and reports aggregate accuracy. Covered by the pure unit `scores_two_of_three_and_aggregates` (2/3, matched `[true,true,false]`, each `matched == score_case`) and the `assert_cmd` integration `eval_reports_aggregate_accuracy_and_per_case_results` against a wiremock provider.
- **AC2** — `eval --format json` emits one JSON doc with numeric `accuracy` and `cases[].{expected,actual,matched}`. Covered by `eval_json_emits_per_case_verdicts_and_aggregate` (negative-control verified — see below).

## Reconciliations with the issue text
- **Pipeline depth:** chose the **full `run_lesson`** per case (decided with the maintainer), not the lighter `request_feedback`-only path — so the feedback evaluated is the feedback shipped (§3.2). Consequence: eval and its tests need `Rscript` (skip-with-notice when absent) and the demo cases are cleanly-running R.
- **Mock seam:** the issue's executable-spec probes invoked a `blendtutor-test-support`/`mockd` binary; that crate was never built (Slice 11 chose in-test wiremock). Eval reuses the same `BLENDTUTOR_PROVIDER_URL` seam via the new `mount_feedback_for`, routing a distinct verdict per submission by a body token. The `mockd` probe commands in the issue are superseded.
- **`expected` type:** `EvalCase.expected` is Slice-12's polarity-only `ExpectedVerdict` (ADR-0007), so scoring compares polarity; the `Verdict → ExpectedVerdict` mapping lands here as `From<&Verdict>`.
- **Case numbering:** the report rows and `EvalRunError` are 1-based; Slice-12's `EvalParseError` keeps its tested 0-based logical index (out of scope), noted inline.

## Test plan
- [x] All unit + integration tests pass (`cargo nextest run`: 108 passing)
- [x] `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `RUSTDOCFLAGS=-D warnings cargo doc` all clean
- [x] mutants(in-diff) gate clean (0 missed; added a test pinning `EvalRunError` Display + source after the gate surfaced them)
- [x] AC2 negative control: swapped the JSON arm to human prose → test failed at parse → reverted
- [x] Roborev findings resolved (case-numbering off-by-one + render/path test gaps fixed; `pub` pure-core API dismissed as the spec-named contract)
- [ ] ADRs written/updated — none needed (covered by ADR-0002/0006/0007)
- [ ] Rodney verification — n/a (no UI surface)