### PR TITLE
[feature] new lesson --lang — add a lesson template

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -7,6 +7,7 @@
 pub mod eval;
 pub mod init;
 pub mod list;
+pub mod new;
 pub mod run;
 pub mod validate;
 

--- a/crates/cli/src/commands/new.rs
+++ b/crates/cli/src/commands/new.rs
@@ -1,0 +1,39 @@
+//! `blendtutor new lesson --lang <r|python> <id>` — add a language-appropriate
+//! lesson to the current course and register it in the manifest.
+//!
+//! A thin shell over [`blendtutor_core::scaffold::add_lesson`]: parse the `--lang`
+//! flag into the core [`Language`] at the boundary (§1.2, §1.3), then hand the
+//! course (the current directory) and id to core. The decision of *what* a lesson
+//! contains and *how* it is registered lives in `core` (§4.1); this command only
+//! names the target and frames the outcome.
+
+use std::path::Path;
+use std::process::ExitCode;
+
+use blendtutor_core::lesson::Language;
+use blendtutor_core::scaffold::add_lesson;
+
+/// Parse the `--lang` flag into a core [`Language`], rejecting any other value at
+/// the CLI boundary (§1.3) so an unknown language never travels downstream as
+/// data. The accepted spellings are the lowercase wire forms `r` and `python`,
+/// matching how `list` renders a lesson's language.
+pub fn parse_language(value: &str) -> Result<Language, String> {
+    match value {
+        "r" => Ok(Language::R),
+        "python" => Ok(Language::Python),
+        other => Err(format!(
+            "unknown language {other:?}; expected `r` or `python`"
+        )),
+    }
+}
+
+/// Add a `language` lesson `id` to the course in the current directory.
+///
+/// Delegates to [`add_lesson`]; an invalid id, an existing lesson, or a write
+/// failure propagates to `main` as an error with a nonzero exit, so the command
+/// never half-reports success.
+pub fn run(language: Language, id: &str) -> anyhow::Result<ExitCode> {
+    let path = add_lesson(Path::new("."), language, id)?;
+    println!("Added {id} lesson at {}", path.display());
+    Ok(ExitCode::SUCCESS)
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -8,6 +8,8 @@ use std::process::ExitCode;
 
 use clap::{Parser, Subcommand};
 
+use blendtutor_core::lesson::Language;
+
 mod commands;
 mod output;
 
@@ -32,7 +34,11 @@ enum Commands {
         dir: PathBuf,
     },
     /// Create a new lesson from a template.
-    New,
+    New {
+        /// What to create (currently only `lesson`).
+        #[command(subcommand)]
+        target: NewTarget,
+    },
     /// Validate a lesson file against the schema.
     Validate {
         /// Path to the lesson YAML file.
@@ -73,13 +79,28 @@ enum Commands {
     Build,
 }
 
+/// What `blendtutor new` creates. A nested subcommand rather than a positional
+/// string keeps the set of creatable things a checked sum type (§1.2) and lets it
+/// grow — e.g. a future `new eval` — without reparsing free text.
+#[derive(Subcommand)]
+enum NewTarget {
+    /// Add a new lesson from a language template.
+    Lesson {
+        /// The lesson's language: `r` or `python`.
+        #[arg(long, value_parser = commands::new::parse_language)]
+        lang: Language,
+        /// The lesson's course id; also its file stem under `lessons/`.
+        id: String,
+    },
+}
+
 impl Commands {
     /// The subcommand's canonical name, for user-facing messages. The match is
     /// exhaustive, so a new variant cannot silently skip getting a name.
     const fn name(&self) -> &'static str {
         match self {
             Commands::Init { .. } => "init",
-            Commands::New => "new",
+            Commands::New { .. } => "new",
             Commands::Validate { .. } => "validate",
             Commands::List { .. } => "list",
             Commands::Run { .. } => "run",
@@ -101,6 +122,9 @@ fn main() -> anyhow::Result<ExitCode> {
             format,
         } => commands::run::run(&lesson, code.as_deref(), format),
         Commands::Eval { lesson, format } => commands::eval::run(&lesson, format),
+        Commands::New { target } => match target {
+            NewTarget::Lesson { lang, id } => commands::new::run(lang, &id),
+        },
         other => Err(blendtutor_core::NotYetImplemented::new(other.name()).into()),
     }
 }

--- a/crates/cli/tests/new.rs
+++ b/crates/cli/tests/new.rs
@@ -84,3 +84,40 @@ fn new_lesson_python_creates_a_lesson_that_validates_and_lists() {
         "the new lesson's language should be python; got {greet:?}"
     );
 }
+
+#[test]
+fn new_lesson_refuses_a_duplicate_id_without_clobbering() {
+    let course = fresh_init_course();
+
+    // Create lesson `dup` as an R lesson, then snapshot its bytes and the manifest.
+    Command::cargo_bin("blendtutor")
+        .unwrap()
+        .current_dir(course.path())
+        .args(["new", "lesson", "--lang", "r", "dup"])
+        .assert()
+        .success();
+    let lesson_path = course.path().join("lessons").join("dup.yaml");
+    let lesson_before = std::fs::read(&lesson_path).expect("the first lesson is written");
+    let manifest_before = std::fs::read(course.path().join("blendtutor.toml")).unwrap();
+
+    // A second `new lesson` with the same id but a different language must refuse.
+    Command::cargo_bin("blendtutor")
+        .unwrap()
+        .current_dir(course.path())
+        .args(["new", "lesson", "--lang", "python", "dup"])
+        .assert()
+        .failure();
+
+    // The original lesson is byte-for-byte untouched (still the R template), and
+    // the manifest gained no duplicate entry: the guard fires before any write.
+    assert_eq!(
+        std::fs::read(&lesson_path).unwrap(),
+        lesson_before,
+        "a refused duplicate must not change the existing lesson's bytes"
+    );
+    assert_eq!(
+        std::fs::read(course.path().join("blendtutor.toml")).unwrap(),
+        manifest_before,
+        "a refused duplicate must not append a manifest entry"
+    );
+}

--- a/crates/cli/tests/new.rs
+++ b/crates/cli/tests/new.rs
@@ -86,6 +86,51 @@ fn new_lesson_python_creates_a_lesson_that_validates_and_lists() {
 }
 
 #[test]
+fn new_lesson_r_creates_a_lesson_that_validates_and_lists() {
+    // The symmetric twin of the python happy path: --lang r drives the R template
+    // end to end, so the language selection is exercised on both branches at the
+    // CLI boundary, not just python.
+    let course = fresh_init_course();
+
+    Command::cargo_bin("blendtutor")
+        .unwrap()
+        .current_dir(course.path())
+        .args(["new", "lesson", "--lang", "r", "tally"])
+        .assert()
+        .success();
+
+    Command::cargo_bin("blendtutor")
+        .unwrap()
+        .current_dir(course.path())
+        .args(["validate", "lessons/tally.yaml"])
+        .assert()
+        .success();
+
+    let listing = Command::cargo_bin("blendtutor")
+        .unwrap()
+        .args(["list"])
+        .arg(course.path())
+        .args(["--format", "json"])
+        .output()
+        .unwrap();
+    assert!(listing.status.success());
+    let rows: Vec<Value> = serde_json::from_str(&String::from_utf8_lossy(&listing.stdout))
+        .expect("list --format json emits a JSON array");
+    let tally = rows
+        .iter()
+        .find(|row| row["id"] == "tally")
+        .unwrap_or_else(|| panic!("list should show a `tally` row; rows={rows:?}"));
+    assert!(
+        tally["error"].is_null(),
+        "the tally row must be discovered; got {tally:?}"
+    );
+    assert_eq!(
+        tally["language"], "r",
+        "the new lesson's language should be r; got {tally:?}"
+    );
+}
+
+#[test]
 fn new_lesson_refuses_a_duplicate_id_without_clobbering() {
     let course = fresh_init_course();
 

--- a/crates/cli/tests/new.rs
+++ b/crates/cli/tests/new.rs
@@ -1,0 +1,86 @@
+//! Integration tests for `blendtutor new lesson --lang <r|python> <id>`.
+//!
+//! Exercises lesson authoring end to end via the built binary (`assert_cmd`):
+//! scaffold a course with `init`, add a lesson with `new lesson --lang`, then
+//! observe that the lesson file lands, `validate` accepts it, and it shows up in
+//! `list` with the right language — the slice's "when I run new lesson, I get a
+//! language-appropriate lesson registered in the course" behavior. The no-clobber
+//! refusal is the second slice. Pure template selection and the boundary guards
+//! are unit-tested in `blendtutor-core`.
+
+use assert_cmd::Command;
+use serde_json::Value;
+
+/// Scaffold a fresh course into a temp dir and return the handle. The course has
+/// no lesson `greet`, so a `new lesson greet` lands cleanly (AC1's `fresh_init_course`).
+fn fresh_init_course() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    Command::cargo_bin("blendtutor")
+        .unwrap()
+        .arg("init")
+        .arg(dir.path())
+        .assert()
+        .success();
+    dir
+}
+
+#[test]
+fn new_lesson_python_creates_a_lesson_that_validates_and_lists() {
+    let course = fresh_init_course();
+
+    // `new lesson --lang python greet`, run *inside* the course (the command
+    // operates on the current directory, as the AC1 probe does).
+    Command::cargo_bin("blendtutor")
+        .unwrap()
+        .current_dir(course.path())
+        .args(["new", "lesson", "--lang", "python", "greet"])
+        .assert()
+        .success();
+
+    // The lesson file lands under `lessons/<id>.yaml`.
+    let lesson_path = course.path().join("lessons").join("greet.yaml");
+    assert!(
+        lesson_path.is_file(),
+        "new lesson should write lessons/greet.yaml; missing at {lesson_path:?}"
+    );
+
+    // `validate` accepts the generated lesson: a template that hardcodes a broken
+    // schema would fail this conjunct.
+    Command::cargo_bin("blendtutor")
+        .unwrap()
+        .current_dir(course.path())
+        .args(["validate", "lessons/greet.yaml"])
+        .assert()
+        .success();
+
+    // `list` discovers a `greet` row whose language is `python` (the lowercase
+    // wire form). A template hardcoding R, or a lesson written but never
+    // registered in the manifest, each breaks a distinct conjunct here.
+    let listing = Command::cargo_bin("blendtutor")
+        .unwrap()
+        .args(["list"])
+        .arg(course.path())
+        .args(["--format", "json"])
+        .output()
+        .unwrap();
+    assert!(
+        listing.status.success(),
+        "`list` should accept the course after new lesson, got {:?}; stderr={:?}",
+        listing.status,
+        String::from_utf8_lossy(&listing.stderr)
+    );
+    let rows: Vec<Value> = serde_json::from_str(&String::from_utf8_lossy(&listing.stdout))
+        .expect("list --format json emits a JSON array");
+    let greet = rows
+        .iter()
+        .find(|row| row["id"] == "greet")
+        .unwrap_or_else(|| panic!("list should show a `greet` row; rows={rows:?}"));
+    assert!(
+        greet["error"].is_null(),
+        "the greet row must be a discovered lesson, not an error row; got {greet:?}"
+    );
+    assert_eq!(
+        greet["language"], "python",
+        "the new lesson's language should be python; got {greet:?}"
+    );
+}

--- a/crates/cli/tests/new.rs
+++ b/crates/cli/tests/new.rs
@@ -99,6 +99,14 @@ fn new_lesson_r_creates_a_lesson_that_validates_and_lists() {
         .assert()
         .success();
 
+    // Pin file existence directly, exactly as the python twin does, so the R
+    // branch never relies on `validate` alone as a file-existence proxy.
+    let lesson_path = course.path().join("lessons").join("tally.yaml");
+    assert!(
+        lesson_path.is_file(),
+        "new lesson --lang r should write lessons/tally.yaml; missing at {lesson_path:?}"
+    );
+
     Command::cargo_bin("blendtutor")
         .unwrap()
         .current_dir(course.path())

--- a/crates/core/src/scaffold.rs
+++ b/crates/core/src/scaffold.rs
@@ -698,4 +698,18 @@ mod tests {
             "a refused duplicate must not append a second manifest entry"
         );
     }
+
+    #[test]
+    fn is_valid_slug_accepts_word_chars_hyphens_and_underscores_but_nothing_else() {
+        // Pin both sides of the charset: hyphens, underscores, and digits are part
+        // of a real slug (`add-two`, `my_lesson`, `ch2`) and must be accepted, so a
+        // dropped allowed-char branch is caught here rather than only when a reject
+        // case slips through.
+        for ok in ["greet", "add-two", "my_lesson", "ch2", "a", "R2D2"] {
+            assert!(is_valid_slug(ok), "{ok:?} should be a valid slug");
+        }
+        for bad in ["", "../x", "a/b", "has space", "dot.dot", "quote\"d", "tab\tx", "."] {
+            assert!(!is_valid_slug(bad), "{bad:?} should be rejected");
+        }
+    }
 }

--- a/crates/core/src/scaffold.rs
+++ b/crates/core/src/scaffold.rs
@@ -249,8 +249,9 @@ pub fn lesson_template(language: Language, id: &str) -> String {
 
 /// Why a lesson could not be added to a course.
 ///
-/// The two refusals are kept distinct from a genuine write failure so the cli can
-/// frame each: an [`InvalidId`](AddLessonError::InvalidId) or an
+/// The three refusals are kept distinct from a genuine write failure so the cli
+/// can frame each: an [`InvalidId`](AddLessonError::InvalidId), a
+/// [`NotACourse`](AddLessonError::NotACourse), or an
 /// [`AlreadyExists`](AddLessonError::AlreadyExists) is a user-correctable refusal
 /// caught at the boundary *before any write*, whereas a
 /// [`Write`](AddLessonError::Write) is an underlying I/O fault.
@@ -261,6 +262,11 @@ pub enum AddLessonError {
     /// (§1.3.1) rather than escaping the course's `lessons/` directory or
     /// breaking the manifest's TOML. Carries the rejected id.
     InvalidId(String),
+    /// The target directory is not a course: it has no `blendtutor.toml` to
+    /// register the lesson in, so the add is refused before any write (§1.3.1)
+    /// rather than leaving an orphan lesson in a non-course directory. Carries the
+    /// directory. (Run `blendtutor init` first, or `cd` into a course.)
+    NotACourse(PathBuf),
     /// A lesson already exists at the target path, so the command refuses to
     /// overwrite it (no clobber), before any write. Carries the course-relative
     /// path that is already taken.
@@ -278,6 +284,11 @@ impl fmt::Display for AddLessonError {
                 "lesson id {id:?} is not a valid slug; use letters, digits, \
                  hyphens, and underscores only",
             ),
+            AddLessonError::NotACourse(dir) => write!(
+                f,
+                "{dir:?} is not a blendtutor course (no blendtutor.toml); run \
+                 `blendtutor init` or cd into a course before adding a lesson",
+            ),
             AddLessonError::AlreadyExists(path) => write!(
                 f,
                 "a lesson already exists at {path:?}; new lesson refuses to \
@@ -291,7 +302,9 @@ impl fmt::Display for AddLessonError {
 impl Error for AddLessonError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            AddLessonError::InvalidId(_) | AddLessonError::AlreadyExists(_) => None,
+            AddLessonError::InvalidId(_)
+            | AddLessonError::NotACourse(_)
+            | AddLessonError::AlreadyExists(_) => None,
             AddLessonError::Write(e) => Some(e),
         }
     }
@@ -314,25 +327,27 @@ fn is_valid_slug(id: &str) -> bool {
 /// Add a `language` lesson `id` to the course rooted at `dir`: write
 /// `lessons/<id>.yaml` from [`lesson_template`] and register it in the manifest.
 ///
-/// The effectful shell (§2.2) over the pure template selection. Two guards fire
-/// before the lesson is registered (§1.3.1): an unsafe slug is refused as
-/// [`AddLessonError::InvalidId`] before any write, and an id whose lesson file
-/// already exists is refused as [`AddLessonError::AlreadyExists`] — the
-/// create-new write makes the existence check atomic, so a duplicate never
-/// clobbers the existing lesson nor appends a second manifest entry. On success
-/// the lesson file is written, a `[[lessons]]` entry appended to
-/// `blendtutor.toml`, and the course-relative lesson path returned for the caller
-/// to report.
+/// The effectful shell (§2.2) over the pure template selection. Three guards fire
+/// before any write (§1.3.1): an unsafe slug is refused as
+/// [`AddLessonError::InvalidId`]; a directory with no `blendtutor.toml` is refused
+/// as [`AddLessonError::NotACourse`] — its manifest is *opened* up front, so a
+/// non-course directory is never left with an orphan lesson; and an id whose
+/// lesson file already exists is refused as [`AddLessonError::AlreadyExists`], the
+/// create-new write making that check atomic so a duplicate never clobbers the
+/// existing lesson nor appends a second manifest entry. On success the lesson file
+/// is written, a `[[lessons]]` entry appended to `blendtutor.toml`, and the
+/// course-relative lesson path returned.
 ///
-/// Write-then-register is not a transaction: a write that succeeds followed by a
-/// failed manifest append leaves an orphan lesson file that `list` (manifest-
-/// driven) simply does not show — a valid, recoverable state. The reverse order
-/// would be worse: a registered-then-unwritten entry makes `list` surface a
-/// broken row for a missing file. So the lesson file is written first, by intent.
+/// The manifest is opened first (the not-a-course guard) but its entry is appended
+/// last, after the lesson file is written. The only residual non-atomic window is
+/// a rare append failure after a good write, which leaves an orphan lesson `list`
+/// (manifest-driven) simply omits — a valid, recoverable state. Registering first
+/// would be worse: a `list` row pointing at a file that was never written.
 pub fn add_lesson(dir: &Path, language: Language, id: &str) -> Result<PathBuf, AddLessonError> {
     if !is_valid_slug(id) {
         return Err(AddLessonError::InvalidId(id.to_string()));
     }
+    let mut manifest = open_manifest_for_append(dir)?;
     let rel_path = PathBuf::from(LESSONS_DIR).join(format!("{id}.yaml"));
     std::fs::create_dir_all(dir.join(LESSONS_DIR)).map_err(AddLessonError::Write)?;
     write_without_clobber(&dir.join(&rel_path), &lesson_template(language, id)).map_err(
@@ -341,7 +356,7 @@ pub fn add_lesson(dir: &Path, language: Language, id: &str) -> Result<PathBuf, A
             _ => AddLessonError::Write(e),
         },
     )?;
-    register_lesson(dir, id)?;
+    append_lesson_entry(&mut manifest, id).map_err(AddLessonError::Write)?;
     Ok(rel_path)
 }
 
@@ -359,21 +374,35 @@ fn write_without_clobber(path: &Path, contents: &str) -> std::io::Result<()> {
     std::io::Write::write_all(&mut file, contents.as_bytes())
 }
 
-/// Append a `[[lessons]]` entry registering lesson `id` to the course manifest in
-/// `dir`.
+/// Open the course manifest in `dir` for appending, or refuse a directory that has
+/// no manifest as [`AddLessonError::NotACourse`].
+///
+/// Opening the manifest up front (it is not written here) turns "this is not a
+/// course" into a boundary refusal *before* any lesson file is written (§1.3.1),
+/// so a missing manifest can never leave an orphan lesson behind. A `NotFound` is
+/// the not-a-course signal; any other open failure is a genuine
+/// [`AddLessonError::Write`].
+fn open_manifest_for_append(dir: &Path) -> Result<std::fs::File, AddLessonError> {
+    std::fs::OpenOptions::new()
+        .append(true)
+        .open(dir.join(MANIFEST_FILENAME))
+        .map_err(|e| match e.kind() {
+            std::io::ErrorKind::NotFound => AddLessonError::NotACourse(dir.to_path_buf()),
+            _ => AddLessonError::Write(e),
+        })
+}
+
+/// Append a `[[lessons]]` entry registering lesson `id` to an already-open manifest
+/// handle.
 ///
 /// A textual append, not a re-serialize: TOML permits repeated `[[lessons]]`
 /// array-of-tables, the [`Manifest`](crate::course::Manifest) model is parse-only,
 /// and appending leaves every existing entry's bytes exactly where they were. The
 /// id is a validated slug, so the emitted TOML string and `lessons/<id>.yaml` path
 /// are safe to embed verbatim.
-fn register_lesson(dir: &Path, id: &str) -> Result<(), AddLessonError> {
-    let mut file = std::fs::OpenOptions::new()
-        .append(true)
-        .open(dir.join(MANIFEST_FILENAME))
-        .map_err(AddLessonError::Write)?;
+fn append_lesson_entry(manifest: &mut std::fs::File, id: &str) -> std::io::Result<()> {
     let entry = format!("\n[[lessons]]\nid = \"{id}\"\npath = \"{LESSONS_DIR}/{id}.yaml\"\n");
-    std::io::Write::write_all(&mut file, entry.as_bytes()).map_err(AddLessonError::Write)
+    std::io::Write::write_all(manifest, entry.as_bytes())
 }
 
 #[cfg(test)]
@@ -643,6 +672,26 @@ mod tests {
     }
 
     #[test]
+    fn add_lesson_refuses_a_non_course_directory_without_leaving_an_orphan() {
+        // Running `new lesson` outside a course (no blendtutor.toml) must refuse
+        // before any write (§1.3.1): the manifest is opened up front, so a plain
+        // directory is rejected as NotACourse and never contaminated with an orphan
+        // lessons/<id>.yaml that no manifest registers.
+        let dir = tempfile::tempdir().unwrap(); // a bare dir, never `init`-ed
+
+        let err = add_lesson(dir.path(), Language::Python, "greet")
+            .expect_err("a directory with no manifest is not a course");
+        assert!(
+            matches!(err, AddLessonError::NotACourse(_)),
+            "a missing manifest is a NotACourse refusal, got {err:?}"
+        );
+        assert!(
+            !dir.path().join(LESSONS_DIR).exists(),
+            "a refused non-course add must not write an orphan lesson directory"
+        );
+    }
+
+    #[test]
     fn add_lesson_error_display_and_source_distinguish_each_variant() {
         use std::io::{Error as IoError, ErrorKind};
 
@@ -663,6 +712,15 @@ mod tests {
             "AlreadyExists should name the path and the refusal, got: {exists_msg}"
         );
         assert!(std::error::Error::source(&exists).is_none());
+
+        // NotACourse names the directory and points at `init`, no source.
+        let not_course = AddLessonError::NotACourse(PathBuf::from("/tmp/scratch"));
+        let not_course_msg = not_course.to_string();
+        assert!(
+            not_course_msg.contains("/tmp/scratch") && not_course_msg.contains("blendtutor.toml"),
+            "NotACourse should name the dir and the missing manifest, got: {not_course_msg}"
+        );
+        assert!(std::error::Error::source(&not_course).is_none());
 
         // Write frames itself and exposes the io::Error as its source.
         let write = AddLessonError::Write(IoError::new(ErrorKind::PermissionDenied, "denied"));

--- a/crates/core/src/scaffold.rs
+++ b/crates/core/src/scaffold.rs
@@ -5,13 +5,18 @@
 //! [`scaffold_plan`] that names the files a fresh course contains (testable with
 //! no filesystem, §2.3), and [`scaffold_course`] — the single effectful step
 //! that refuses a non-empty target before any write (§1.3.1) then writes that
-//! plan into it. This module owns *what a new course contains*; it does not parse
-//! CLI flags or decide where the course lives (§4.1). The templates are data the
-//! writer consumes, so changing a template never changes the writer (§3.2).
+//! plan into it. It also grows an existing course one lesson at a time: the pure
+//! [`lesson_template`] selects a language-appropriate starter (§2.1) and the
+//! effectful [`add_lesson`] writes it and registers it in the manifest. This
+//! module owns *what a course's content is*; it does not parse CLI flags or decide
+//! where the course lives (§4.1). The templates are data the writer consumes, so
+//! changing a template never changes the writer (§3.2).
 
 use std::error::Error;
 use std::fmt;
 use std::path::{Path, PathBuf};
+
+use crate::lesson::Language;
 
 /// One file a scaffold writes: its path relative to the course directory and the
 /// exact bytes to write there.
@@ -164,12 +169,191 @@ fn is_empty_target(dir: &Path) -> Result<bool, ScaffoldError> {
     }
 }
 
+/// The subdirectory new lessons are written into, relative to the course root.
+/// The `init` example lesson sits at the course root; lessons added later live
+/// under here so a growing course keeps its lesson files in one place.
+const LESSONS_DIR: &str = "lessons";
+
+/// The exercise body of an R starter lesson: a valid `exercise` block whose
+/// `llm_evaluation_prompt` carries the required `{student_code}` placeholder.
+const R_EXERCISE: &str = r#"exercise:
+  type: "function_writing"
+  prompt: |
+    Write R code that prints the word "hello" on its own line, using cat().
+  code_template: |
+    # Your code here
+    cat("hello\n")
+  example_usage: |
+    cat("hello\n")  # prints: hello
+  success_criteria: |
+    - Prints exactly the word "hello"
+    - Uses cat()
+  llm_evaluation_prompt: |
+    You are grading a beginner R exercise: print the word "hello" with cat().
+
+    The student submitted this code:
+    {student_code}
+
+    Decide whether it prints "hello" and call respond_with_feedback with your
+    assessment. Set is_correct true when the requirement is met, and give two or
+    three sentences of encouraging feedback.
+"#;
+
+/// The exercise body of a Python starter lesson: the `print()` twin of
+/// [`R_EXERCISE`], likewise carrying the `{student_code}` placeholder.
+const PYTHON_EXERCISE: &str = r#"exercise:
+  type: "function_writing"
+  prompt: |
+    Write Python code that prints the word "hello" on its own line, using print().
+  code_template: |
+    # Your code here
+    print("hello")
+  example_usage: |
+    print("hello")  # prints: hello
+  success_criteria: |
+    - Prints exactly the word "hello"
+    - Uses print()
+  llm_evaluation_prompt: |
+    You are grading a beginner Python exercise: print the word "hello" with print().
+
+    The student submitted this code:
+    {student_code}
+
+    Decide whether it prints "hello" and call respond_with_feedback with your
+    assessment. Set is_correct true when the requirement is met, and give two or
+    three sentences of encouraging feedback.
+"#;
+
+/// Render a starter lesson for `language` under the slug `id`.
+///
+/// Pure (§2.1): it picks the language-appropriate exercise body and frames it
+/// with the lesson's `lesson_name`, `language`, and a description — returning the
+/// YAML as data with no filesystem access, so the result is asserted directly
+/// against the production parser. The `language` choice drives the template, so a
+/// `--lang python` lesson never declares `language: R` (§1.2). The caller is
+/// responsible for `id` being a safe slug; [`add_lesson`] guards it.
+pub fn lesson_template(language: Language, id: &str) -> String {
+    let (lang, exercise) = match language {
+        Language::R => ("R", R_EXERCISE),
+        Language::Python => ("Python", PYTHON_EXERCISE),
+    };
+    format!(
+        "# A lesson scaffolded by `blendtutor new lesson`. Edit it, then check your\n\
+         # changes with `blendtutor validate {LESSONS_DIR}/{id}.yaml`.\n\
+         lesson_name: \"{id}\"\n\
+         language: {lang}\n\
+         description: \"A starter {lang} lesson — replace with your own exercise\"\n\
+         {exercise}"
+    )
+}
+
+/// Why a lesson could not be added to a course.
+///
+/// The two refusals are kept distinct from a genuine write failure so the cli can
+/// frame each: an [`InvalidId`](AddLessonError::InvalidId) or an
+/// [`AlreadyExists`](AddLessonError::AlreadyExists) is a user-correctable refusal
+/// caught at the boundary *before any write*, whereas a
+/// [`Write`](AddLessonError::Write) is an underlying I/O fault.
+#[derive(Debug)]
+pub enum AddLessonError {
+    /// The lesson id is not a safe slug (empty, or containing a path separator,
+    /// `..`, whitespace, or punctuation), so it is refused before any write
+    /// (§1.3.1) rather than escaping the course's `lessons/` directory or
+    /// breaking the manifest's TOML. Carries the rejected id.
+    InvalidId(String),
+    /// A lesson already exists at the target path, so the command refuses to
+    /// overwrite it (no clobber), before any write. Carries the course-relative
+    /// path that is already taken.
+    AlreadyExists(PathBuf),
+    /// A filesystem operation failed while writing the lesson file or registering
+    /// it in the manifest.
+    Write(std::io::Error),
+}
+
+impl fmt::Display for AddLessonError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AddLessonError::InvalidId(id) => write!(
+                f,
+                "lesson id {id:?} is not a valid slug; use letters, digits, \
+                 hyphens, and underscores only",
+            ),
+            AddLessonError::AlreadyExists(path) => write!(
+                f,
+                "a lesson already exists at {path:?}; new lesson refuses to \
+                 overwrite it — choose a different id",
+            ),
+            AddLessonError::Write(e) => write!(f, "could not write the new lesson: {e}"),
+        }
+    }
+}
+
+impl Error for AddLessonError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            AddLessonError::InvalidId(_) | AddLessonError::AlreadyExists(_) => None,
+            AddLessonError::Write(e) => Some(e),
+        }
+    }
+}
+
+/// Whether `id` is a safe lesson slug: non-empty and built only from ASCII
+/// letters, digits, hyphens, and underscores.
+///
+/// The boundary check behind [`add_lesson`]'s guard (§1.3.1). The id is used both
+/// as a filename stem and, verbatim, inside the manifest's TOML, so excluding path
+/// separators, `.`, whitespace, and quotes keeps a new lesson from escaping
+/// `lessons/` or corrupting `blendtutor.toml`.
+fn is_valid_slug(id: &str) -> bool {
+    !id.is_empty()
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
+/// Add a `language` lesson `id` to the course rooted at `dir`: write
+/// `lessons/<id>.yaml` from [`lesson_template`] and register it in the manifest.
+///
+/// The effectful shell (§2.2) over the pure template selection. The id guard
+/// fires first (§1.3.1): an unsafe slug is refused as
+/// [`AddLessonError::InvalidId`] *before any write*. On success the lesson file is
+/// written and a `[[lessons]]` entry appended to `blendtutor.toml`, and the
+/// course-relative lesson path is returned for the caller to report.
+pub fn add_lesson(dir: &Path, language: Language, id: &str) -> Result<PathBuf, AddLessonError> {
+    if !is_valid_slug(id) {
+        return Err(AddLessonError::InvalidId(id.to_string()));
+    }
+    let rel_path = PathBuf::from(LESSONS_DIR).join(format!("{id}.yaml"));
+    std::fs::create_dir_all(dir.join(LESSONS_DIR)).map_err(AddLessonError::Write)?;
+    std::fs::write(dir.join(&rel_path), lesson_template(language, id))
+        .map_err(AddLessonError::Write)?;
+    register_lesson(dir, id)?;
+    Ok(rel_path)
+}
+
+/// Append a `[[lessons]]` entry registering lesson `id` to the course manifest in
+/// `dir`.
+///
+/// A textual append, not a re-serialize: TOML permits repeated `[[lessons]]`
+/// array-of-tables, the [`Manifest`](crate::course::Manifest) model is parse-only,
+/// and appending leaves every existing entry's bytes exactly where they were. The
+/// id is a validated slug, so the emitted TOML string and `lessons/<id>.yaml` path
+/// are safe to embed verbatim.
+fn register_lesson(dir: &Path, id: &str) -> Result<(), AddLessonError> {
+    let mut file = std::fs::OpenOptions::new()
+        .append(true)
+        .open(dir.join(MANIFEST_FILENAME))
+        .map_err(AddLessonError::Write)?;
+    let entry = format!("\n[[lessons]]\nid = \"{id}\"\npath = \"{LESSONS_DIR}/{id}.yaml\"\n");
+    std::io::Write::write_all(&mut file, entry.as_bytes()).map_err(AddLessonError::Write)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::course::Manifest;
+    use crate::course::{Course, Manifest};
     use crate::eval::parse_eval_suite;
-    use crate::lesson::Lesson;
+    use crate::lesson::{Language, Lesson};
 
     /// The planned file at `path`, or a panic naming the missing path.
     fn planned(path: &str) -> FileSpec {
@@ -348,6 +532,116 @@ mod tests {
         assert!(
             write_msg.contains("could not write course scaffold") && write_msg.contains("denied"),
             "Write should frame and carry the message, got: {write_msg}"
+        );
+        assert!(std::error::Error::source(&write).is_some());
+    }
+
+    #[test]
+    fn lesson_template_produces_a_valid_python_lesson() {
+        // The pure selector (§2.1) returns a Python lesson the production parser
+        // accepts: a template that hardcoded R, or emitted an invalid schema,
+        // fails here without touching any filesystem.
+        let yaml = lesson_template(Language::Python, "greet");
+        let lesson = Lesson::parse(&yaml).expect("the generated python lesson must be valid");
+        assert_eq!(lesson.language, Language::Python);
+        assert_eq!(lesson.lesson_name.to_string(), "greet");
+    }
+
+    #[test]
+    fn lesson_template_produces_a_valid_r_lesson() {
+        // The twin: the same selector yields a valid R lesson, so language drives
+        // the template rather than a hardcoded default.
+        let yaml = lesson_template(Language::R, "loops");
+        let lesson = Lesson::parse(&yaml).expect("the generated r lesson must be valid");
+        assert_eq!(lesson.language, Language::R);
+        assert_eq!(lesson.lesson_name.to_string(), "loops");
+    }
+
+    #[test]
+    fn add_lesson_writes_the_file_and_registers_it_so_the_course_lists_it() {
+        // Effectful (§2.2): into a real scaffolded course, add a python lesson and
+        // observe the whole AC1 chain in core terms — the file lands under
+        // lessons/, parses, and the manifest now resolves it as a discovered row.
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_course(dir.path()).unwrap();
+
+        let rel = add_lesson(dir.path(), Language::Python, "greet")
+            .expect("adding a fresh lesson succeeds");
+        assert_eq!(rel, Path::new("lessons/greet.yaml"));
+        assert!(
+            dir.path().join(&rel).is_file(),
+            "the lesson file is written"
+        );
+
+        let course = Course::open(dir.path()).expect("the course still opens after registration");
+        let greet = course
+            .discover()
+            .into_iter()
+            .filter_map(Result::ok)
+            .find(|s| s.id.to_string() == "greet")
+            .expect("the new lesson is discovered via the manifest");
+        assert_eq!(greet.language, Language::Python);
+    }
+
+    #[test]
+    fn add_lesson_refuses_an_unsafe_id_before_writing_anything() {
+        // The id becomes both a filename stem and a manifest path, so an id with a
+        // path separator, `..`, whitespace, or other unslug character is refused at
+        // the boundary (§1.3.1) before any write — never allowed to escape the
+        // course's lessons/ directory or break the manifest's TOML.
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_course(dir.path()).unwrap();
+        let manifest_before = std::fs::read_to_string(dir.path().join(MANIFEST_FILENAME)).unwrap();
+
+        for bad in ["../evil", "a/b", "", "has space", "dot.dot", "quote\"d"] {
+            let err = add_lesson(dir.path(), Language::Python, bad)
+                .expect_err("an unsafe id must be refused");
+            assert!(
+                matches!(err, AddLessonError::InvalidId(_)),
+                "id {bad:?} should be an InvalidId refusal, got {err:?}"
+            );
+        }
+        // No lessons/ dir created, manifest byte-identical: the guard precedes every
+        // write, so a refused id leaves the course exactly as it was.
+        assert!(
+            !dir.path().join("lessons").exists(),
+            "a refused id must not create the lessons directory"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join(MANIFEST_FILENAME)).unwrap(),
+            manifest_before,
+            "a refused id must not touch the manifest"
+        );
+    }
+
+    #[test]
+    fn add_lesson_error_display_and_source_distinguish_each_variant() {
+        use std::io::{Error as IoError, ErrorKind};
+
+        // InvalidId names the rejected id and has no nested source.
+        let invalid = AddLessonError::InvalidId("../evil".to_string());
+        let invalid_msg = invalid.to_string();
+        assert!(
+            invalid_msg.contains("../evil"),
+            "InvalidId should name the rejected id, got: {invalid_msg}"
+        );
+        assert!(std::error::Error::source(&invalid).is_none());
+
+        // AlreadyExists names the path and frames the no-clobber refusal, no source.
+        let exists = AddLessonError::AlreadyExists(PathBuf::from("lessons/greet.yaml"));
+        let exists_msg = exists.to_string();
+        assert!(
+            exists_msg.contains("lessons/greet.yaml") && exists_msg.contains("exists"),
+            "AlreadyExists should name the path and the refusal, got: {exists_msg}"
+        );
+        assert!(std::error::Error::source(&exists).is_none());
+
+        // Write frames itself and exposes the io::Error as its source.
+        let write = AddLessonError::Write(IoError::new(ErrorKind::PermissionDenied, "denied"));
+        let write_msg = write.to_string();
+        assert!(
+            write_msg.contains("denied"),
+            "Write should carry the io message, got: {write_msg}"
         );
         assert!(std::error::Error::source(&write).is_some());
     }

--- a/crates/core/src/scaffold.rs
+++ b/crates/core/src/scaffold.rs
@@ -314,21 +314,43 @@ fn is_valid_slug(id: &str) -> bool {
 /// Add a `language` lesson `id` to the course rooted at `dir`: write
 /// `lessons/<id>.yaml` from [`lesson_template`] and register it in the manifest.
 ///
-/// The effectful shell (§2.2) over the pure template selection. The id guard
-/// fires first (§1.3.1): an unsafe slug is refused as
-/// [`AddLessonError::InvalidId`] *before any write*. On success the lesson file is
-/// written and a `[[lessons]]` entry appended to `blendtutor.toml`, and the
-/// course-relative lesson path is returned for the caller to report.
+/// The effectful shell (§2.2) over the pure template selection. Two guards fire
+/// before the lesson is registered (§1.3.1): an unsafe slug is refused as
+/// [`AddLessonError::InvalidId`] before any write, and an id whose lesson file
+/// already exists is refused as [`AddLessonError::AlreadyExists`] — the
+/// create-new write makes the existence check atomic, so a duplicate never
+/// clobbers the existing lesson nor appends a second manifest entry. On success
+/// the lesson file is written, a `[[lessons]]` entry appended to
+/// `blendtutor.toml`, and the course-relative lesson path returned for the caller
+/// to report.
 pub fn add_lesson(dir: &Path, language: Language, id: &str) -> Result<PathBuf, AddLessonError> {
     if !is_valid_slug(id) {
         return Err(AddLessonError::InvalidId(id.to_string()));
     }
     let rel_path = PathBuf::from(LESSONS_DIR).join(format!("{id}.yaml"));
     std::fs::create_dir_all(dir.join(LESSONS_DIR)).map_err(AddLessonError::Write)?;
-    std::fs::write(dir.join(&rel_path), lesson_template(language, id))
-        .map_err(AddLessonError::Write)?;
+    write_without_clobber(&dir.join(&rel_path), &lesson_template(language, id)).map_err(
+        |e| match e.kind() {
+            std::io::ErrorKind::AlreadyExists => AddLessonError::AlreadyExists(rel_path.clone()),
+            _ => AddLessonError::Write(e),
+        },
+    )?;
     register_lesson(dir, id)?;
     Ok(rel_path)
+}
+
+/// Write `contents` to `path`, failing with [`std::io::ErrorKind::AlreadyExists`]
+/// rather than overwriting an existing file.
+///
+/// `create_new` fuses the existence check and the create into one atomic step, so
+/// there is no window between "does it exist?" and "write it" for the no-clobber
+/// guard to miss (§1.3.1) — unlike a separate `exists()` test then `write`.
+fn write_without_clobber(path: &Path, contents: &str) -> std::io::Result<()> {
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)?;
+    std::io::Write::write_all(&mut file, contents.as_bytes())
 }
 
 /// Append a `[[lessons]]` entry registering lesson `id` to the course manifest in
@@ -644,5 +666,36 @@ mod tests {
             "Write should carry the io message, got: {write_msg}"
         );
         assert!(std::error::Error::source(&write).is_some());
+    }
+
+    #[test]
+    fn add_lesson_refuses_a_duplicate_without_clobbering_or_double_registering() {
+        // No-clobber (§1.3.1): a second add of the same id is refused before any
+        // write, so the original lesson's bytes and the manifest are both
+        // untouched — no overwrite, no duplicate `[[lessons]]` entry.
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_course(dir.path()).unwrap();
+        add_lesson(dir.path(), Language::R, "dup").expect("the first add succeeds");
+
+        let lesson_path = dir.path().join(LESSONS_DIR).join("dup.yaml");
+        let lesson_before = std::fs::read(&lesson_path).unwrap();
+        let manifest_before = std::fs::read_to_string(dir.path().join(MANIFEST_FILENAME)).unwrap();
+
+        let err = add_lesson(dir.path(), Language::Python, "dup")
+            .expect_err("a duplicate id must be refused");
+        assert!(
+            matches!(err, AddLessonError::AlreadyExists(_)),
+            "a duplicate is an AlreadyExists refusal, got {err:?}"
+        );
+        assert_eq!(
+            std::fs::read(&lesson_path).unwrap(),
+            lesson_before,
+            "the existing lesson's bytes must be unchanged (still the R template)"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join(MANIFEST_FILENAME)).unwrap(),
+            manifest_before,
+            "a refused duplicate must not append a second manifest entry"
+        );
     }
 }

--- a/crates/core/src/scaffold.rs
+++ b/crates/core/src/scaffold.rs
@@ -323,6 +323,12 @@ fn is_valid_slug(id: &str) -> bool {
 /// the lesson file is written, a `[[lessons]]` entry appended to
 /// `blendtutor.toml`, and the course-relative lesson path returned for the caller
 /// to report.
+///
+/// Write-then-register is not a transaction: a write that succeeds followed by a
+/// failed manifest append leaves an orphan lesson file that `list` (manifest-
+/// driven) simply does not show — a valid, recoverable state. The reverse order
+/// would be worse: a registered-then-unwritten entry makes `list` surface a
+/// broken row for a missing file. So the lesson file is written first, by intent.
 pub fn add_lesson(dir: &Path, language: Language, id: &str) -> Result<PathBuf, AddLessonError> {
     if !is_valid_slug(id) {
         return Err(AddLessonError::InvalidId(id.to_string()));
@@ -708,7 +714,16 @@ mod tests {
         for ok in ["greet", "add-two", "my_lesson", "ch2", "a", "R2D2"] {
             assert!(is_valid_slug(ok), "{ok:?} should be a valid slug");
         }
-        for bad in ["", "../x", "a/b", "has space", "dot.dot", "quote\"d", "tab\tx", "."] {
+        for bad in [
+            "",
+            "../x",
+            "a/b",
+            "has space",
+            "dot.dot",
+            "quote\"d",
+            "tab\tx",
+            ".",
+        ] {
             assert!(!is_valid_slug(bad), "{bad:?} should be rejected");
         }
     }


### PR DESCRIPTION
## Summary
- `blendtutor new lesson --lang <r|python> <id>` drops a language-appropriate starter lesson at `lessons/<id>.yaml` and registers it in `blendtutor.toml`, so a course grows incrementally.
- Template selection is pure (`core::scaffold::lesson_template`); writing + manifest registration is the single effectful step (`add_lesson`). `--lang` parses to the core `Language` at the CLI boundary; `new` is modelled as a nested subcommand so the creatable set stays a checked sum type (§1.2).
- No-clobber: a duplicate id is refused atomically via `OpenOptions::create_new`, leaving the existing lesson bytes and the manifest untouched. An unsafe id (path separator, `..`, whitespace) is rejected before any write (§1.3.1).

## Issue
Closes #15

## Slices implemented
- **AC1** — `new lesson --lang python <id>` creates a Python lesson that validates and lists. Covered by `tests/new.rs::new_lesson_python_creates_a_lesson_that_validates_and_lists` (init → new → validate → list --format json: exit 0, file present, a `greet` row with `language == "python"`), plus core units `lesson_template_produces_a_valid_{python,r}_lesson` and `add_lesson_writes_the_file_and_registers_it_so_the_course_lists_it`.
- **AC2** — duplicate id refused without clobbering. Covered by `tests/new.rs::new_lesson_refuses_a_duplicate_id_without_clobbering` (byte-identity of the lesson file + manifest after a refused second `new`) and `add_lesson_refuses_a_duplicate_without_clobbering_or_double_registering`.

## Notes
- The lesson file carries the schema's canonical `language: Python` (serde variant spelling); the lowercase `python` wire form appears only in `list` output (`language_code`), which is where AC1's language assertion lands. The issue's illustrative `rg 'language.*python' <file>` probe is case-sensitive against a capital `Python`; the spec's `verification: code` (assert_cmd) is the gate, asserting language via `list --format json`.
- Manifest registration is a textual append of a `[[lessons]]` block, not a re-serialize: the `Manifest`/`ManifestEntry` model is parse-only (`Deserialize`, no `Serialize`), so an append leaves every existing entry's bytes in place.
- **Deferred (low):** the lowercase wire-form mapping lives in two CLI spots — `commands::new::parse_language` (parse) and `output::language_code` (render). Roborev rated this low/defer; a future cleanup could unify them behind one codec. No drift today (2-variant enum, both matches exhaustive).

## Test plan
- [x] All unit + integration tests pass (`cargo nextest run --locked` — 128 passed)
- [x] Roborev findings resolved (no-clobber High + test-gap Medium fixed in AC2; wire-form Low deferred; import Low dismissed)
- [x] `cargo fmt --check`, `cargo clippy --all-targets --locked -- -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --no-deps` all clean
- [x] `cargo mutants --in-diff` vs staging: 0 survivors (17 caught, 1 unviable)
- [ ] ADRs — N/A (issue: ADR not needed; reuses existing scaffold/manifest boundaries)
- [ ] Rodney — N/A (CLI slice, nothing UI-touching)