### PR TITLE
[feat] Make model discovery provider-aware for Fireworks

### DIFF
--- a/crates/cli/tests/build.rs
+++ b/crates/cli/tests/build.rs
@@ -370,8 +370,8 @@ fn build_webr_ships_the_byok_anthropic_feedback_seam() {
     for token in [
         "parseModels(",                   // §2.2 pure model-list extraction
         "listModels(",                    // §2.2 effectful fetch wrapping parseModels
-        "${baseUrl}/v1/models",           // AC4 §3.4 models URL derives from providerBaseUrl()
-        r#"createElement("select")"#,     // AC1 the picker `<select>` is built dynamically
+        "${baseUrl}${modelsPath}", // AC4 §3.4 models URL derives from providerBaseUrl() via variable
+        r#"createElement("select")"#, // AC1 the picker `<select>` is built dynamically
         "feedbackRequest(prompt, model)", // AC2 the model is an explicit request argument
     ] {
         assert!(
@@ -430,6 +430,34 @@ fn build_webr_ships_the_byok_anthropic_feedback_seam() {
         feedback.contains("listModels({ baseUrl, apiKey, provider")
             || feedback.contains("listModels({ baseUrl, apiKey, provider,"),
         "listModels must receive the provider discriminator; feedback={feedback}"
+    );
+
+    // Issue #52 sneaky-pass 1 guard: handleSubmit must thread providerId into
+    // renderModelPicker — dropping `provider: providerId` from the call site
+    // (line ~586) passes every other assertion (listModels and renderModelPicker
+    // still reference `provider` as a parameter) but at runtime `source.provider`
+    // is undefined → Anthropic fallback → Fireworks key sent as x-api-key → 401
+    // → empty roster → claude-opus-4-8 regardless of provider.
+    assert!(
+        feedback.contains("provider: providerId"),
+        "handleSubmit must thread providerId into renderModelPicker (sneaky-pass 1 guard); \
+         feedback={feedback}"
+    );
+
+    // Issue #52 sneaky-pass 3 guard: modelRoster must take a provider parameter
+    // AND the call site must thread it — reverting to `modelRoster(models)`
+    // silently returns [MODEL] for the Fireworks picker, hiding all
+    // non-Anthropic models even when the function definition still nominally
+    // names the parameter.
+    assert!(
+        feedback.contains("modelRoster(models, provider)"),
+        "modelRoster must take a provider parameter (sneaky-pass 3 guard); \
+         feedback={feedback}"
+    );
+    assert!(
+        feedback.contains("modelRoster(await listModels"),
+        "modelRoster call site must thread provider from listModels result \
+         (sneaky-pass 3 call-site guard); feedback={feedback}"
     );
 
     // §1.2/§3.2: the JS request mirrors the Rust contract. The prompt delimiters are

--- a/crates/cli/tests/build.rs
+++ b/crates/cli/tests/build.rs
@@ -368,7 +368,6 @@ fn build_webr_ships_the_byok_anthropic_feedback_seam() {
     // the regression gate — the live behavior (populate, default, fallback,
     // override-routing) is the rodney arm in the PR evidence.
     for token in [
-        "parseModels(",                   // §2.2 pure model-list extraction
         "listModels(",                    // §2.2 effectful fetch wrapping parseModels
         "${baseUrl}${modelsPath}", // AC4 §3.4 models URL derives from providerBaseUrl() via variable
         r#"createElement("select")"#, // AC1 the picker `<select>` is built dynamically
@@ -379,6 +378,14 @@ fn build_webr_ships_the_byok_anthropic_feedback_seam() {
             "feedback.js must ship the live model-picker seam token `{token}`; feedback={feedback}"
         );
     }
+    // AC5: parseModels must stay provider-agnostic — the function signature takes
+    // only `json`, not a `provider` parameter, so it returns the same sorted model
+    // list regardless of provider (filtering is the caller's book).
+    assert!(
+        feedback.contains("function parseModels(json) {"),
+        "parseModels must stay provider-agnostic (AC5); feedback={feedback}"
+    );
+
     // AC1/AC3: the fallback literal stays the named default the empty- or failed-
     // query branch resolves to (also pinned alive by the no-`sk-ant` scan).
     assert!(
@@ -470,6 +477,20 @@ fn build_webr_ships_the_byok_anthropic_feedback_seam() {
     assert!(
         feedback.contains("}), provider)"),
         "modelRoster call site must thread provider as the 2nd arg (sneaky-pass 3); feedback={feedback}"
+    );
+
+    // Terminal sneaky-pass-3 guard: the provider-conditional fallback ternary
+    // must appear in BOTH modelRoster (line ~197) and renderModelPicker (line
+    // ~522) — a regression that removes it from either function while leaving
+    // the other copy intact would pass a `feedback.contains(...)` vacuously.
+    // Count >= 2 pins the actual fallback *behavior* (not just seams).
+    let fallback_ternary = "provider === \"fireworks\" ? FIREWORKS_MODEL : MODEL";
+    let ternary_count = feedback.matches(fallback_ternary).count();
+    assert!(
+        ternary_count >= 2,
+        "the provider-conditional fallback ternary must appear in BOTH modelRoster and \
+         renderModelPicker (count {}); feedback={feedback}",
+        ternary_count
     );
 
     // §1.2/§3.2: the JS request mirrors the Rust contract. The prompt delimiters are

--- a/crates/cli/tests/build.rs
+++ b/crates/cli/tests/build.rs
@@ -423,6 +423,14 @@ fn build_webr_ships_the_byok_anthropic_feedback_seam() {
         !feedback.contains("/v1/v1/models"),
         "feedback.js must NOT contain the doubled /v1/v1/models path; feedback={feedback}"
     );
+    // Positive pin: modelsPath is provider-conditional — a regression to a
+    // hardcoded "/v1/models" would pass the negative /v1/v1 check while breaking
+    // Fireworks at runtime (Fireworks base URL already carries /v1).
+    assert!(
+        feedback.contains("provider === \"fireworks\" ? \"/models\" : \"/v1/models\""),
+        "modelsPath must be provider-conditional (Fireworks /models, Anthropic /v1/models); \
+         feedback={feedback}"
+    );
 
     // Issue #52: the provider discriminator threads end-to-end through the model
     // picker — listModels receives a `provider` field (predicate 4).
@@ -458,6 +466,10 @@ fn build_webr_ships_the_byok_anthropic_feedback_seam() {
         feedback.contains("modelRoster(await listModels"),
         "modelRoster call site must thread provider from listModels result \
          (sneaky-pass 3 call-site guard); feedback={feedback}"
+    );
+    assert!(
+        feedback.contains("}), provider)"),
+        "modelRoster call site must thread provider as the 2nd arg (sneaky-pass 3); feedback={feedback}"
     );
 
     // §1.2/§3.2: the JS request mirrors the Rust contract. The prompt delimiters are

--- a/crates/cli/tests/build.rs
+++ b/crates/cli/tests/build.rs
@@ -394,6 +394,44 @@ fn build_webr_ships_the_byok_anthropic_feedback_seam() {
         "feedbackRequest must take the model as an argument, not close over MODEL"
     );
 
+    // Issue #52: the model picker is provider-aware — both auth shapes coexist
+    // in the file; selection is provider-conditional, not global (predicate 1).
+    assert!(
+        feedback.contains("Bearer"),
+        "feedback.js must carry Bearer auth (Fireworks) alongside x-api-key (Anthropic); feedback={feedback}"
+    );
+    assert!(
+        feedback.contains("x-api-key"),
+        "feedback.js must retain x-api-key auth (Anthropic) alongside Bearer (Fireworks); feedback={feedback}"
+    );
+
+    // Issue #52: fallback model is provider-conditional — both Fireworks and
+    // Anthropic fallbacks coexist (predicate 2).
+    assert!(
+        feedback.contains("accounts/fireworks/models/deepseek-v4-flash"),
+        "feedback.js must carry the Fireworks fallback model alongside claude-opus-4-8; feedback={feedback}"
+    );
+    assert!(
+        feedback.contains("claude-opus-4-8"),
+        "feedback.js must retain claude-opus-4-8 as the Anthropic fallback model; feedback={feedback}"
+    );
+
+    // Issue #52: models URL is provider-aware — the doubled /v1/v1 path must not
+    // appear (predicate 3: Fireworks base URL already carries /v1, so /v1/models
+    // would double).
+    assert!(
+        !feedback.contains("/v1/v1/models"),
+        "feedback.js must NOT contain the doubled /v1/v1/models path; feedback={feedback}"
+    );
+
+    // Issue #52: the provider discriminator threads end-to-end through the model
+    // picker — listModels receives a `provider` field (predicate 4).
+    assert!(
+        feedback.contains("listModels({ baseUrl, apiKey, provider")
+            || feedback.contains("listModels({ baseUrl, apiKey, provider,"),
+        "listModels must receive the provider discriminator; feedback={feedback}"
+    );
+
     // §1.2/§3.2: the JS request mirrors the Rust contract. The prompt delimiters are
     // pinned to the *same exported constants* `build_prompt` emits, so the
     // learner-side prompt structure cannot drift from the author-side one — and the
@@ -609,6 +647,17 @@ fn build_webr_ships_the_multi_provider_feedback_seam() {
     assert!(
         feedback.contains(r#""Anthropic""#),
         "feedback.js must reference the Anthropic provider label; feedback={feedback}"
+    );
+    // Opportunistic (#51 review): pin the full assignment so a default-swap
+    // regression that changes the constant without updating the wiring is caught.
+    assert!(
+        feedback.contains(r#"DEFAULT_PROVIDER = "fireworks""#),
+        "feedback.js must set DEFAULT_PROVIDER to fireworks; feedback={feedback}"
+    );
+    // The option.selected wiring makes the default effective at render time.
+    assert!(
+        feedback.contains("id === DEFAULT_PROVIDER") && feedback.contains("option.selected = true"),
+        "feedback.js must wire id === DEFAULT_PROVIDER to option.selected; feedback={feedback}"
     );
 
     // AC2: a closed-set PROVIDERS map carries both fireworks and anthropic with

--- a/crates/core/assets/shared/feedback.js
+++ b/crates/core/assets/shared/feedback.js
@@ -548,11 +548,11 @@ function modelPickerPresent(container) {
 }
 
 // The model the learner has chosen — read straight from the picker at submit time
-// (no module state), falling back to the named default if the select is somehow
-// absent so the request always carries a model.
-function selectedModel(container) {
+// (no module state), falling back to the provider-specific fallback if the select
+// is somehow absent so the request always carries a model the provider can serve.
+function selectedModel(container, providerId) {
   const select = container.querySelector('[data-byok="model"]');
-  return select ? select.value : MODEL;
+  return select ? select.value : PROVIDERS[providerId].fallbackModel;
 }
 
 // Orchestrate one submit, in four named states:
@@ -586,7 +586,7 @@ async function handleSubmit() {
     await renderModelPicker(container, { baseUrl, apiKey, provider: providerId });
     return;
   }
-  const model = selectedModel(container);
+  const model = selectedModel(container, providerId);
   const submission = currentSubmission();
   const prompt = buildPrompt(submission);
   const backend = PROVIDERS[providerId].factory({ baseUrl, apiKey });

--- a/crates/core/assets/shared/feedback.js
+++ b/crates/core/assets/shared/feedback.js
@@ -136,7 +136,7 @@ function storeKey(key, providerId) {
 
 function readProvider() {
   const stored = window.sessionStorage.getItem("byok_provider");
-  return stored && stored in PROVIDERS ? stored : DEFAULT_PROVIDER;
+  return stored && Object.hasOwn(PROVIDERS, stored) ? stored : DEFAULT_PROVIDER;
 }
 
 function storeProvider(providerId) {
@@ -178,9 +178,11 @@ function providerBaseUrl(providerId) {
 
 // --- model discovery (the picker source seam) ------------------------------------
 
-// Pure: extract the model-id list from an Anthropic `/v1/models` response. Tolerates
-// a missing or empty `data` array (→ []) and ignores non-string ids; the caller
-// applies the fallback roster, so this never has to invent a default.
+// Pure: extract the model-id list from a `/v1/models` (or `/models`) response.
+// Both Anthropic and Fireworks return `{data:[{id}]}` — the shared shape is
+// extracted once, provider-agnostic (§1.1, §2.2). Tolerates a missing or empty
+// `data` array (→ []) and ignores non-string ids; the caller applies the
+// fallback roster, so this never has to invent a default.
 function parseModels(json) {
   const data = (json && json.data) || [];
   return data
@@ -189,27 +191,33 @@ function parseModels(json) {
 }
 
 // Pure: the roster the picker renders — the live list when it has any models, else a
-// roster of just the named fallback. Keeps "never a zero-option dead select" as one
-// named policy rather than a guard scattered across the picker.
-function modelRoster(models) {
-  return models.length ? models : [MODEL];
+// roster of just the provider-specific fallback. Keeps "never a zero-option dead
+// select" as one named policy rather than a guard scattered across the picker.
+function modelRoster(models, provider) {
+  const fallback = provider === "fireworks" ? FIREWORKS_MODEL : MODEL;
+  return models.length ? models : [fallback];
 }
 
 // Effectful: fetch the models this key can reach, through the SAME host-gated base
 // URL as messages — a non-local `?provider=` override is ignored here too, so the
 // picker opens no new key-exfil vector. Returns [] on any failure (non-OK, network,
 // malformed JSON); the pure `modelRoster` turns [] into a usable roster, so a models
-// outage is never a dead end. The key rides `x-api-key` with the direct-browser-
-// access opt-in, exactly as the messages call.
-async function listModels({ baseUrl, apiKey }) {
+// outage is never a dead end. Auth headers and models path switch on `provider`:
+//   - Anthropic: `x-api-key` + `anthropic-version` + `anthropic-dangerous-direct-
+//     browser-access`, path `${baseUrl}/v1/models` (base has no /v1).
+//   - Fireworks: `Authorization: Bearer`, path `${baseUrl}/models` (base already
+//     carries /v1 — concatenating /v1/models would double the path → 404).
+async function listModels({ baseUrl, apiKey, provider }) {
   try {
-    const response = await fetch(`${baseUrl}/v1/models`, {
-      headers: {
-        "x-api-key": apiKey,
-        "anthropic-version": "2023-06-01",
-        "anthropic-dangerous-direct-browser-access": "true",
-      },
-    });
+    const headers = provider === "fireworks"
+      ? { "Authorization": "Bearer " + apiKey }
+      : {
+          "x-api-key": apiKey,
+          "anthropic-version": "2023-06-01",
+          "anthropic-dangerous-direct-browser-access": "true",
+        };
+    const modelsPath = provider === "fireworks" ? "/models" : "/v1/models";
+    const response = await fetch(`${baseUrl}${modelsPath}`, { headers });
     if (!response.ok) {
       return [];
     }
@@ -494,7 +502,9 @@ function renderError(container, error) {
 // when present. The select carries a distinct `data-byok="model"` marker and lives
 // under `#feedback`, so the `#feedback select` test predicate pins it without prefix-
 // colliding with the page-level `#lesson-select` (§1.5). Effectful only in that it
-// awaits `listModels`; the roster and the default choice are pure.
+// awaits `listModels`; the roster and the default choice are pure. The `source`
+// object carries a `provider` field that flows into `listModels` (auth + path) and
+// `modelRoster` (fallback model).
 async function renderModelPicker(container, source) {
   // A loading note while the live list is in flight, so a slow models query doesn't
   // read as a dead click; the roster replaces it the moment it resolves.
@@ -503,11 +513,13 @@ async function renderModelPicker(container, source) {
   loading.textContent = "Loading models…";
   container.replaceChildren(loading);
 
-  const roster = modelRoster(await listModels(source));
+  const { baseUrl, apiKey, provider } = source;
+  const roster = modelRoster(await listModels({ baseUrl, apiKey, provider }), provider);
 
   const picker = document.createElement("div");
   picker.dataset.byok = "model-picker";
 
+  const fallbackModel = provider === "fireworks" ? FIREWORKS_MODEL : MODEL;
   const label = document.createElement("label");
   label.textContent = "Feedback model: ";
   const select = document.createElement("select");
@@ -520,7 +532,7 @@ async function renderModelPicker(container, source) {
   }
   // Default to the named fallback when the roster carries it, else the first model —
   // never an empty value, so submit always has a model to send.
-  select.value = roster.includes(MODEL) ? MODEL : roster[0];
+  select.value = roster.includes(fallbackModel) ? fallbackModel : roster[0];
   label.append(select);
 
   const hint = document.createElement("p");
@@ -571,7 +583,7 @@ async function handleSubmit() {
     // construction — there is no reachable error to surface, so the loading note is
     // always replaced. If a future provider adds throwing logic *outside* listModels,
     // add the renderError guard here then.
-    await renderModelPicker(container, { baseUrl, apiKey });
+    await renderModelPicker(container, { baseUrl, apiKey, provider: providerId });
     return;
   }
   const model = selectedModel(container);


### PR DESCRIPTION
## Summary
Makes the model picker work for Fireworks by threading the provider discriminator through `listModels`, `modelRoster`, and `renderModelPicker`. Previously `listModels` hardcoded Anthropic auth headers and the `/v1/models` path — Fireworks uses Bearer auth and its base URL already carries `/v1`, so `/v1/models` would double to `/v1/v1/models` → 404 → empty roster → fallback to Anthropic-only model that Fireworks can't serve.

## Issue
Closes #52

## ACs implemented
- [x] `listModels({ baseUrl, apiKey, provider })` switches auth + path on provider
- [x] `modelRoster(models, provider)` returns provider-conditional fallback
- [x] Provider discriminator threads through `renderModelPicker` → `handleSubmit`
- [x] `parseModels` stays provider-agnostic with contract comment
- [x] Cross-target byte-identity preserved (`build_pyodide_ships_the_same_shared_feedback_seam` passes)
- [x] No `/v1/v1/models` in shipped output
- [x] Both `Bearer` and `x-api-key` auth shapes coexist
- [x] Both `accounts/fireworks/models/deepseek-v4-flash` and `claude-opus-4-8` fallbacks coexist
- [x] Existing Anthropic tokens all untouched

## Opportunistic bundling (from #51 review)
- [x] `DEFAULT_PROVIDER = "fireworks"` assignment pinned + `id === DEFAULT_PROVIDER → option.selected` wiring asserted
- [x] `readProvider` uses `Object.hasOwn` (prototype-pollution fix)

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested (no /v1/v1/models, discriminator required)
- [x] Verification medium satisfied (code — all build tests pass)
- [x] Design intent respected
- [x] No scope creep

## Test plan
- [x] `cargo test -p blendtutor-cli --test build` — all 10 build tests pass
- [x] `cargo test -p blendtutor-core` — all 102 unit tests pass
- [x] `cargo test -p blendtutor-cli` — all 43 integration tests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace` — clean