### PR TITLE
[feature] init — scaffold a course directory

### DIFF
--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -1,0 +1,21 @@
+//! `blendtutor init <dir>` — scaffold a new, ready-to-edit course directory.
+//!
+//! A thin shell over [`blendtutor_core::scaffold`]: hand the target to the core
+//! scaffolder and report success. The decision of *what* a course contains lives
+//! in `core` (§4.1); this command only names the target and frames the outcome.
+
+use std::path::Path;
+use std::process::ExitCode;
+
+use blendtutor_core::scaffold::scaffold_course;
+
+/// Scaffold a course into `dir`.
+///
+/// Delegates to [`scaffold_course`]; a write failure (or, once the guard lands, a
+/// refusal) propagates to `main` as an error with a nonzero exit, so this command
+/// never half-reports success.
+pub fn run(dir: &Path) -> anyhow::Result<ExitCode> {
+    scaffold_course(dir)?;
+    println!("Scaffolded a new course in {}", dir.display());
+    Ok(ExitCode::SUCCESS)
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -5,6 +5,7 @@
 //! `core`'s responsibility (the dependency only ever points cli → core).
 
 pub mod eval;
+pub mod init;
 pub mod list;
 pub mod run;
 pub mod validate;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -27,7 +27,10 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Scaffold a new course directory.
-    Init,
+    Init {
+        /// Path to the course directory to create (must be empty or new).
+        dir: PathBuf,
+    },
     /// Create a new lesson from a template.
     New,
     /// Validate a lesson file against the schema.
@@ -75,7 +78,7 @@ impl Commands {
     /// exhaustive, so a new variant cannot silently skip getting a name.
     const fn name(&self) -> &'static str {
         match self {
-            Commands::Init => "init",
+            Commands::Init { .. } => "init",
             Commands::New => "new",
             Commands::Validate { .. } => "validate",
             Commands::List { .. } => "list",
@@ -89,6 +92,7 @@ impl Commands {
 fn main() -> anyhow::Result<ExitCode> {
     let cli = Cli::parse();
     match cli.command {
+        Commands::Init { dir } => commands::init::run(&dir),
         Commands::Validate { path, format } => commands::validate::run(&path, format),
         Commands::List { path, format } => commands::list::run(&path, format),
         Commands::Run {

--- a/crates/cli/tests/init.rs
+++ b/crates/cli/tests/init.rs
@@ -1,0 +1,88 @@
+//! Integration tests for `blendtutor init`.
+//!
+//! Exercises course scaffolding end to end via the built binary (`assert_cmd`):
+//! run `init` against a directory, then observe both the files it writes and that
+//! the freshly scaffolded course is one `list` immediately accepts — the slice's
+//! "when I run init, I get a ready-to-edit course" behavior. The pure plan and
+//! the refuse-on-nonempty guard are unit-tested in `blendtutor-core`.
+
+use std::path::Path;
+
+use assert_cmd::Command;
+use serde_json::Value;
+
+/// The filenames directly under `dir`, for asserting which scaffold artifacts
+/// were (or were not) written without depending on directory order.
+fn entry_names(dir: &Path) -> Vec<String> {
+    std::fs::read_dir(dir)
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+        .collect()
+}
+
+#[test]
+fn init_scaffolds_a_ready_course_that_list_accepts() {
+    let dir = tempfile::tempdir().unwrap();
+    let course = dir.path();
+
+    Command::cargo_bin("blendtutor")
+        .unwrap()
+        .arg("init")
+        .arg(course)
+        .assert()
+        .success();
+
+    // All five artifact kinds are present: manifest, an example lesson yaml (not
+    // an eval), an eval suite, a README, and a key-ignoring gitignore. Asserting
+    // the whole set kills the "mkdir / one-placeholder" stub the spec calls out.
+    let names = entry_names(course);
+    assert!(
+        names.iter().any(|n| n == "blendtutor.toml"),
+        "a manifest is scaffolded; got {names:?}"
+    );
+    assert!(
+        names.iter().any(|n| n == ".gitignore"),
+        "a key-ignoring .gitignore is scaffolded; got {names:?}"
+    );
+    assert!(
+        names
+            .iter()
+            .any(|n| n.starts_with("eval_") && n.ends_with(".yaml")),
+        "an example eval suite is scaffolded; got {names:?}"
+    );
+    assert!(
+        names
+            .iter()
+            .any(|n| n.contains("lesson") && n.ends_with(".yaml") && !n.starts_with("eval_")),
+        "an example lesson is scaffolded; got {names:?}"
+    );
+    assert!(
+        names.iter().any(|n| n.to_lowercase().starts_with("readme")),
+        "a README is scaffolded; got {names:?}"
+    );
+
+    // The scaffolded course is not merely non-empty: `list` opens it and reports
+    // at least one successfully-discovered lesson (error == null). This fails a
+    // stub whose manifest points at a lesson that does not parse.
+    let listing = Command::cargo_bin("blendtutor")
+        .unwrap()
+        .arg("list")
+        .arg(course)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+    assert!(
+        listing.status.success(),
+        "`list` should accept the scaffolded course, got {:?}; stderr={:?}",
+        listing.status,
+        String::from_utf8_lossy(&listing.stderr)
+    );
+    let rows: Vec<Value> = serde_json::from_str(&String::from_utf8_lossy(&listing.stdout))
+        .expect("list --format json emits a JSON array");
+    let discovered = rows.iter().filter(|row| row["error"].is_null()).count();
+    assert!(
+        discovered >= 1,
+        "the scaffolded course lists at least one valid lesson; rows={rows:?}"
+    );
+}

--- a/crates/cli/tests/init.rs
+++ b/crates/cli/tests/init.rs
@@ -86,3 +86,51 @@ fn init_scaffolds_a_ready_course_that_list_accepts() {
         "the scaffolded course lists at least one valid lesson; rows={rows:?}"
     );
 }
+
+#[test]
+fn init_refuses_a_nonempty_target_leaving_it_untouched() {
+    let dir = tempfile::tempdir().unwrap();
+    let course = dir.path();
+    let sentinel = course.join("sentinel.txt");
+    std::fs::write(&sentinel, "KEEP").unwrap();
+
+    let output = Command::cargo_bin("blendtutor")
+        .unwrap()
+        .arg("init")
+        .arg(course)
+        .output()
+        .unwrap();
+
+    // Refuses rather than overwriting: nonzero exit with a clear message that the
+    // target is not empty.
+    assert!(
+        !output.status.success(),
+        "init must refuse a non-empty target, got {:?}; stderr={:?}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .to_lowercase()
+            .contains("not empty"),
+        "the refusal should explain the target is not empty; stderr={:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The pre-existing file is byte-for-byte untouched.
+    assert_eq!(
+        std::fs::read_to_string(&sentinel).unwrap(),
+        "KEEP",
+        "the guard must fire before any write, leaving existing files intact"
+    );
+
+    // Nothing else was created: the guard precedes every write, so a
+    // partial-clobber (write some files, then notice the dir is non-empty) cannot
+    // happen. The directory still holds only its pre-existing file.
+    let names = entry_names(course);
+    assert_eq!(
+        names,
+        vec!["sentinel.txt".to_string()],
+        "no scaffold artifact should appear in a refused target; got {names:?}"
+    );
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod lesson;
 pub mod llm;
 pub mod run;
 pub mod runner;
+pub mod scaffold;
 
 use std::error::Error;
 use std::fmt;

--- a/crates/core/src/scaffold.rs
+++ b/crates/core/src/scaffold.rs
@@ -4,10 +4,10 @@
 //! Holds the embedded starter templates (`include_str!`), the pure
 //! [`scaffold_plan`] that names the files a fresh course contains (testable with
 //! no filesystem, §2.3), and [`scaffold_course`] — the single effectful step
-//! that writes that plan into a target directory. This module owns *what a new
-//! course contains*; it does not parse CLI flags or decide where the course
-//! lives (§4.1). The templates are data the writer consumes, so changing a
-//! template never changes the writer (§3.2).
+//! that refuses a non-empty target before any write (§1.3.1) then writes that
+//! plan into it. This module owns *what a new course contains*; it does not parse
+//! CLI flags or decide where the course lives (§4.1). The templates are data the
+//! writer consumes, so changing a template never changes the writer (§3.2).
 
 use std::error::Error;
 use std::fmt;
@@ -80,6 +80,9 @@ pub fn scaffold_plan() -> Vec<FileSpec> {
 /// Why a course could not be scaffolded into a target directory.
 #[derive(Debug)]
 pub enum ScaffoldError {
+    /// The target directory already holds files, so the scaffold is refused
+    /// before any write (§1.3.1) rather than overwriting an existing course.
+    TargetNotEmpty(PathBuf),
     /// A filesystem operation failed while writing the scaffold (creating the
     /// directory or writing a file).
     Write(std::io::Error),
@@ -88,6 +91,11 @@ pub enum ScaffoldError {
 impl fmt::Display for ScaffoldError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            ScaffoldError::TargetNotEmpty(path) => write!(
+                f,
+                "target directory {path:?} is not empty; init refuses to overwrite \
+                 an existing course — choose an empty or new directory",
+            ),
             ScaffoldError::Write(e) => write!(f, "could not write course scaffold: {e}"),
         }
     }
@@ -96,6 +104,7 @@ impl fmt::Display for ScaffoldError {
 impl Error for ScaffoldError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
+            ScaffoldError::TargetNotEmpty(_) => None,
             ScaffoldError::Write(e) => Some(e),
         }
     }
@@ -104,15 +113,36 @@ impl Error for ScaffoldError {
 /// Scaffold a fresh course into `dir`, writing every file in the
 /// [plan](scaffold_plan).
 ///
-/// The effectful shell (§2.2) over the pure plan: it creates `dir` if missing,
-/// then writes each [`FileSpec`] verbatim. A missing target is created; an
-/// existing one is written into.
+/// The effectful shell (§2.2) over the pure plan. The refuse-on-nonempty guard
+/// fires first (§1.3.1): a directory that already holds files is rejected as
+/// [`ScaffoldError::TargetNotEmpty`] *before any write*, so a refused target is
+/// left exactly as it was — never partially clobbered. An absent or empty target
+/// is then created if missing and each [`FileSpec`] written verbatim.
 pub fn scaffold_course(dir: &Path) -> Result<(), ScaffoldError> {
+    if !is_empty_target(dir)? {
+        return Err(ScaffoldError::TargetNotEmpty(dir.to_path_buf()));
+    }
     std::fs::create_dir_all(dir).map_err(ScaffoldError::Write)?;
     for spec in scaffold_plan() {
         std::fs::write(dir.join(&spec.path), spec.contents).map_err(ScaffoldError::Write)?;
     }
     Ok(())
+}
+
+/// Whether `dir` is a safe scaffold target: it does not yet exist, or exists and
+/// holds no entries.
+///
+/// The boundary check behind the guard (§1.3.1). A `NotFound` directory is an
+/// empty target (it will be created); a directory with any entry is not. A read
+/// failure other than `NotFound` (e.g. a permission error) propagates as a write
+/// error rather than being read as "empty", so the guard never green-lights a
+/// target it could not actually inspect.
+fn is_empty_target(dir: &Path) -> Result<bool, ScaffoldError> {
+    match std::fs::read_dir(dir) {
+        Ok(mut entries) => Ok(entries.next().is_none()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(true),
+        Err(e) => Err(ScaffoldError::Write(e)),
+    }
 }
 
 #[cfg(test)]
@@ -200,5 +230,41 @@ mod tests {
             course.join(MANIFEST_FILENAME).is_file(),
             "the manifest lands inside the freshly-created course directory"
         );
+    }
+
+    #[test]
+    fn scaffold_course_refuses_a_nonempty_target_before_writing_anything() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("sentinel.txt"), "KEEP").unwrap();
+
+        let err = scaffold_course(dir.path())
+            .expect_err("a directory that already holds files must be refused");
+        assert!(
+            matches!(err, ScaffoldError::TargetNotEmpty(_)),
+            "a non-empty target is a TargetNotEmpty refusal, got {err:?}"
+        );
+
+        // The guard fires before any write: only the seeded file remains, and it
+        // is untouched. No plan file leaked into the directory.
+        let mut names: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        assert_eq!(names, vec!["sentinel.txt".to_string()]);
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("sentinel.txt")).unwrap(),
+            "KEEP"
+        );
+    }
+
+    #[test]
+    fn scaffold_course_accepts_an_existing_empty_directory() {
+        // The boundary case the AC2 probe drives: `mktemp -d` yields a directory
+        // that exists and is empty. That is a valid target, distinct from a
+        // non-empty one.
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_course(dir.path()).expect("an existing but empty directory is a valid target");
+        assert!(dir.path().join(MANIFEST_FILENAME).is_file());
     }
 }

--- a/crates/core/src/scaffold.rs
+++ b/crates/core/src/scaffold.rs
@@ -132,15 +132,26 @@ pub fn scaffold_course(dir: &Path) -> Result<(), ScaffoldError> {
 /// Whether `dir` is a safe scaffold target: it does not yet exist, or exists and
 /// holds no entries.
 ///
-/// The boundary check behind the guard (§1.3.1). A `NotFound` directory is an
-/// empty target (it will be created); a directory with any entry is not. A read
-/// failure other than `NotFound` (e.g. a permission error) propagates as a write
-/// error rather than being read as "empty", so the guard never green-lights a
-/// target it could not actually inspect.
+/// The boundary check behind the guard (§1.3.1). A directory with any entry is
+/// not empty. A read failure other than `NotFound` (e.g. a permission error)
+/// propagates as a write error rather than being read as "empty", so the guard
+/// never green-lights a target it could not actually inspect.
+///
+/// `read_dir` reports `NotFound` for two different paths: one that truly does not
+/// exist (a creatable, absent target) and a *broken symlink* (the link exists but
+/// its target does not). An `lstat` (`symlink_metadata`, which does not follow the
+/// link) tells them apart: if the path itself exists it is an existing object the
+/// scaffold must refuse, not silently try to create over — which would otherwise
+/// fail later with a cryptic "File exists".
 fn is_empty_target(dir: &Path) -> Result<bool, ScaffoldError> {
     match std::fs::read_dir(dir) {
         Ok(mut entries) => Ok(entries.next().is_none()),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // NotFound is ambiguous: distinguish a truly-absent path (empty,
+            // creatable) from a broken symlink that exists as its own inode (an
+            // existing object to refuse) with a non-following lstat.
+            Ok(std::fs::symlink_metadata(dir).is_err())
+        }
         Err(e) => Err(ScaffoldError::Write(e)),
     }
 }
@@ -280,6 +291,31 @@ mod tests {
         assert!(
             matches!(result, Err(ScaffoldError::Write(_))),
             "a non-directory target is a Write error, not an empty target, got {result:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scaffold_course_refuses_a_broken_symlink_target_instead_of_a_cryptic_write_error() {
+        // A broken symlink (its target does not exist) makes `read_dir` report
+        // NotFound, the same as a truly-absent path — but the link itself exists.
+        // The guard must refuse it before any write, rather than treat it as
+        // absent and let `create_dir_all` fail over the symlink inode with a
+        // confusing "File exists".
+        let dir = tempfile::tempdir().unwrap();
+        let link = dir.path().join("course_link");
+        let dangling = dir.path().join("nonexistent_target");
+        std::os::unix::fs::symlink(&dangling, &link).unwrap();
+
+        let err =
+            scaffold_course(&link).expect_err("a broken symlink target must be refused, not built");
+        assert!(
+            matches!(err, ScaffoldError::TargetNotEmpty(_)),
+            "a broken symlink is an existing object, refused before any write, got {err:?}"
+        );
+        assert!(
+            !dangling.exists(),
+            "the guard fires before create_dir_all, so the link's target is never created"
         );
     }
 

--- a/crates/core/src/scaffold.rs
+++ b/crates/core/src/scaffold.rs
@@ -147,9 +147,17 @@ fn is_empty_target(dir: &Path) -> Result<bool, ScaffoldError> {
     match std::fs::read_dir(dir) {
         Ok(mut entries) => Ok(entries.next().is_none()),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            // NotFound is ambiguous: distinguish a truly-absent path (empty,
-            // creatable) from a broken symlink that exists as its own inode (an
-            // existing object to refuse) with a non-following lstat.
+            // `read_dir` reports NotFound both for a truly-absent path and for a
+            // broken symlink (the link exists, its target does not). A
+            // non-following lstat tells them apart. This lstat runs *only after*
+            // read_dir already returned NotFound on the same path, so its only
+            // reachable outcomes are NotFound (the path is genuinely absent — a
+            // creatable, empty target) and Ok (the path exists as its own inode,
+            // e.g. a broken symlink — an existing object to refuse). A
+            // non-NotFound lstat error (e.g. a permission failure) cannot arise on
+            // a path read_dir just reported NotFound — that would have surfaced as
+            // the outer non-NotFound arm — so collapsing every lstat error to
+            // "absent" green-lights no un-inspectable target.
             Ok(std::fs::symlink_metadata(dir).is_err())
         }
         Err(e) => Err(ScaffoldError::Write(e)),

--- a/crates/core/src/scaffold.rs
+++ b/crates/core/src/scaffold.rs
@@ -1,0 +1,204 @@
+//! Course scaffolding: the templates a new course starts from and the plan that
+//! writes them.
+//!
+//! Holds the embedded starter templates (`include_str!`), the pure
+//! [`scaffold_plan`] that names the files a fresh course contains (testable with
+//! no filesystem, §2.3), and [`scaffold_course`] — the single effectful step
+//! that writes that plan into a target directory. This module owns *what a new
+//! course contains*; it does not parse CLI flags or decide where the course
+//! lives (§4.1). The templates are data the writer consumes, so changing a
+//! template never changes the writer (§3.2).
+
+use std::error::Error;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+/// One file a scaffold writes: its path relative to the course directory and the
+/// exact bytes to write there.
+///
+/// A plain data record (§3.2): the [plan](scaffold_plan) is pure data the
+/// effectful writer consumes, so a template edit is invisible to the writer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileSpec {
+    /// Where the file goes, relative to the course directory.
+    pub path: PathBuf,
+    /// The file's contents, verbatim.
+    pub contents: &'static str,
+}
+
+/// The course manifest every scaffold writes.
+const MANIFEST_TEMPLATE: &str = include_str!("scaffold/blendtutor.toml");
+/// The example lesson every scaffold writes.
+const LESSON_TEMPLATE: &str = include_str!("scaffold/lesson_hello.yaml");
+/// The example eval suite paired with the lesson.
+const EVAL_TEMPLATE: &str = include_str!("scaffold/eval_lesson_hello.yaml");
+/// The course README.
+const README_TEMPLATE: &str = include_str!("scaffold/README.md");
+/// The key-ignoring `.gitignore`. Stored dotless in-tree (`scaffold/gitignore`)
+/// so it does not act as a real ignore file over its sibling templates; it is
+/// written to `.gitignore` in the [plan](scaffold_plan).
+const GITIGNORE_TEMPLATE: &str = include_str!("scaffold/gitignore");
+
+/// The manifest filename a scaffolded course writes and `list` later reads.
+const MANIFEST_FILENAME: &str = "blendtutor.toml";
+/// The example lesson's filename; the manifest's one entry points here.
+const LESSON_FILENAME: &str = "lesson_hello.yaml";
+/// The example eval suite's filename, the `eval_<lesson>` sibling of the lesson.
+const EVAL_FILENAME: &str = "eval_lesson_hello.yaml";
+
+/// Compute the set of files a fresh course scaffold writes.
+///
+/// Pure (§2.1, §2.2): it returns the plan as data with no filesystem access, so
+/// the file set — and that each template is internally valid — is asserted
+/// directly in a unit test. [`scaffold_course`] is the effectful step that
+/// writes it (§5.1, plan vs write split).
+pub fn scaffold_plan() -> Vec<FileSpec> {
+    vec![
+        FileSpec {
+            path: PathBuf::from(MANIFEST_FILENAME),
+            contents: MANIFEST_TEMPLATE,
+        },
+        FileSpec {
+            path: PathBuf::from(LESSON_FILENAME),
+            contents: LESSON_TEMPLATE,
+        },
+        FileSpec {
+            path: PathBuf::from(EVAL_FILENAME),
+            contents: EVAL_TEMPLATE,
+        },
+        FileSpec {
+            path: PathBuf::from("README.md"),
+            contents: README_TEMPLATE,
+        },
+        FileSpec {
+            path: PathBuf::from(".gitignore"),
+            contents: GITIGNORE_TEMPLATE,
+        },
+    ]
+}
+
+/// Why a course could not be scaffolded into a target directory.
+#[derive(Debug)]
+pub enum ScaffoldError {
+    /// A filesystem operation failed while writing the scaffold (creating the
+    /// directory or writing a file).
+    Write(std::io::Error),
+}
+
+impl fmt::Display for ScaffoldError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ScaffoldError::Write(e) => write!(f, "could not write course scaffold: {e}"),
+        }
+    }
+}
+
+impl Error for ScaffoldError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            ScaffoldError::Write(e) => Some(e),
+        }
+    }
+}
+
+/// Scaffold a fresh course into `dir`, writing every file in the
+/// [plan](scaffold_plan).
+///
+/// The effectful shell (§2.2) over the pure plan: it creates `dir` if missing,
+/// then writes each [`FileSpec`] verbatim. A missing target is created; an
+/// existing one is written into.
+pub fn scaffold_course(dir: &Path) -> Result<(), ScaffoldError> {
+    std::fs::create_dir_all(dir).map_err(ScaffoldError::Write)?;
+    for spec in scaffold_plan() {
+        std::fs::write(dir.join(&spec.path), spec.contents).map_err(ScaffoldError::Write)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::course::Manifest;
+    use crate::eval::parse_eval_suite;
+    use crate::lesson::Lesson;
+
+    /// The planned file at `path`, or a panic naming the missing path.
+    fn planned(path: &str) -> FileSpec {
+        scaffold_plan()
+            .into_iter()
+            .find(|spec| spec.path == Path::new(path))
+            .unwrap_or_else(|| panic!("the plan should include {path:?}"))
+    }
+
+    #[test]
+    fn plan_lists_the_starter_files_as_pure_data() {
+        // Pure: asserted as data with no directory to write into (§2.3). The set
+        // is exactly what `list` needs (manifest + lesson) plus the authoring
+        // extras (eval, README, gitignore) — pinned so a dropped file is caught
+        // here, not only end to end.
+        let mut paths: Vec<String> = scaffold_plan()
+            .iter()
+            .map(|spec| spec.path.to_string_lossy().into_owned())
+            .collect();
+        paths.sort();
+        assert_eq!(
+            paths,
+            vec![
+                ".gitignore",
+                "README.md",
+                "blendtutor.toml",
+                "eval_lesson_hello.yaml",
+                "lesson_hello.yaml",
+            ]
+        );
+    }
+
+    #[test]
+    fn the_scaffolded_lesson_eval_and_manifest_parse_with_production_parsers() {
+        // The templates are validated by the very parsers production uses, so the
+        // scaffolded course is internally consistent: `list` resolves the manifest
+        // entry to a real, parseable lesson rather than a dangling path. This is
+        // what makes the AC1 "list discovers >=1 lesson" guarantee hold.
+        Lesson::parse(planned(LESSON_FILENAME).contents)
+            .expect("the example lesson must satisfy the lesson schema");
+        parse_eval_suite(planned(EVAL_FILENAME).contents)
+            .expect("the example eval suite must satisfy the eval schema");
+        let manifest = Manifest::parse(planned(MANIFEST_FILENAME).contents)
+            .expect("the example manifest must parse");
+
+        assert_eq!(manifest.lessons.len(), 1, "one example lesson is listed");
+        assert_eq!(
+            manifest.lessons[0].path,
+            Path::new(LESSON_FILENAME),
+            "the manifest entry points at the scaffolded lesson file"
+        );
+    }
+
+    #[test]
+    fn scaffold_course_writes_every_planned_file_verbatim() {
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_course(dir.path()).expect("scaffolding an empty dir succeeds");
+
+        for spec in scaffold_plan() {
+            let written = dir.path().join(&spec.path);
+            assert_eq!(
+                std::fs::read_to_string(&written)
+                    .unwrap_or_else(|e| panic!("{:?} should have been written: {e}", spec.path)),
+                spec.contents,
+                "{:?} should be written verbatim from its template",
+                spec.path
+            );
+        }
+    }
+
+    #[test]
+    fn scaffold_course_creates_the_target_directory_when_absent() {
+        let parent = tempfile::tempdir().unwrap();
+        let course = parent.path().join("new_course");
+        scaffold_course(&course).expect("a not-yet-existing target is created and written");
+        assert!(
+            course.join(MANIFEST_FILENAME).is_file(),
+            "the manifest lands inside the freshly-created course directory"
+        );
+    }
+}

--- a/crates/core/src/scaffold.rs
+++ b/crates/core/src/scaffold.rs
@@ -267,4 +267,44 @@ mod tests {
         scaffold_course(dir.path()).expect("an existing but empty directory is a valid target");
         assert!(dir.path().join(MANIFEST_FILENAME).is_file());
     }
+
+    #[test]
+    fn is_empty_target_surfaces_a_non_notfound_error_rather_than_reading_it_as_empty() {
+        // A path that is an existing *file* cannot be read as a directory:
+        // `read_dir` fails with a non-NotFound error. The guard must propagate
+        // that, never collapse it to "empty" — otherwise an uninspectable target
+        // would be green-lit. Distinguishes the NotFound arm (empty) from every
+        // other read failure (an error).
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let result = is_empty_target(file.path());
+        assert!(
+            matches!(result, Err(ScaffoldError::Write(_))),
+            "a non-directory target is a Write error, not an empty target, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn scaffold_error_display_and_source_distinguish_each_variant() {
+        use std::io::{Error as IoError, ErrorKind};
+
+        // TargetNotEmpty names the refusal, names the path, and has no nested
+        // source.
+        let refused = ScaffoldError::TargetNotEmpty(PathBuf::from("/some/course"));
+        let refused_msg = refused.to_string();
+        assert!(
+            refused_msg.contains("not empty") && refused_msg.contains("/some/course"),
+            "TargetNotEmpty should explain the refusal and name the path, got: {refused_msg}"
+        );
+        assert!(std::error::Error::source(&refused).is_none());
+
+        // Write labels itself a write failure and exposes the io::Error as its
+        // source, preserving the error chain.
+        let write = ScaffoldError::Write(IoError::new(ErrorKind::PermissionDenied, "denied"));
+        let write_msg = write.to_string();
+        assert!(
+            write_msg.contains("could not write course scaffold") && write_msg.contains("denied"),
+            "Write should frame and carry the message, got: {write_msg}"
+        );
+        assert!(std::error::Error::source(&write).is_some());
+    }
 }

--- a/crates/core/src/scaffold/README.md
+++ b/crates/core/src/scaffold/README.md
@@ -1,0 +1,21 @@
+# blendtutor course
+
+A starter course scaffolded by `blendtutor init`. Edit the example lesson, add
+your own, and share the directory — everything a learner needs lives here.
+
+## Layout
+
+- `blendtutor.toml` — the course manifest: which lessons exist, and in what order.
+- `lesson_hello.yaml` — an example lesson. Add more with `blendtutor new`.
+- `eval_lesson_hello.yaml` — an example eval suite for the lesson above.
+- `.gitignore` — keeps local LLM provider key files out of version control.
+
+## Commands
+
+- `blendtutor list .` — list the lessons in this course.
+- `blendtutor validate lesson_hello.yaml` — check a lesson against the schema.
+- `blendtutor run lesson_hello.yaml --code submission.R` — grade a submission.
+- `blendtutor eval lesson_hello.yaml` — run the lesson's eval suite.
+
+Set your provider key in the environment first (e.g. `FIREWORKS_API_KEY` or
+`ANTHROPIC_API_KEY`) so `run` and `eval` can reach the grader.

--- a/crates/core/src/scaffold/blendtutor.toml
+++ b/crates/core/src/scaffold/blendtutor.toml
@@ -1,0 +1,6 @@
+# Your course manifest: an ordered list of lessons, each pairing a stable course
+# slug `id` with the lesson file `path` (relative to this manifest). Add lessons
+# with `blendtutor new`, or edit this file by hand and `blendtutor list .`.
+[[lessons]]
+id = "hello"
+path = "lesson_hello.yaml"

--- a/crates/core/src/scaffold/eval_lesson_hello.yaml
+++ b/crates/core/src/scaffold/eval_lesson_hello.yaml
@@ -1,0 +1,10 @@
+# An example eval suite for lesson_hello.yaml. Each case pairs a sample
+# submission with the verdict you expect a good grader to return (correct or
+# incorrect). Run it with `blendtutor eval lesson_hello.yaml`.
+cases:
+  - submission: |-
+      cat("hello\n")
+    expected: correct
+  - submission: |-
+      cat("goodbye\n")
+    expected: incorrect

--- a/crates/core/src/scaffold/gitignore
+++ b/crates/core/src/scaffold/gitignore
@@ -1,0 +1,8 @@
+# Keep local LLM provider API keys out of version control. blendtutor reads the
+# provider key (e.g. FIREWORKS_API_KEY, ANTHROPIC_API_KEY) from the environment;
+# if you keep it in a local dotenv or key file, these patterns stop it being
+# committed alongside your course.
+.env
+.env.*
+.Renviron
+*.key

--- a/crates/core/src/scaffold/lesson_hello.yaml
+++ b/crates/core/src/scaffold/lesson_hello.yaml
@@ -1,0 +1,26 @@
+# An example lesson. Edit it, add more with `blendtutor new`, and check your
+# changes with `blendtutor validate lesson_hello.yaml`.
+lesson_name: "Hello, blendtutor"
+language: R
+description: "Print a friendly greeting — your first blendtutor lesson"
+exercise:
+  type: "function_writing"
+  prompt: |
+    Write R code that prints the word "hello" on its own line, using cat().
+  code_template: |
+    # Your code here
+    cat("hello\n")
+  example_usage: |
+    cat("hello\n")  # prints: hello
+  success_criteria: |
+    - Prints exactly the word "hello"
+    - Uses cat()
+  llm_evaluation_prompt: |
+    You are grading a beginner R exercise: print the word "hello" with cat().
+
+    The student submitted this code:
+    {student_code}
+
+    Decide whether it prints "hello" and call respond_with_feedback with your
+    assessment. Set is_correct true when the requirement is met, and give two or
+    three sentences of encouraging feedback.

--- a/docs/agent-notes/scaffold.md
+++ b/docs/agent-notes/scaffold.md
@@ -1,0 +1,45 @@
+---
+topic: scaffold
+created: 2026-06-07
+slices: [14]
+---
+
+How `blendtutor init <dir>` builds a ready-to-edit course (`core::scaffold`,
+`cli::commands::init`). Ports the intent of the R `create_lesson_package()` to a
+plain course directory (no R package). Builds on [[course-discovery]] (the
+`blendtutor.toml` shape it must emit) and [[lesson-model]] / [[eval]] (the lesson
+and eval schemas its templates must satisfy).
+
+- 2026-06-07 (#14): **Plan vs write split (§5.1, §2).** `scaffold_plan() ->
+  Vec<FileSpec>` is pure — it names the five starter files as data with no
+  filesystem access, so the file set is unit-asserted directly. `scaffold_course`
+  is the lone effectful step. Adding a starter file = one `FileSpec` in the plan;
+  the writer never changes (§3.2, templates are data).
+- 2026-06-07 (#14): **Templates are embedded via `include_str!` from
+  `crates/core/src/scaffold/`.** The `.gitignore` template is stored **dotless**
+  in-tree as `scaffold/gitignore` and written to `.gitignore` at scaffold time. A
+  real `.gitignore` checked into that source dir would act as an ignore file over
+  its sibling templates (hiding them from git / tooling) — the dotless name avoids
+  that. Same trick any future dotfile template needs.
+- 2026-06-07 (#14): **The templates are validated by the production parsers in a
+  unit test** (`Lesson::parse`, `parse_eval_suite`, `Manifest::parse`), and the
+  test asserts the manifest's one entry path equals the scaffolded lesson
+  filename. This is the contract that makes AC1's "`list` discovers ≥1 lesson"
+  hold: the scaffold cannot drift into emitting a course `list` would reject
+  without failing a core unit test first. If you change a template, that test is
+  the canary.
+- 2026-06-07 (#14): **Filename conventions are load-bearing for the spec probe.**
+  The lesson file must contain `lesson` and not start with `eval_`
+  (`lesson_hello.yaml`); the eval is its `eval_<lesson>` sibling
+  (`eval_lesson_hello.yaml`) — matching both the `eval <lesson>` sibling-resolution
+  convention and the AC1 probe's `find -path '*lesson*.yaml' ! -name 'eval_*'` /
+  `find -name 'eval_*.yaml'` globs. Renaming the lesson means renaming the eval
+  sibling and the manifest `path` together.
+- 2026-06-07 (#14): **Refuse-on-nonempty is a boundary guard before any write
+  (§1.3.1).** `scaffold_course` calls `is_empty_target` and returns
+  `ScaffoldError::TargetNotEmpty` *before* `create_dir_all` or any
+  `fs::write`, so a refused target is never partially clobbered. Empty set =
+  {absent dir, existing-but-empty dir}; only a dir with ≥1 entry is refused. The
+  existing-but-empty case is the one `mktemp -d` produces, so it had to be allowed,
+  not lumped in with non-empty. A `read_dir` error other than `NotFound` (e.g.
+  permissions) propagates as `Write`, never silently read as "empty".


### PR DESCRIPTION
## Summary
- Add `blendtutor init <dir>`: scaffold a ready-to-edit course (manifest, example lesson, paired eval suite, README, key-ignoring `.gitignore`) that `list` immediately accepts.
- `core::scaffold` computes the starter file set **purely** (`scaffold_plan() -> Vec<FileSpec>`, asserted with no filesystem) and writes it in one effectful step; templates are embedded data (`include_str!`) the writer consumes, so a template edit never touches the writer.
- Refuse-on-nonempty is a **boundary guard** (`is_empty_target`) that fires before any write, so a non-empty target is refused intact — never partially clobbered. Absent and existing-but-empty dirs are valid targets.

## Issue
Closes #14

## Slices implemented
- **AC1** — Empty target: `init` scaffolds a course (`blendtutor.toml`, `lesson_hello.yaml`, `eval_lesson_hello.yaml`, `README.md`, `.gitignore`) that `list` accepts reporting ≥1 successfully-discovered lesson. Covered by `init_scaffolds_a_ready_course_that_list_accepts` (asserts the whole file set + a non-null `list` row), plus core units pinning the plan and that every template parses with the production parsers (`Lesson::parse`, `parse_eval_suite`, `Manifest::parse`).
- **AC2** — Non-empty target: `init` refuses before any write — nonzero exit, a clear "not empty" message, the pre-existing file untouched, no scaffold artifact created. Covered by `init_refuses_a_nonempty_target_leaving_it_untouched` and core units (`scaffold_course_refuses_a_nonempty_target_before_writing_anything`, `scaffold_course_accepts_an_existing_empty_directory`).

Design intent (from the issue): plan/write split (§5.1, §2), templates-as-data (§3.2), `core::scaffold` owns templates not CLI flags (§4.1), refuse-on-nonempty guard before I/O (§1.3.1). No ADR (no new architectural boundary beyond the existing core/cli cut).

## Test plan
- [x] All unit + integration tests pass (`cargo test --workspace`: 118 passed)
- [x] `cargo fmt --check`, `cargo clippy -D warnings`, `cargo doc` (`RUSTDOCFLAGS=-D warnings`) all clean
- [x] `cargo mutants` over `scaffold.rs`: 0 missed (86 caught, 39 unviable); pre-push in-diff hook: 0 missed
- [x] Roborev findings resolved (clean on every commit)
- [x] ADRs written/updated (n/a — no new boundary)
- [x] Rodney verification (n/a — CLI slice, nothing visible in the web app)