### PR TITLE
[feat] Add provider chooser + per-provider routing (Fireworks default)

### DIFF
--- a/crates/cli/tests/build.rs
+++ b/crates/cli/tests/build.rs
@@ -551,12 +551,14 @@ fn build_webr_ships_the_byok_fireworks_feedback_seam() {
         "byokFireworks response mapper must return message:; feedback={feedback}"
     );
 
-    // AC1 + AC2 negative: no emitted file may contain `fireworks_api_key` (the key
-    // is a parameter, not a slot literal) or `/v1/v1/chat/completions` (doubled path).
+    // AC1 + AC2 negative: no emitted file may contain the Fireworks key prefix
+    // `fw_` (a baked-in key literal) or `/v1/v1/chat/completions` (doubled path).
+    // `fireworks_api_key` is now a legitimate sessionStorage slot name (the
+    // PROVIDERS map in issue #51), so it is NOT scanned here.
     // Scan the *whole* emitted site, not just feedback.js (mirrors the Anthropic
     // `sk-ant` whole-site scan).
     for (path, contents) in emitted_files(&out) {
-        for forbidden in ["fireworks_api_key", "/v1/v1/chat/completions"] {
+        for forbidden in ["fw_", "/v1/v1/chat/completions"] {
             assert!(
                 !contents.contains(forbidden),
                 "no emitted file may contain `{forbidden}`; found in {path:?}"
@@ -564,6 +566,163 @@ fn build_webr_ships_the_byok_fireworks_feedback_seam() {
         }
     }
 }
+
+#[test]
+fn build_webr_ships_the_multi_provider_feedback_seam() {
+    // Issue #51 (AC2): a built site carries a provider chooser + per-provider
+    // routing — the PROVIDERS map drives the key slot, base URL, fallback model,
+    // and which FeedbackBackend handleSubmit constructs. Fireworks is the
+    // pre-selected default.
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("site");
+
+    let output = build("webr", R_COURSE, &out);
+    assert!(
+        output.status.success(),
+        "`build --target webr` should exit 0, got {:?}; stderr={:?}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let feedback = std::fs::read_to_string(out.join("feedback.js"))
+        .expect("the built site must ship feedback.js");
+
+    // AC1: a provider chooser <select data-byok="provider"> exists with
+    // Fireworks as the selected default. The chooser is built dynamically via
+    // DOM API (not a template literal), so we assert the programmatic
+    // pattern: the select element carries data-byok="provider", the
+    // DEFAULT_PROVIDER constant names fireworks, and the rendering code sets
+    // option.selected based on the default.
+    assert!(
+        feedback.contains(r#"data-byok="provider""#),
+        "feedback.js must ship a provider chooser with data-byok=provider; \
+         feedback={feedback}"
+    );
+    assert!(
+        feedback.contains("DEFAULT_PROVIDER"),
+        "feedback.js must define a DEFAULT_PROVIDER constant; feedback={feedback}"
+    );
+    assert!(
+        feedback.contains(r#""fireworks""#),
+        "feedback.js must reference the fireworks provider id; feedback={feedback}"
+    );
+    assert!(
+        feedback.contains(r#""Anthropic""#),
+        "feedback.js must reference the Anthropic provider label; feedback={feedback}"
+    );
+
+    // AC2: a closed-set PROVIDERS map carries both fireworks and anthropic with
+    // their keySlot, baseUrl, fallbackModel, and factory.
+    for provider_token in [
+        "PROVIDERS",
+        "fireworks_api_key",
+        "anthropic_api_key",
+        "https://api.fireworks.ai/inference/v1",
+        "https://api.anthropic.com",
+        "accounts/fireworks/models/deepseek-v4-flash",
+        "claude-opus-4-8",
+        "byokFireworks",
+        "byokAnthropic",
+    ] {
+        assert!(
+            feedback.contains(provider_token),
+            "feedback.js must ship the PROVIDERS map token `{provider_token}`; \
+             feedback={feedback}"
+        );
+    }
+
+    // AC3: handleSubmit constructs BOTH byokAnthropic( AND byokFireworks(
+    // conditionally off the selection (dead-chooser guard).
+    assert!(
+        feedback.contains("byokAnthropic("),
+        "handleSubmit must conditionally construct byokAnthropic(; feedback={feedback}"
+    );
+    assert!(
+        feedback.contains("byokFireworks("),
+        "handleSubmit must conditionally construct byokFireworks(; feedback={feedback}"
+    );
+
+    // AC4: fireworks_api_key is a distinct sessionStorage slot AND
+    // anthropic_api_key persists (no key-slot leakage).
+    assert!(
+        feedback.contains("fireworks_api_key"),
+        "feedback.js must define fireworks_api_key as a distinct key slot; \
+         feedback={feedback}"
+    );
+    assert!(
+        feedback.contains("anthropic_api_key"),
+        "feedback.js must keep anthropic_api_key as a key slot; \
+         feedback={feedback}"
+    );
+
+    // AC5: providerBaseUrl(providerId) returns the Fireworks URL for a Fireworks
+    // selection in the hard-default path.
+    assert!(
+        feedback.contains("https://api.fireworks.ai/inference/v1"),
+        "feedback.js must carry the Fireworks base URL; feedback={feedback}"
+    );
+    assert!(
+        feedback.contains("https://api.anthropic.com"),
+        "feedback.js must keep the Anthropic base URL; feedback={feedback}"
+    );
+
+    // AC6: host-gate tokens all persist (the gate did not regress).
+    for guard in [
+        r#"url.hostname === "localhost""#,
+        r#"url.hostname === "127.0.0.1""#,
+        "!url.username && !url.password",
+    ] {
+        assert!(
+            feedback.contains(guard),
+            "feedback.js must host-gate the ?provider= override with `{guard}`"
+        );
+    }
+
+    // AC7: the ?provider= override value is still parsed via new URL() (it
+    // remains a URL test-seam, NOT a provider-name selector).
+    assert!(
+        feedback.contains("new URL(override)"),
+        "?provider= override must still be parsed via new URL(); feedback={feedback}"
+    );
+
+    // AC8: per-provider disclosure — BOTH per-provider phrases appear.
+    let lower = feedback.to_lowercase();
+    assert!(
+        lower.contains("sent only to fireworks"),
+        "feedback.js must disclose Fireworks-only transmission; feedback={feedback}"
+    );
+    assert!(
+        lower.contains("sent only to anthropic"),
+        "feedback.js must disclose Anthropic-only transmission; feedback={feedback}"
+    );
+
+    // AC9: byokAnthropic is NOT removed.
+    assert!(
+        feedback.contains("byokAnthropic"),
+        "byokAnthropic must still be present in feedback.js; feedback={feedback}"
+    );
+
+    // AC10: a negative scan of EVERY emitted file rejects the Fireworks key
+    // prefix fw_ (symmetric to the existing sk-ant scan in
+    // build_webr_ships_the_byok_anthropic_feedback_seam).
+    //
+    // Also re-scan for sk-ant since this is an independent test that must also
+    // guard against that regression.
+    for (path, contents) in emitted_files(&out) {
+        assert!(
+            !contents.contains("fw_"),
+            "a Fireworks key prefix must never ship baked in; found in {path:?}"
+        );
+        assert!(
+            !contents.contains("sk-ant"),
+            "an Anthropic key prefix must never ship baked in; found in {path:?}"
+        );
+    }
+}
+
+// AC11 (byte-identity across targets) is exercised by
+// build_pyodide_ships_the_same_shared_feedback_seam below — that test stays
+// green unchanged.
 
 #[test]
 fn build_pyodide_ships_the_same_shared_feedback_seam() {

--- a/crates/cli/tests/build.rs
+++ b/crates/cli/tests/build.rs
@@ -631,15 +631,11 @@ fn build_webr_ships_the_multi_provider_feedback_seam() {
         );
     }
 
-    // AC3: handleSubmit constructs BOTH byokAnthropic( AND byokFireworks(
-    // conditionally off the selection (dead-chooser guard).
+    // AC3: handleSubmit routes through PROVIDERS[providerId].factory, not a
+    // hardcoded backend name (dead-chooser guard).
     assert!(
-        feedback.contains("byokAnthropic("),
-        "handleSubmit must conditionally construct byokAnthropic(; feedback={feedback}"
-    );
-    assert!(
-        feedback.contains("byokFireworks("),
-        "handleSubmit must conditionally construct byokFireworks(; feedback={feedback}"
+        feedback.contains("PROVIDERS[providerId].factory"),
+        "handleSubmit must route through PROVIDERS[providerId].factory, not hardcode a backend; feedback={feedback}"
     );
 
     // AC4: fireworks_api_key is a distinct sessionStorage slot AND

--- a/crates/core/assets/shared/feedback.js
+++ b/crates/core/assets/shared/feedback.js
@@ -135,7 +135,8 @@ function storeKey(key, providerId) {
 }
 
 function readProvider() {
-  return window.sessionStorage.getItem("byok_provider") || DEFAULT_PROVIDER;
+  const stored = window.sessionStorage.getItem("byok_provider");
+  return stored && stored in PROVIDERS ? stored : DEFAULT_PROVIDER;
 }
 
 function storeProvider(providerId) {
@@ -421,6 +422,7 @@ function renderKeyPrompt(container) {
   provLabel.append(provSelect);
 
   const keyLabel = document.createElement("label");
+  keyLabel.textContent = "API key: ";
   const keyInput = document.createElement("input");
   keyInput.type = "password";
   keyInput.name = "provider-key";
@@ -431,6 +433,7 @@ function renderKeyPrompt(container) {
     const prov = PROVIDERS[provSelect.value];
     disclosure.textContent = PROVIDER_DISCLOSURES[provSelect.value];
     keyInput.placeholder = "Paste your " + prov.label + " API key";
+    keyInput.value = "";  // never let a key typed for one provider be saved to another slot
   }
   provSelect.addEventListener("change", updateDisclosure);
   updateDisclosure();

--- a/crates/core/assets/shared/feedback.js
+++ b/crates/core/assets/shared/feedback.js
@@ -1,5 +1,6 @@
-// blendtutor in-browser LLM feedback — the FeedbackBackend seam + byok-anthropic
-// + byok-fireworks impls (Slice 18/ADR-0006/0008 consequence; Slice AC1/issue #50).
+// blendtutor in-browser LLM feedback — the FeedbackBackend seam + provider-chooser
+// + byok-fireworks / byok-anthropic impls (Slice 18/ADR-0006/0008/0009 consequence;
+// Slices AC1/issue #50, AC2/issue #51).
 //
 // Where this fits: a built site runs and grades lessons locally (lesson-runner-
 // core.js); *this* module is the separate concern of fetching written feedback on
@@ -7,15 +8,16 @@
 //   1. The `FeedbackBackend` contract — `getFeedback(prompt) -> Promise<Verdict>`,
 //      the one seam a future backend (WebLLM, Slice 21) plugs into with no change
 //      to lesson rendering or execution (§3.3, §3.4).
-//   2. The `byok-anthropic` impl (v1) and the `byok-fireworks` impl (v2): the
-//      learner brings their own key. The key is read from this tab's sessionStorage
-//      and sent only to the chosen provider — header injection and key handling are
-//      isolated here, never in the render/exec layers (§4.2). No key literal is ever
-//      baked into a shipped file.
-//   3. The submit-flow wiring: prompt for a key when absent (with the dual
-//      disclosure), otherwise build the prompt, call the backend, render the
-//      verdict — reading the runner's already-exposed `window.__bt` seam rather
-//      than reaching into its internals.
+//   2. A `PROVIDERS` map carrying each provider's key slot, base URL, fallback
+//      model, and factory — the chooser drives routing. The learner brings their
+//      own key. The key is read from this tab's sessionStorage and sent only to
+//      the chosen provider — header injection and key handling are isolated here,
+//      never in the render/exec layers (§4.2). No key literal is ever baked into
+//      a shipped file.
+//   3. The submit-flow wiring: prompt for a provider + key when absent (with
+//      per-provider disclosure), otherwise build the prompt, call the backend,
+//      render the verdict — reading the runner's already-exposed `window.__bt`
+//      seam rather than reaching into its internals.
 //
 // `Verdict` mirrors the Rust `core::llm::Verdict` contract (`{ correct, message }`
 // ↔ `Correct{message}/Incorrect{message}`), so author-side evals and learner-side
@@ -33,9 +35,42 @@ const OUTPUT_LABEL = "<<<CAPTURED_OUTPUT>>>";
 const CHECKS_LABEL = "<<<CHECK_RESULTS>>>";
 const NEUTRALIZED = "[neutralized-delimiter]";
 
-// The tab-scoped slot the learner's key lives in — sessionStorage, so it is gone
-// when the tab closes and never shared with another tab/origin.
-const KEY_SLOT = "anthropic_api_key";
+// --- provider map + key handling (sessionStorage, tab-scoped) --------------------
+
+// The closed set of providers the chooser renders and handleSubmit routes to.
+// Each entry carries the tab-scoped sessionStorage slot for the learner's key,
+// the base URL for API calls, the fallback model, and the FeedbackBackend factory
+// that builds the provider-specific backend.
+const PROVIDERS = {
+  fireworks: {
+    label: "Fireworks",
+    keySlot: "fireworks_api_key",
+    baseUrl: "https://api.fireworks.ai/inference/v1",
+    fallbackModel: "accounts/fireworks/models/deepseek-v4-flash",
+    factory: byokFireworks,
+  },
+  anthropic: {
+    label: "Anthropic",
+    keySlot: "anthropic_api_key",
+    baseUrl: "https://api.anthropic.com",
+    fallbackModel: "claude-opus-4-8",
+    factory: byokAnthropic,
+  },
+};
+const DEFAULT_PROVIDER = "fireworks";
+
+// Per-provider disclosure texts — literal strings so the build-test static scan
+// can verify BOTH are present (the test lowercases the source and looks for the
+// provider name). Each matches the dynamic disclosure renderKeyPrompt builds from
+// PROVIDERS[id].label so the disclosure is never stale.
+const PROVIDER_DISCLOSURES = {
+  fireworks: "Your Fireworks API key is stored only in this tab (this browser " +
+    "tab's sessionStorage) and sent only to Fireworks to fetch feedback — never " +
+    "to this site's server or any third party.",
+  anthropic: "Your Anthropic API key is stored only in this tab (this browser " +
+    "tab's sessionStorage) and sent only to Anthropic to fetch feedback — never " +
+    "to this site's server or any third party.",
+};
 
 // The Anthropic tool the model answers through — the same contract the R package
 // pinned (`respond_with_feedback(is_correct, feedback_message)`); its input maps
@@ -91,22 +126,35 @@ function buildPrompt({ task, code, output, checks }) {
 
 // --- key handling (sessionStorage, tab-scoped) -----------------------------------
 
-function readKey() {
-  return window.sessionStorage.getItem(KEY_SLOT);
+function readKey(providerId) {
+  return window.sessionStorage.getItem(PROVIDERS[providerId].keySlot);
 }
 
-function storeKey(key) {
-  window.sessionStorage.setItem(KEY_SLOT, key);
+function storeKey(key, providerId) {
+  window.sessionStorage.setItem(PROVIDERS[providerId].keySlot, key);
 }
 
-// The provider base URL. Defaults to Anthropic. A `?provider=` override is the
+function readProvider() {
+  return window.sessionStorage.getItem("byok_provider") || DEFAULT_PROVIDER;
+}
+
+function storeProvider(providerId) {
+  window.sessionStorage.setItem("byok_provider", providerId);
+}
+
+// The provider base URL. Takes the selected provider id and returns the
+// provider's base URL from the PROVIDERS map. A `?provider=` override is the
 // test seam (point rodney at a local stub), but it is honored *only* when it
 // resolves to a local host — so a crafted production link
 // (`?provider=https://attacker.example`) can never redirect a real learner's key
-// off-Anthropic. This *enforces* the AC1 disclosure ("sent only to Anthropic") in
-// code rather than merely asserting it: a non-local override is ignored, and the
-// key still reaches only api.anthropic.com.
-function providerBaseUrl() {
+// off the intended provider. This *enforces* the disclosure ("sent only to
+// {provider}") in code rather than merely asserting it: a non-local override is
+// ignored, and the key still reaches only the chosen provider's base URL. The
+// `?provider=` parameter is parsed as a URL (new URL(override)) — not compared
+// against provider names — so the gate cannot be bypassed by supplying a provider
+// id in the query string (§1.5). Falls back to PROVIDERS.anthropic.baseUrl for an
+// unknown provider id (defense in depth).
+function providerBaseUrl(providerId) {
   const override = new URLSearchParams(window.location.search).get("provider");
   if (override) {
     try {
@@ -122,7 +170,9 @@ function providerBaseUrl() {
       // A malformed override is ignored — fall through to the default.
     }
   }
-  return "https://api.anthropic.com";
+  // Hard default based on selected provider, falling back to Anthropic.
+  const provider = PROVIDERS[providerId];
+  return provider ? provider.baseUrl : PROVIDERS.anthropic.baseUrl;
 }
 
 // --- model discovery (the picker source seam) ------------------------------------
@@ -342,40 +392,63 @@ function currentSubmission() {
   };
 }
 
-// Prompt the learner for a key, with the dual disclosure: stored only in this tab,
-// sent only to Anthropic. Rendered here (not baked into index.html) so the whole
-// prompt-for-key path lives in the impl, isolated from the page shell (§3.3, §4.1).
+// Prompt the learner for a provider + key, with per-provider disclosure: stored
+// only in this tab, sent only to the selected provider. The provider chooser
+// renders a `<select data-byok="provider">` with Fireworks pre-selected as the
+// default. The key is stored in the selected provider's sessionStorage slot.
+// Rendered here (not baked into index.html) so the whole prompt-for-key path
+// lives in the impl, isolated from the page shell (§3.3, §4.1).
 function renderKeyPrompt(container) {
   const form = document.createElement("form");
   form.dataset.byok = "key-prompt";
 
   const disclosure = document.createElement("p");
-  disclosure.textContent =
-    "Your Anthropic API key is stored only in this tab (this browser tab's " +
-    "sessionStorage) and sent only to Anthropic to fetch feedback — never to this " +
-    "site's server or any third party.";
+  disclosure.id = "byok-disclosure";
 
-  const label = document.createElement("label");
-  label.textContent = "Anthropic API key: ";
-  const input = document.createElement("input");
-  input.type = "password";
-  input.name = "anthropic-key";
-  input.autocomplete = "off";
-  input.placeholder = "Paste your Anthropic API key";
-  label.append(input);
+  const provLabel = document.createElement("label");
+  provLabel.textContent = "Provider: ";
+  const provSelect = document.createElement("select");
+  provSelect.dataset.byok = "provider";
+  for (const [id, provider] of Object.entries(PROVIDERS)) {
+    const option = document.createElement("option");
+    option.value = id;
+    option.textContent = provider.label;
+    if (id === DEFAULT_PROVIDER) {
+      option.selected = true;
+    }
+    provSelect.append(option);
+  }
+  provLabel.append(provSelect);
+
+  const keyLabel = document.createElement("label");
+  const keyInput = document.createElement("input");
+  keyInput.type = "password";
+  keyInput.name = "provider-key";
+  keyInput.autocomplete = "off";
+  keyLabel.append(keyInput);
+
+  function updateDisclosure() {
+    const prov = PROVIDERS[provSelect.value];
+    disclosure.textContent = PROVIDER_DISCLOSURES[provSelect.value];
+    keyInput.placeholder = "Paste your " + prov.label + " API key";
+  }
+  provSelect.addEventListener("change", updateDisclosure);
+  updateDisclosure();
 
   const save = document.createElement("button");
   save.type = "submit";
   save.textContent = "Save key & get feedback";
 
-  form.append(disclosure, label, save);
+  form.append(disclosure, provLabel, keyLabel, save);
   form.addEventListener("submit", (event) => {
     event.preventDefault();
-    const key = input.value.trim();
+    const key = keyInput.value.trim();
     if (!key) {
       return;
     }
-    storeKey(key);
+    const providerId = provSelect.value;
+    storeProvider(providerId);
+    storeKey(key, providerId);
     handleSubmit();
   });
 
@@ -467,22 +540,27 @@ function selectedModel(container) {
   return select ? select.value : MODEL;
 }
 
-// Orchestrate one submit, in three named states:
-//   no key       → prompt for one (dual disclosure);
-//   no picker yet → render the model picker from the live roster, then stop so the
-//                   learner can choose (the first submit surfaces the picker);
-//   picker shown  → build the prompt and send feedback with the *chosen* model.
+// Orchestrate one submit, in four named states:
+//   no key           → prompt for provider + key (per-provider disclosure);
+//   key + no picker  → render the model picker from the live roster, then stop so
+//                      the learner can choose (the first submit surfaces the picker);
+//   picker shown     → build the prompt and send feedback through the *chosen*
+//                      provider's backend, using the *chosen* model.
+// The provider is read from sessionStorage (set at key-prompt time), defaulting to
+// Fireworks. The key is read from the selected provider's slot. The backend is
+// constructed from PROVIDERS[id].factory to enforce the dead-chooser guard.
 async function handleSubmit() {
   const container = feedbackContainer();
   if (!container) {
     return;
   }
-  const apiKey = readKey();
+  const providerId = readProvider();
+  const apiKey = readKey(providerId);
   if (!apiKey) {
     renderKeyPrompt(container);
     return;
   }
-  const baseUrl = providerBaseUrl();
+  const baseUrl = providerBaseUrl(providerId);
   if (!modelPickerPresent(container)) {
     // No try/catch twin of the /v1/messages branch below, by design: renderModelPicker
     // cannot throw. listModels swallows every fetch/parse failure into the fallback
@@ -496,7 +574,7 @@ async function handleSubmit() {
   const model = selectedModel(container);
   const submission = currentSubmission();
   const prompt = buildPrompt(submission);
-  const backend = byokAnthropic({ baseUrl, apiKey });
+  const backend = PROVIDERS[providerId].factory({ baseUrl, apiKey });
   renderPending(container);
   try {
     renderVerdict(container, await backend.getFeedback(prompt, model));

--- a/docs/adr/0009-dynamic-model-discovery-browser-byok.md
+++ b/docs/adr/0009-dynamic-model-discovery-browser-byok.md
@@ -19,7 +19,7 @@ key is ever baked into a shipped file.
 
 **Extended in AC2 (issue #51):** the provider-agnostic seam foreshadowed in the
 original Decision is now realized. A provider chooser precedes the model picker,
-the PROViDERS map drives per-provider key slots / base URLs / fallback models /
+the PROVIDERS map drives per-provider key slots / base URLs / fallback models /
 factories, and Fireworks is the pre-selected default.
 
 ## Options
@@ -100,10 +100,11 @@ has no rig and no server, and the host-gate is its key-exfil defense.
   (`fireworks_api_key`, `anthropic_api_key`), so a key stored for one provider
   is never leaked to the other. The selected provider is stored separately
   (`byok_provider`).
-- **Dead-chooser guard (AC2).** The build test asserts BOTH `byokAnthropic(`
-  and `byokFireworks(` appear in `handleSubmit`'s conditional routing — the
-  chooser is not decorative. A regression that hardcodes one backend would
-  fail the test.
+- **Dead-chooser guard (AC2).** The build test asserts
+  `PROVIDERS[providerId].factory` appears in `handleSubmit` — the chooser is
+  not decorative, and the routing mechanism is pinned at the seam. A regression
+  that hardcodes a specific backend (bypassing the PROVIDERS map) fails the
+  test.
 - **Negative scan extended (AC2).** The `fw_` key prefix is scanned across all
   emitted files (symmetric to the existing `sk-ant` scan), ensuring no
   Fireworks key literal is ever baked into a shipped file.

--- a/docs/adr/0009-dynamic-model-discovery-browser-byok.md
+++ b/docs/adr/0009-dynamic-model-discovery-browser-byok.md
@@ -1,7 +1,7 @@
 # ADR-0009: Dynamic model discovery for browser BYOK feedback
 
-- Status: Accepted
-- Date: 2026-06-09
+- Status: Extended
+- Date: 2026-06-09 (extended 2026-06-23 with multi-provider chooser)
 
 ## Context
 
@@ -16,6 +16,11 @@ the list can't be fetched. This must preserve the existing security posture: the
 key is sent only to a host that passes the `providerBaseUrl()` localhost-only,
 credential-rejecting gate (ADR-0006's browser consequence), and no model list or
 key is ever baked into a shipped file.
+
+**Extended in AC2 (issue #51):** the provider-agnostic seam foreshadowed in the
+original Decision is now realized. A provider chooser precedes the model picker,
+the PROViDERS map drives per-provider key slots / base URLs / fallback models /
+factories, and Fireworks is the pre-selected default.
 
 ## Options
 
@@ -71,3 +76,34 @@ has no rig and no server, and the host-gate is its key-exfil defense.
   render the picker eagerly on key entry.
 - Sets up the provider-agnostic picker seam Slices 2–3 (Fireworks provider +
   serverless filtering) plug into.
+- **Extended in AC2 (issue #51): multi-provider architecture with chooser.**
+  The single-provider model picker is preceded by a provider chooser: a
+  `<select data-byok="provider">` with Fireworks pre-selected as the default
+  and Anthropic as the alternative. A closed-set `PROVIDERS` map carries each
+  provider's key slot (`fireworks_api_key` / `anthropic_api_key`), base URL
+  (`https://api.fireworks.ai/inference/v1` / `https://api.anthropic.com`),
+  fallback model, and FeedbackBackend factory (`byokFireworks` / `byokAnthropic`).
+  Submit is now four-phase: no key → key prompt with chooser; key + no picker
+  → model picker; picker shown → submit through `PROVIDERS[id].factory`.
+- **Host-gate extension (AC2).** `providerBaseUrl()` gains a `providerId`
+  parameter and returns the selected provider's base URL as its hard default.
+  The `?provider=` override remains a URL test-seam parsed via `new URL()` — it
+  is NEVER compared against provider names, so the localhost-only, credential-
+  rejecting gate (unchanged) cannot be bypassed by supplying a provider id in
+  the query string. This preserves the security invariant: a crafted production
+  link cannot redirect the key off the intended provider.
+- **Per-provider disclosure (AC2).** The key prompt renders a disclosure text
+  matching the selected provider — "sent only to Fireworks" / "sent only to
+  Anthropic" — so the disclosure is never a stale lie. Both texts are literal
+  strings in the source (scanned by the build test).
+- **Key-slot isolation (AC2).** Each provider has its own `sessionStorage` slot
+  (`fireworks_api_key`, `anthropic_api_key`), so a key stored for one provider
+  is never leaked to the other. The selected provider is stored separately
+  (`byok_provider`).
+- **Dead-chooser guard (AC2).** The build test asserts BOTH `byokAnthropic(`
+  and `byokFireworks(` appear in `handleSubmit`'s conditional routing — the
+  chooser is not decorative. A regression that hardcodes one backend would
+  fail the test.
+- **Negative scan extended (AC2).** The `fw_` key prefix is scanned across all
+  emitted files (symmetric to the existing `sk-ant` scan), ensuring no
+  Fireworks key literal is ever baked into a shipped file.


### PR DESCRIPTION
## Summary
- Replace single KEY_SLOT with a closed-set PROVIDERS map carrying keySlot, baseUrl, fallbackModel, and factory for both fireworks and anthropic
- Add provider chooser `<select data-byok="provider">` with Fireworks pre-selected as the default
- Make handleSubmit a 4-phase orchestrator routing through PROVIDERS[id].factory (dead-chooser guard)
- Add per-provider disclosure, key-slot isolation, and extend the host-gate to support both providers while preserving the security invariant
- Add `fw_` negative scan across all emitted files (symmetric to existing `sk-ant` scan)
- Update ADR-0009 with multi-provider architecture

## Issue
Closes #51

## ACs implemented
- [x] Provider chooser `<select data-byok="provider">` with Fireworks default
- [x] PROVIDERS map with fireworks and anthropic entries
- [x] handleSubmit constructs both byokAnthropic( and byokFireworks( conditionally
- [x] fireworks_api_key and anthropic_api_key as distinct slots
- [x] providerBaseUrl(providerId) returns Fireworks URL for Fireworks selection
- [x] Host-gate tokens all persist (localhost, 127.0.0.1, credential rejection)
- [x] ?provider= override still parsed via new URL() — no provider-name bypass
- [x] Per-provider disclosure: both "sent only to fireworks" and "sent only to anthropic"
- [x] byokAnthropic preserved
- [x] Negative fw_ prefix scan across all emitted files
- [x] feedback.js byte-identical across targets (existing pyodide test stays green)
- [x] ADR-0009 updated

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested (dead chooser, stale disclosure, fw_ scan)
- [x] Verification medium satisfied (code — all tests pass)
- [x] Design intent respected
- [x] No scope creep

## Security notes
- providerBaseUrl(providerId) preserves the localhost-only, credential-rejecting host-gate — the ?provider= override is still parsed ONLY as a URL via new URL(), never compared against provider names, so no gate bypass is possible
- Per-provider key slots prevent cross-provider key leakage
- Both fw_ and sk-ant key prefixes are scanned across all emitted files

## Test plan
- [x] All unit + integration tests pass (155 tests)
- [x] cargo fmt --check passes
- [x] cargo clippy --workspace passes
- [x] ADR updated