### PR TITLE
feat(site): vendor CodeMirror 6 bundle as committed static asset

### DIFF
--- a/crates/core/assets/shared/codemirror.js
+++ b/crates/core/assets/shared/codemirror.js
@@ -1,0 +1,18955 @@
+// node_modules/@marijn/find-cluster-break/src/index.js
+var rangeFrom = [];
+var rangeTo = [];
+(() => {
+  let numbers = "lc,34,7n,7,7b,19,,,,2,,2,,,20,b,1c,l,g,,2t,7,2,6,2,2,,4,z,,u,r,2j,b,1m,9,9,,o,4,,9,,3,,5,17,3,3b,f,,w,1j,,,,4,8,4,,3,7,a,2,t,,1m,,,,2,4,8,,9,,a,2,q,,2,2,1l,,4,2,4,2,2,3,3,,u,2,3,,b,2,1l,,4,5,,2,4,,k,2,m,6,,,1m,,,2,,4,8,,7,3,a,2,u,,1n,,,,c,,9,,14,,3,,1l,3,5,3,,4,7,2,b,2,t,,1m,,2,,2,,3,,5,2,7,2,b,2,s,2,1l,2,,,2,4,8,,9,,a,2,t,,20,,4,,2,3,,,8,,29,,2,7,c,8,2q,,2,9,b,6,22,2,r,,,,,,1j,e,,5,,2,5,b,,10,9,,2u,4,,6,,2,2,2,p,2,4,3,g,4,d,,2,2,6,,f,,jj,3,qa,3,t,3,t,2,u,2,1s,2,,7,8,,2,b,9,,19,3,3b,2,y,,3a,3,4,2,9,,6,3,63,2,2,,1m,,,7,,,,,2,8,6,a,2,,1c,h,1r,4,1c,7,,,5,,14,9,c,2,w,4,2,2,,3,1k,,,2,3,,,3,1m,8,2,2,48,3,,d,,7,4,,6,,3,2,5i,1m,,5,ek,,5f,x,2da,3,3x,,2o,w,fe,6,2x,2,n9w,4,,a,w,2,28,2,7k,,3,,4,,p,2,5,,47,2,q,i,d,,12,8,p,b,1a,3,1c,,2,4,2,2,13,,1v,6,2,2,2,2,c,,8,,1b,,1f,,,3,2,2,5,2,,,16,2,8,,6m,,2,,4,,fn4,,kh,g,g,g,a6,2,gt,,6a,,45,5,1ae,3,,2,5,4,14,3,4,,4l,2,fx,4,ar,2,49,b,4w,,1i,f,1k,3,1d,4,2,2,1x,3,10,5,,8,1q,,c,2,1g,9,a,4,2,,2n,3,2,,,2,6,,4g,,3,8,l,2,1l,2,,,,,m,,e,7,3,5,5f,8,2,3,,,n,,29,,2,6,,,2,,,2,,2,6j,,2,4,6,2,,2,r,2,2d,8,2,,,2,2y,,,,2,6,,,2t,3,2,4,,5,77,9,,2,6t,,a,2,,,4,,40,4,2,2,4,,w,a,14,6,2,4,8,,9,6,2,3,1a,d,,2,ba,7,,6,,,2a,m,2,7,,2,,2,3e,6,3,,,2,,7,,,20,2,3,,,,9n,2,f0b,5,1n,7,t4,,1r,4,29,,f5k,2,43q,,,3,4,5,8,8,2,7,u,4,44,3,1iz,1j,4,1e,8,,e,,m,5,,f,11s,7,,h,2,7,,2,,5,79,7,c5,4,15s,7,31,7,240,5,gx7k,2o,3k,6o".split(",").map((s) => s ? parseInt(s, 36) : 1);
+  for (let i2 = 0, n = 0; i2 < numbers.length; i2++)
+    (i2 % 2 ? rangeTo : rangeFrom).push(n = n + numbers[i2]);
+})();
+function isExtendingChar(code2) {
+  if (code2 < 768) return false;
+  for (let from = 0, to = rangeFrom.length; ; ) {
+    let mid = from + to >> 1;
+    if (code2 < rangeFrom[mid]) to = mid;
+    else if (code2 >= rangeTo[mid]) from = mid + 1;
+    else return true;
+    if (from == to) return false;
+  }
+}
+function isRegionalIndicator(code2) {
+  return code2 >= 127462 && code2 <= 127487;
+}
+var ZWJ = 8205;
+function findClusterBreak(str, pos, forward = true, includeExtending = true) {
+  return (forward ? nextClusterBreak : prevClusterBreak)(str, pos, includeExtending);
+}
+function nextClusterBreak(str, pos, includeExtending) {
+  if (pos == str.length) return pos;
+  if (pos && surrogateLow(str.charCodeAt(pos)) && surrogateHigh(str.charCodeAt(pos - 1))) pos--;
+  let prev = codePointAt(str, pos);
+  pos += codePointSize(prev);
+  while (pos < str.length) {
+    let next = codePointAt(str, pos);
+    if (prev == ZWJ || next == ZWJ || includeExtending && isExtendingChar(next)) {
+      pos += codePointSize(next);
+      prev = next;
+    } else if (isRegionalIndicator(next)) {
+      let countBefore = 0, i2 = pos - 2;
+      while (i2 >= 0 && isRegionalIndicator(codePointAt(str, i2))) {
+        countBefore++;
+        i2 -= 2;
+      }
+      if (countBefore % 2 == 0) break;
+      else pos += 2;
+    } else {
+      break;
+    }
+  }
+  return pos;
+}
+function prevClusterBreak(str, pos, includeExtending) {
+  while (pos > 0) {
+    let found = nextClusterBreak(str, pos - 2, includeExtending);
+    if (found < pos) return found;
+    pos--;
+  }
+  return 0;
+}
+function codePointAt(str, pos) {
+  let code0 = str.charCodeAt(pos);
+  if (!surrogateHigh(code0) || pos + 1 == str.length) return code0;
+  let code1 = str.charCodeAt(pos + 1);
+  if (!surrogateLow(code1)) return code0;
+  return (code0 - 55296 << 10) + (code1 - 56320) + 65536;
+}
+function surrogateLow(ch) {
+  return ch >= 56320 && ch < 57344;
+}
+function surrogateHigh(ch) {
+  return ch >= 55296 && ch < 56320;
+}
+function codePointSize(code2) {
+  return code2 < 65536 ? 1 : 2;
+}
+
+// node_modules/@codemirror/state/dist/index.js
+var Text = class _Text {
+  /**
+  Get the line description around the given position.
+  */
+  lineAt(pos) {
+    if (pos < 0 || pos > this.length)
+      throw new RangeError(`Invalid position ${pos} in document of length ${this.length}`);
+    return this.lineInner(pos, false, 1, 0);
+  }
+  /**
+  Get the description for the given (1-based) line number.
+  */
+  line(n) {
+    if (n < 1 || n > this.lines)
+      throw new RangeError(`Invalid line number ${n} in ${this.lines}-line document`);
+    return this.lineInner(n, true, 1, 0);
+  }
+  /**
+  Replace a range of the text with the given content.
+  */
+  replace(from, to, text) {
+    [from, to] = clip(this, from, to);
+    let parts = [];
+    this.decompose(
+      0,
+      from,
+      parts,
+      2
+      /* Open.To */
+    );
+    if (text.length)
+      text.decompose(
+        0,
+        text.length,
+        parts,
+        1 | 2
+        /* Open.To */
+      );
+    this.decompose(
+      to,
+      this.length,
+      parts,
+      1
+      /* Open.From */
+    );
+    return TextNode.from(parts, this.length - (to - from) + text.length);
+  }
+  /**
+  Append another document to this one.
+  */
+  append(other) {
+    return this.replace(this.length, this.length, other);
+  }
+  /**
+  Retrieve the text between the given points.
+  */
+  slice(from, to = this.length) {
+    [from, to] = clip(this, from, to);
+    let parts = [];
+    this.decompose(from, to, parts, 0);
+    return TextNode.from(parts, to - from);
+  }
+  /**
+  Test whether this text is equal to another instance.
+  */
+  eq(other) {
+    if (other == this)
+      return true;
+    if (other.length != this.length || other.lines != this.lines)
+      return false;
+    let start = this.scanIdentical(other, 1), end = this.length - this.scanIdentical(other, -1);
+    let a = new RawTextCursor(this), b = new RawTextCursor(other);
+    for (let skip = start, pos = start; ; ) {
+      a.next(skip);
+      b.next(skip);
+      skip = 0;
+      if (a.lineBreak != b.lineBreak || a.done != b.done || a.value != b.value)
+        return false;
+      pos += a.value.length;
+      if (a.done || pos >= end)
+        return true;
+    }
+  }
+  /**
+  Iterate over the text. When `dir` is `-1`, iteration happens
+  from end to start. This will return lines and the breaks between
+  them as separate strings.
+  */
+  iter(dir = 1) {
+    return new RawTextCursor(this, dir);
+  }
+  /**
+  Iterate over a range of the text. When `from` > `to`, the
+  iterator will run in reverse.
+  */
+  iterRange(from, to = this.length) {
+    return new PartialTextCursor(this, from, to);
+  }
+  /**
+  Return a cursor that iterates over the given range of lines,
+  _without_ returning the line breaks between, and yielding empty
+  strings for empty lines.
+  
+  When `from` and `to` are given, they should be 1-based line numbers.
+  */
+  iterLines(from, to) {
+    let inner;
+    if (from == null) {
+      inner = this.iter();
+    } else {
+      if (to == null)
+        to = this.lines + 1;
+      let start = this.line(from).from;
+      inner = this.iterRange(start, Math.max(start, to == this.lines + 1 ? this.length : to <= 1 ? 0 : this.line(to - 1).to));
+    }
+    return new LineCursor(inner);
+  }
+  /**
+  Return the document as a string, using newline characters to
+  separate lines.
+  */
+  toString() {
+    return this.sliceString(0);
+  }
+  /**
+  Convert the document to an array of lines (which can be
+  deserialized again via [`Text.of`](https://codemirror.net/6/docs/ref/#state.Text^of)).
+  */
+  toJSON() {
+    let lines = [];
+    this.flatten(lines);
+    return lines;
+  }
+  /**
+  @internal
+  */
+  constructor() {
+  }
+  /**
+  Create a `Text` instance for the given array of lines.
+  */
+  static of(text) {
+    if (text.length == 0)
+      throw new RangeError("A document must have at least one line");
+    if (text.length == 1 && !text[0])
+      return _Text.empty;
+    return text.length <= 32 ? new TextLeaf(text) : TextNode.from(TextLeaf.split(text, []));
+  }
+};
+var TextLeaf = class _TextLeaf extends Text {
+  constructor(text, length = textLength(text)) {
+    super();
+    this.text = text;
+    this.length = length;
+  }
+  get lines() {
+    return this.text.length;
+  }
+  get children() {
+    return null;
+  }
+  lineInner(target, isLine, line, offset) {
+    for (let i2 = 0; ; i2++) {
+      let string2 = this.text[i2], end = offset + string2.length;
+      if ((isLine ? line : end) >= target)
+        return new Line(offset, end, line, string2);
+      offset = end + 1;
+      line++;
+    }
+  }
+  decompose(from, to, target, open) {
+    let text = from <= 0 && to >= this.length ? this : new _TextLeaf(sliceText(this.text, from, to), Math.min(to, this.length) - Math.max(0, from));
+    if (open & 1) {
+      let prev = target.pop();
+      let joined = appendText(text.text, prev.text.slice(), 0, text.length);
+      if (joined.length <= 32) {
+        target.push(new _TextLeaf(joined, prev.length + text.length));
+      } else {
+        let mid = joined.length >> 1;
+        target.push(new _TextLeaf(joined.slice(0, mid)), new _TextLeaf(joined.slice(mid)));
+      }
+    } else {
+      target.push(text);
+    }
+  }
+  replace(from, to, text) {
+    if (!(text instanceof _TextLeaf))
+      return super.replace(from, to, text);
+    [from, to] = clip(this, from, to);
+    let lines = appendText(this.text, appendText(text.text, sliceText(this.text, 0, from)), to);
+    let newLen = this.length + text.length - (to - from);
+    if (lines.length <= 32)
+      return new _TextLeaf(lines, newLen);
+    return TextNode.from(_TextLeaf.split(lines, []), newLen);
+  }
+  sliceString(from, to = this.length, lineSep = "\n") {
+    [from, to] = clip(this, from, to);
+    let result = "";
+    for (let pos = 0, i2 = 0; pos <= to && i2 < this.text.length; i2++) {
+      let line = this.text[i2], end = pos + line.length;
+      if (pos > from && i2)
+        result += lineSep;
+      if (from < end && to > pos)
+        result += line.slice(Math.max(0, from - pos), to - pos);
+      pos = end + 1;
+    }
+    return result;
+  }
+  flatten(target) {
+    for (let line of this.text)
+      target.push(line);
+  }
+  scanIdentical() {
+    return 0;
+  }
+  static split(text, target) {
+    let part = [], len = -1;
+    for (let line of text) {
+      part.push(line);
+      len += line.length + 1;
+      if (part.length == 32) {
+        target.push(new _TextLeaf(part, len));
+        part = [];
+        len = -1;
+      }
+    }
+    if (len > -1)
+      target.push(new _TextLeaf(part, len));
+    return target;
+  }
+};
+var TextNode = class _TextNode extends Text {
+  constructor(children, length) {
+    super();
+    this.children = children;
+    this.length = length;
+    this.lines = 0;
+    for (let child of children)
+      this.lines += child.lines;
+  }
+  lineInner(target, isLine, line, offset) {
+    for (let i2 = 0; ; i2++) {
+      let child = this.children[i2], end = offset + child.length, endLine = line + child.lines - 1;
+      if ((isLine ? endLine : end) >= target)
+        return child.lineInner(target, isLine, line, offset);
+      offset = end + 1;
+      line = endLine + 1;
+    }
+  }
+  decompose(from, to, target, open) {
+    for (let i2 = 0, pos = 0; pos <= to && i2 < this.children.length; i2++) {
+      let child = this.children[i2], end = pos + child.length;
+      if (from <= end && to >= pos) {
+        let childOpen = open & ((pos <= from ? 1 : 0) | (end >= to ? 2 : 0));
+        if (pos >= from && end <= to && !childOpen)
+          target.push(child);
+        else
+          child.decompose(from - pos, to - pos, target, childOpen);
+      }
+      pos = end + 1;
+    }
+  }
+  replace(from, to, text) {
+    [from, to] = clip(this, from, to);
+    if (text.lines < this.lines)
+      for (let i2 = 0, pos = 0; i2 < this.children.length; i2++) {
+        let child = this.children[i2], end = pos + child.length;
+        if (from >= pos && to <= end) {
+          let updated = child.replace(from - pos, to - pos, text);
+          let totalLines = this.lines - child.lines + updated.lines;
+          if (updated.lines < totalLines >> 5 - 1 && updated.lines > totalLines >> 5 + 1) {
+            let copy = this.children.slice();
+            copy[i2] = updated;
+            return new _TextNode(copy, this.length - (to - from) + text.length);
+          }
+          return super.replace(pos, end, updated);
+        }
+        pos = end + 1;
+      }
+    return super.replace(from, to, text);
+  }
+  sliceString(from, to = this.length, lineSep = "\n") {
+    [from, to] = clip(this, from, to);
+    let result = "";
+    for (let i2 = 0, pos = 0; i2 < this.children.length && pos <= to; i2++) {
+      let child = this.children[i2], end = pos + child.length;
+      if (pos > from && i2)
+        result += lineSep;
+      if (from < end && to > pos)
+        result += child.sliceString(from - pos, to - pos, lineSep);
+      pos = end + 1;
+    }
+    return result;
+  }
+  flatten(target) {
+    for (let child of this.children)
+      child.flatten(target);
+  }
+  scanIdentical(other, dir) {
+    if (!(other instanceof _TextNode))
+      return 0;
+    let length = 0;
+    let [iA, iB, eA, eB] = dir > 0 ? [0, 0, this.children.length, other.children.length] : [this.children.length - 1, other.children.length - 1, -1, -1];
+    for (; ; iA += dir, iB += dir) {
+      if (iA == eA || iB == eB)
+        return length;
+      let chA = this.children[iA], chB = other.children[iB];
+      if (chA != chB)
+        return length + chA.scanIdentical(chB, dir);
+      length += chA.length + 1;
+    }
+  }
+  static from(children, length = children.reduce((l, ch) => l + ch.length + 1, -1)) {
+    let lines = 0;
+    for (let ch of children)
+      lines += ch.lines;
+    if (lines < 32) {
+      let flat = [];
+      for (let ch of children)
+        ch.flatten(flat);
+      return new TextLeaf(flat, length);
+    }
+    let chunk = Math.max(
+      32,
+      lines >> 5
+      /* Tree.BranchShift */
+    ), maxChunk = chunk << 1, minChunk = chunk >> 1;
+    let chunked = [], currentLines = 0, currentLen = -1, currentChunk = [];
+    function add(child) {
+      let last;
+      if (child.lines > maxChunk && child instanceof _TextNode) {
+        for (let node of child.children)
+          add(node);
+      } else if (child.lines > minChunk && (currentLines > minChunk || !currentLines)) {
+        flush();
+        chunked.push(child);
+      } else if (child instanceof TextLeaf && currentLines && (last = currentChunk[currentChunk.length - 1]) instanceof TextLeaf && child.lines + last.lines <= 32) {
+        currentLines += child.lines;
+        currentLen += child.length + 1;
+        currentChunk[currentChunk.length - 1] = new TextLeaf(last.text.concat(child.text), last.length + 1 + child.length);
+      } else {
+        if (currentLines + child.lines > chunk)
+          flush();
+        currentLines += child.lines;
+        currentLen += child.length + 1;
+        currentChunk.push(child);
+      }
+    }
+    function flush() {
+      if (currentLines == 0)
+        return;
+      chunked.push(currentChunk.length == 1 ? currentChunk[0] : _TextNode.from(currentChunk, currentLen));
+      currentLen = -1;
+      currentLines = currentChunk.length = 0;
+    }
+    for (let child of children)
+      add(child);
+    flush();
+    return chunked.length == 1 ? chunked[0] : new _TextNode(chunked, length);
+  }
+};
+Text.empty = /* @__PURE__ */ new TextLeaf([""], 0);
+function textLength(text) {
+  let length = -1;
+  for (let line of text)
+    length += line.length + 1;
+  return length;
+}
+function appendText(text, target, from = 0, to = 1e9) {
+  for (let pos = 0, i2 = 0, first = true; i2 < text.length && pos <= to; i2++) {
+    let line = text[i2], end = pos + line.length;
+    if (end >= from) {
+      if (end > to)
+        line = line.slice(0, to - pos);
+      if (pos < from)
+        line = line.slice(from - pos);
+      if (first) {
+        target[target.length - 1] += line;
+        first = false;
+      } else
+        target.push(line);
+    }
+    pos = end + 1;
+  }
+  return target;
+}
+function sliceText(text, from, to) {
+  return appendText(text, [""], from, to);
+}
+var RawTextCursor = class {
+  constructor(text, dir = 1) {
+    this.dir = dir;
+    this.done = false;
+    this.lineBreak = false;
+    this.value = "";
+    this.nodes = [text];
+    this.offsets = [dir > 0 ? 1 : (text instanceof TextLeaf ? text.text.length : text.children.length) << 1];
+  }
+  nextInner(skip, dir) {
+    this.done = this.lineBreak = false;
+    for (; ; ) {
+      let last = this.nodes.length - 1;
+      let top2 = this.nodes[last], offsetValue = this.offsets[last], offset = offsetValue >> 1;
+      let size = top2 instanceof TextLeaf ? top2.text.length : top2.children.length;
+      if (offset == (dir > 0 ? size : 0)) {
+        if (last == 0) {
+          this.done = true;
+          this.value = "";
+          return this;
+        }
+        if (dir > 0)
+          this.offsets[last - 1]++;
+        this.nodes.pop();
+        this.offsets.pop();
+      } else if ((offsetValue & 1) == (dir > 0 ? 0 : 1)) {
+        this.offsets[last] += dir;
+        if (skip == 0) {
+          this.lineBreak = true;
+          this.value = "\n";
+          return this;
+        }
+        skip--;
+      } else if (top2 instanceof TextLeaf) {
+        let next = top2.text[offset + (dir < 0 ? -1 : 0)];
+        this.offsets[last] += dir;
+        if (next.length > Math.max(0, skip)) {
+          this.value = skip == 0 ? next : dir > 0 ? next.slice(skip) : next.slice(0, next.length - skip);
+          return this;
+        }
+        skip -= next.length;
+      } else {
+        let next = top2.children[offset + (dir < 0 ? -1 : 0)];
+        if (skip > next.length) {
+          skip -= next.length;
+          this.offsets[last] += dir;
+        } else {
+          if (dir < 0)
+            this.offsets[last]--;
+          this.nodes.push(next);
+          this.offsets.push(dir > 0 ? 1 : (next instanceof TextLeaf ? next.text.length : next.children.length) << 1);
+        }
+      }
+    }
+  }
+  next(skip = 0) {
+    if (skip < 0) {
+      this.nextInner(-skip, -this.dir);
+      skip = this.value.length;
+    }
+    return this.nextInner(skip, this.dir);
+  }
+};
+var PartialTextCursor = class {
+  constructor(text, start, end) {
+    this.value = "";
+    this.done = false;
+    this.cursor = new RawTextCursor(text, start > end ? -1 : 1);
+    this.pos = start > end ? text.length : 0;
+    this.from = Math.min(start, end);
+    this.to = Math.max(start, end);
+  }
+  nextInner(skip, dir) {
+    if (dir < 0 ? this.pos <= this.from : this.pos >= this.to) {
+      this.value = "";
+      this.done = true;
+      return this;
+    }
+    skip += Math.max(0, dir < 0 ? this.pos - this.to : this.from - this.pos);
+    let limit = dir < 0 ? this.pos - this.from : this.to - this.pos;
+    if (skip > limit)
+      skip = limit;
+    limit -= skip;
+    let { value } = this.cursor.next(skip);
+    this.pos += (value.length + skip) * dir;
+    this.value = value.length <= limit ? value : dir < 0 ? value.slice(value.length - limit) : value.slice(0, limit);
+    this.done = !this.value;
+    return this;
+  }
+  next(skip = 0) {
+    if (skip < 0)
+      skip = Math.max(skip, this.from - this.pos);
+    else if (skip > 0)
+      skip = Math.min(skip, this.to - this.pos);
+    return this.nextInner(skip, this.cursor.dir);
+  }
+  get lineBreak() {
+    return this.cursor.lineBreak && this.value != "";
+  }
+};
+var LineCursor = class {
+  constructor(inner) {
+    this.inner = inner;
+    this.afterBreak = true;
+    this.value = "";
+    this.done = false;
+  }
+  next(skip = 0) {
+    let { done, lineBreak, value } = this.inner.next(skip);
+    if (done && this.afterBreak) {
+      this.value = "";
+      this.afterBreak = false;
+    } else if (done) {
+      this.done = true;
+      this.value = "";
+    } else if (lineBreak) {
+      if (this.afterBreak) {
+        this.value = "";
+      } else {
+        this.afterBreak = true;
+        this.next();
+      }
+    } else {
+      this.value = value;
+      this.afterBreak = false;
+    }
+    return this;
+  }
+  get lineBreak() {
+    return false;
+  }
+};
+if (typeof Symbol != "undefined") {
+  Text.prototype[Symbol.iterator] = function() {
+    return this.iter();
+  };
+  RawTextCursor.prototype[Symbol.iterator] = PartialTextCursor.prototype[Symbol.iterator] = LineCursor.prototype[Symbol.iterator] = function() {
+    return this;
+  };
+}
+var Line = class {
+  /**
+  @internal
+  */
+  constructor(from, to, number2, text) {
+    this.from = from;
+    this.to = to;
+    this.number = number2;
+    this.text = text;
+  }
+  /**
+  The length of the line (not including any line break after it).
+  */
+  get length() {
+    return this.to - this.from;
+  }
+};
+function clip(text, from, to) {
+  from = Math.max(0, Math.min(text.length, from));
+  return [from, Math.max(from, Math.min(text.length, to))];
+}
+function findClusterBreak2(str, pos, forward = true, includeExtending = true) {
+  return findClusterBreak(str, pos, forward, includeExtending);
+}
+function surrogateLow2(ch) {
+  return ch >= 56320 && ch < 57344;
+}
+function surrogateHigh2(ch) {
+  return ch >= 55296 && ch < 56320;
+}
+function codePointAt2(str, pos) {
+  let code0 = str.charCodeAt(pos);
+  if (!surrogateHigh2(code0) || pos + 1 == str.length)
+    return code0;
+  let code1 = str.charCodeAt(pos + 1);
+  if (!surrogateLow2(code1))
+    return code0;
+  return (code0 - 55296 << 10) + (code1 - 56320) + 65536;
+}
+function codePointSize2(code2) {
+  return code2 < 65536 ? 1 : 2;
+}
+var DefaultSplit = /\r\n?|\n/;
+var MapMode = /* @__PURE__ */ (function(MapMode2) {
+  MapMode2[MapMode2["Simple"] = 0] = "Simple";
+  MapMode2[MapMode2["TrackDel"] = 1] = "TrackDel";
+  MapMode2[MapMode2["TrackBefore"] = 2] = "TrackBefore";
+  MapMode2[MapMode2["TrackAfter"] = 3] = "TrackAfter";
+  return MapMode2;
+})(MapMode || (MapMode = {}));
+var ChangeDesc = class _ChangeDesc {
+  // Sections are encoded as pairs of integers. The first is the
+  // length in the current document, and the second is -1 for
+  // unaffected sections, and the length of the replacement content
+  // otherwise. So an insertion would be (0, n>0), a deletion (n>0,
+  // 0), and a replacement two positive numbers.
+  /**
+  @internal
+  */
+  constructor(sections) {
+    this.sections = sections;
+  }
+  /**
+  The length of the document before the change.
+  */
+  get length() {
+    let result = 0;
+    for (let i2 = 0; i2 < this.sections.length; i2 += 2)
+      result += this.sections[i2];
+    return result;
+  }
+  /**
+  The length of the document after the change.
+  */
+  get newLength() {
+    let result = 0;
+    for (let i2 = 0; i2 < this.sections.length; i2 += 2) {
+      let ins = this.sections[i2 + 1];
+      result += ins < 0 ? this.sections[i2] : ins;
+    }
+    return result;
+  }
+  /**
+  False when there are actual changes in this set.
+  */
+  get empty() {
+    return this.sections.length == 0 || this.sections.length == 2 && this.sections[1] < 0;
+  }
+  /**
+  Iterate over the unchanged parts left by these changes. `posA`
+  provides the position of the range in the old document, `posB`
+  the new position in the changed document.
+  */
+  iterGaps(f) {
+    for (let i2 = 0, posA = 0, posB = 0; i2 < this.sections.length; ) {
+      let len = this.sections[i2++], ins = this.sections[i2++];
+      if (ins < 0) {
+        f(posA, posB, len);
+        posB += len;
+      } else {
+        posB += ins;
+      }
+      posA += len;
+    }
+  }
+  /**
+  Iterate over the ranges changed by these changes. (See
+  [`ChangeSet.iterChanges`](https://codemirror.net/6/docs/ref/#state.ChangeSet.iterChanges) for a
+  variant that also provides you with the inserted text.)
+  `fromA`/`toA` provides the extent of the change in the starting
+  document, `fromB`/`toB` the extent of the replacement in the
+  changed document.
+  
+  When `individual` is true, adjacent changes (which are kept
+  separate for [position mapping](https://codemirror.net/6/docs/ref/#state.ChangeDesc.mapPos)) are
+  reported separately.
+  */
+  iterChangedRanges(f, individual = false) {
+    iterChanges(this, f, individual);
+  }
+  /**
+  Get a description of the inverted form of these changes.
+  */
+  get invertedDesc() {
+    let sections = [];
+    for (let i2 = 0; i2 < this.sections.length; ) {
+      let len = this.sections[i2++], ins = this.sections[i2++];
+      if (ins < 0)
+        sections.push(len, ins);
+      else
+        sections.push(ins, len);
+    }
+    return new _ChangeDesc(sections);
+  }
+  /**
+  Compute the combined effect of applying another set of changes
+  after this one. The length of the document after this set should
+  match the length before `other`.
+  */
+  composeDesc(other) {
+    return this.empty ? other : other.empty ? this : composeSets(this, other);
+  }
+  /**
+  Map this description, which should start with the same document
+  as `other`, over another set of changes, so that it can be
+  applied after it. When `before` is true, map as if the changes
+  in `this` happened before the ones in `other`.
+  */
+  mapDesc(other, before = false) {
+    return other.empty ? this : mapSet(this, other, before);
+  }
+  mapPos(pos, assoc = -1, mode = MapMode.Simple) {
+    let posA = 0, posB = 0;
+    for (let i2 = 0; i2 < this.sections.length; ) {
+      let len = this.sections[i2++], ins = this.sections[i2++], endA = posA + len;
+      if (ins < 0) {
+        if (endA > pos)
+          return posB + (pos - posA);
+        posB += len;
+      } else {
+        if (mode != MapMode.Simple && endA >= pos && (mode == MapMode.TrackDel && posA < pos && endA > pos || mode == MapMode.TrackBefore && posA < pos || mode == MapMode.TrackAfter && endA > pos))
+          return null;
+        if (endA > pos || endA == pos && assoc < 0 && !len)
+          return pos == posA || assoc < 0 ? posB : posB + ins;
+        posB += ins;
+      }
+      posA = endA;
+    }
+    if (pos > posA)
+      throw new RangeError(`Position ${pos} is out of range for changeset of length ${posA}`);
+    return posB;
+  }
+  /**
+  Check whether these changes touch a given range. When one of the
+  changes entirely covers the range, the string `"cover"` is
+  returned.
+  */
+  touchesRange(from, to = from) {
+    for (let i2 = 0, pos = 0; i2 < this.sections.length && pos <= to; ) {
+      let len = this.sections[i2++], ins = this.sections[i2++], end = pos + len;
+      if (ins >= 0 && pos <= to && end >= from)
+        return pos < from && end > to ? "cover" : true;
+      pos = end;
+    }
+    return false;
+  }
+  /**
+  @internal
+  */
+  toString() {
+    let result = "";
+    for (let i2 = 0; i2 < this.sections.length; ) {
+      let len = this.sections[i2++], ins = this.sections[i2++];
+      result += (result ? " " : "") + len + (ins >= 0 ? ":" + ins : "");
+    }
+    return result;
+  }
+  /**
+  Serialize this change desc to a JSON-representable value.
+  */
+  toJSON() {
+    return this.sections;
+  }
+  /**
+  Create a change desc from its JSON representation (as produced
+  by [`toJSON`](https://codemirror.net/6/docs/ref/#state.ChangeDesc.toJSON).
+  */
+  static fromJSON(json) {
+    if (!Array.isArray(json) || json.length % 2 || json.some((a) => typeof a != "number"))
+      throw new RangeError("Invalid JSON representation of ChangeDesc");
+    return new _ChangeDesc(json);
+  }
+  /**
+  @internal
+  */
+  static create(sections) {
+    return new _ChangeDesc(sections);
+  }
+};
+var ChangeSet = class _ChangeSet extends ChangeDesc {
+  constructor(sections, inserted) {
+    super(sections);
+    this.inserted = inserted;
+  }
+  /**
+  Apply the changes to a document, returning the modified
+  document.
+  */
+  apply(doc2) {
+    if (this.length != doc2.length)
+      throw new RangeError("Applying change set to a document with the wrong length");
+    iterChanges(this, (fromA, toA, fromB, _toB, text) => doc2 = doc2.replace(fromB, fromB + (toA - fromA), text), false);
+    return doc2;
+  }
+  mapDesc(other, before = false) {
+    return mapSet(this, other, before, true);
+  }
+  /**
+  Given the document as it existed _before_ the changes, return a
+  change set that represents the inverse of this set, which could
+  be used to go from the document created by the changes back to
+  the document as it existed before the changes.
+  */
+  invert(doc2) {
+    let sections = this.sections.slice(), inserted = [];
+    for (let i2 = 0, pos = 0; i2 < sections.length; i2 += 2) {
+      let len = sections[i2], ins = sections[i2 + 1];
+      if (ins >= 0) {
+        sections[i2] = ins;
+        sections[i2 + 1] = len;
+        let index = i2 >> 1;
+        while (inserted.length < index)
+          inserted.push(Text.empty);
+        inserted.push(len ? doc2.slice(pos, pos + len) : Text.empty);
+      }
+      pos += len;
+    }
+    return new _ChangeSet(sections, inserted);
+  }
+  /**
+  Combine two subsequent change sets into a single set. `other`
+  must start in the document produced by `this`. If `this` goes
+  `docA` → `docB` and `other` represents `docB` → `docC`, the
+  returned value will represent the change `docA` → `docC`.
+  */
+  compose(other) {
+    return this.empty ? other : other.empty ? this : composeSets(this, other, true);
+  }
+  /**
+  Given another change set starting in the same document, maps this
+  change set over the other, producing a new change set that can be
+  applied to the document produced by applying `other`. When
+  `before` is `true`, order changes as if `this` comes before
+  `other`, otherwise (the default) treat `other` as coming first.
+  
+  Given two changes `A` and `B`, `A.compose(B.map(A))` and
+  `B.compose(A.map(B, true))` will produce the same document. This
+  provides a basic form of [operational
+  transformation](https://en.wikipedia.org/wiki/Operational_transformation),
+  and can be used for collaborative editing.
+  */
+  map(other, before = false) {
+    return other.empty ? this : mapSet(this, other, before, true);
+  }
+  /**
+  Iterate over the changed ranges in the document, calling `f` for
+  each, with the range in the original document (`fromA`-`toA`)
+  and the range that replaces it in the new document
+  (`fromB`-`toB`).
+  
+  When `individual` is true, adjacent changes are reported
+  separately.
+  */
+  iterChanges(f, individual = false) {
+    iterChanges(this, f, individual);
+  }
+  /**
+  Get a [change description](https://codemirror.net/6/docs/ref/#state.ChangeDesc) for this change
+  set.
+  */
+  get desc() {
+    return ChangeDesc.create(this.sections);
+  }
+  /**
+  @internal
+  */
+  filter(ranges) {
+    let resultSections = [], resultInserted = [], filteredSections = [];
+    let iter = new SectionIter(this);
+    done: for (let i2 = 0, pos = 0; ; ) {
+      let next = i2 == ranges.length ? 1e9 : ranges[i2++];
+      while (pos < next || pos == next && iter.len == 0) {
+        if (iter.done)
+          break done;
+        let len = Math.min(iter.len, next - pos);
+        addSection(filteredSections, len, -1);
+        let ins = iter.ins == -1 ? -1 : iter.off == 0 ? iter.ins : 0;
+        addSection(resultSections, len, ins);
+        if (ins > 0)
+          addInsert(resultInserted, resultSections, iter.text);
+        iter.forward(len);
+        pos += len;
+      }
+      let end = ranges[i2++];
+      while (pos < end) {
+        if (iter.done)
+          break done;
+        let len = Math.min(iter.len, end - pos);
+        addSection(resultSections, len, -1);
+        addSection(filteredSections, len, iter.ins == -1 ? -1 : iter.off == 0 ? iter.ins : 0);
+        iter.forward(len);
+        pos += len;
+      }
+    }
+    return {
+      changes: new _ChangeSet(resultSections, resultInserted),
+      filtered: ChangeDesc.create(filteredSections)
+    };
+  }
+  /**
+  Serialize this change set to a JSON-representable value.
+  */
+  toJSON() {
+    let parts = [];
+    for (let i2 = 0; i2 < this.sections.length; i2 += 2) {
+      let len = this.sections[i2], ins = this.sections[i2 + 1];
+      if (ins < 0)
+        parts.push(len);
+      else if (ins == 0)
+        parts.push([len]);
+      else
+        parts.push([len].concat(this.inserted[i2 >> 1].toJSON()));
+    }
+    return parts;
+  }
+  /**
+  Create a change set for the given changes, for a document of the
+  given length, using `lineSep` as line separator.
+  */
+  static of(changes, length, lineSep) {
+    let sections = [], inserted = [], pos = 0;
+    let total = null;
+    function flush(force = false) {
+      if (!force && !sections.length)
+        return;
+      if (pos < length)
+        addSection(sections, length - pos, -1);
+      let set = new _ChangeSet(sections, inserted);
+      total = total ? total.compose(set.map(total)) : set;
+      sections = [];
+      inserted = [];
+      pos = 0;
+    }
+    function process2(spec) {
+      if (Array.isArray(spec)) {
+        for (let sub of spec)
+          process2(sub);
+      } else if (spec instanceof _ChangeSet) {
+        if (spec.length != length)
+          throw new RangeError(`Mismatched change set length (got ${spec.length}, expected ${length})`);
+        flush();
+        total = total ? total.compose(spec.map(total)) : spec;
+      } else {
+        let { from, to = from, insert: insert2 } = spec;
+        if (from > to || from < 0 || to > length)
+          throw new RangeError(`Invalid change range ${from} to ${to} (in doc of length ${length})`);
+        let insText = !insert2 ? Text.empty : typeof insert2 == "string" ? Text.of(insert2.split(lineSep || DefaultSplit)) : insert2;
+        let insLen = insText.length;
+        if (from == to && insLen == 0)
+          return;
+        if (from < pos)
+          flush();
+        if (from > pos)
+          addSection(sections, from - pos, -1);
+        addSection(sections, to - from, insLen);
+        addInsert(inserted, sections, insText);
+        pos = to;
+      }
+    }
+    process2(changes);
+    flush(!total);
+    return total;
+  }
+  /**
+  Create an empty changeset of the given length.
+  */
+  static empty(length) {
+    return new _ChangeSet(length ? [length, -1] : [], []);
+  }
+  /**
+  Create a changeset from its JSON representation (as produced by
+  [`toJSON`](https://codemirror.net/6/docs/ref/#state.ChangeSet.toJSON).
+  */
+  static fromJSON(json) {
+    if (!Array.isArray(json))
+      throw new RangeError("Invalid JSON representation of ChangeSet");
+    let sections = [], inserted = [];
+    for (let i2 = 0; i2 < json.length; i2++) {
+      let part = json[i2];
+      if (typeof part == "number") {
+        sections.push(part, -1);
+      } else if (!Array.isArray(part) || typeof part[0] != "number" || part.some((e, i3) => i3 && typeof e != "string")) {
+        throw new RangeError("Invalid JSON representation of ChangeSet");
+      } else if (part.length == 1) {
+        sections.push(part[0], 0);
+      } else {
+        while (inserted.length < i2)
+          inserted.push(Text.empty);
+        inserted[i2] = Text.of(part.slice(1));
+        sections.push(part[0], inserted[i2].length);
+      }
+    }
+    return new _ChangeSet(sections, inserted);
+  }
+  /**
+  @internal
+  */
+  static createSet(sections, inserted) {
+    return new _ChangeSet(sections, inserted);
+  }
+};
+function addSection(sections, len, ins, forceJoin = false) {
+  if (len == 0 && ins <= 0)
+    return;
+  let last = sections.length - 2;
+  if (last >= 0 && ins <= 0 && ins == sections[last + 1])
+    sections[last] += len;
+  else if (last >= 0 && len == 0 && sections[last] == 0)
+    sections[last + 1] += ins;
+  else if (forceJoin) {
+    sections[last] += len;
+    sections[last + 1] += ins;
+  } else
+    sections.push(len, ins);
+}
+function addInsert(values, sections, value) {
+  if (value.length == 0)
+    return;
+  let index = sections.length - 2 >> 1;
+  if (index < values.length) {
+    values[values.length - 1] = values[values.length - 1].append(value);
+  } else {
+    while (values.length < index)
+      values.push(Text.empty);
+    values.push(value);
+  }
+}
+function iterChanges(desc, f, individual) {
+  let inserted = desc.inserted;
+  for (let posA = 0, posB = 0, i2 = 0; i2 < desc.sections.length; ) {
+    let len = desc.sections[i2++], ins = desc.sections[i2++];
+    if (ins < 0) {
+      posA += len;
+      posB += len;
+    } else {
+      let endA = posA, endB = posB, text = Text.empty;
+      for (; ; ) {
+        endA += len;
+        endB += ins;
+        if (ins && inserted)
+          text = text.append(inserted[i2 - 2 >> 1]);
+        if (individual || i2 == desc.sections.length || desc.sections[i2 + 1] < 0)
+          break;
+        len = desc.sections[i2++];
+        ins = desc.sections[i2++];
+      }
+      f(posA, endA, posB, endB, text);
+      posA = endA;
+      posB = endB;
+    }
+  }
+}
+function mapSet(setA, setB, before, mkSet = false) {
+  let sections = [], insert2 = mkSet ? [] : null;
+  let a = new SectionIter(setA), b = new SectionIter(setB);
+  for (let inserted = -1; ; ) {
+    if (a.done && b.len || b.done && a.len) {
+      throw new Error("Mismatched change set lengths");
+    } else if (a.ins == -1 && b.ins == -1) {
+      let len = Math.min(a.len, b.len);
+      addSection(sections, len, -1);
+      a.forward(len);
+      b.forward(len);
+    } else if (b.ins >= 0 && (a.ins < 0 || inserted == a.i || a.off == 0 && (b.len < a.len || b.len == a.len && !before))) {
+      let len = b.len;
+      addSection(sections, b.ins, -1);
+      while (len) {
+        let piece = Math.min(a.len, len);
+        if (a.ins >= 0 && inserted < a.i && a.len <= piece) {
+          addSection(sections, 0, a.ins);
+          if (insert2)
+            addInsert(insert2, sections, a.text);
+          inserted = a.i;
+        }
+        a.forward(piece);
+        len -= piece;
+      }
+      b.next();
+    } else if (a.ins >= 0) {
+      let len = 0, left = a.len;
+      while (left) {
+        if (b.ins == -1) {
+          let piece = Math.min(left, b.len);
+          len += piece;
+          left -= piece;
+          b.forward(piece);
+        } else if (b.ins == 0 && b.len < left) {
+          left -= b.len;
+          b.next();
+        } else {
+          break;
+        }
+      }
+      addSection(sections, len, inserted < a.i ? a.ins : 0);
+      if (insert2 && inserted < a.i)
+        addInsert(insert2, sections, a.text);
+      inserted = a.i;
+      a.forward(a.len - left);
+    } else if (a.done && b.done) {
+      return insert2 ? ChangeSet.createSet(sections, insert2) : ChangeDesc.create(sections);
+    } else {
+      throw new Error("Mismatched change set lengths");
+    }
+  }
+}
+function composeSets(setA, setB, mkSet = false) {
+  let sections = [];
+  let insert2 = mkSet ? [] : null;
+  let a = new SectionIter(setA), b = new SectionIter(setB);
+  for (let open = false; ; ) {
+    if (a.done && b.done) {
+      return insert2 ? ChangeSet.createSet(sections, insert2) : ChangeDesc.create(sections);
+    } else if (a.ins == 0) {
+      addSection(sections, a.len, 0, open);
+      a.next();
+    } else if (b.len == 0 && !b.done) {
+      addSection(sections, 0, b.ins, open);
+      if (insert2)
+        addInsert(insert2, sections, b.text);
+      b.next();
+    } else if (a.done || b.done) {
+      throw new Error("Mismatched change set lengths");
+    } else {
+      let len = Math.min(a.len2, b.len), sectionLen = sections.length;
+      if (a.ins == -1) {
+        let insB = b.ins == -1 ? -1 : b.off ? 0 : b.ins;
+        addSection(sections, len, insB, open);
+        if (insert2 && insB)
+          addInsert(insert2, sections, b.text);
+      } else if (b.ins == -1) {
+        addSection(sections, a.off ? 0 : a.len, len, open);
+        if (insert2)
+          addInsert(insert2, sections, a.textBit(len));
+      } else {
+        addSection(sections, a.off ? 0 : a.len, b.off ? 0 : b.ins, open);
+        if (insert2 && !b.off)
+          addInsert(insert2, sections, b.text);
+      }
+      open = (a.ins > len || b.ins >= 0 && b.len > len) && (open || sections.length > sectionLen);
+      a.forward2(len);
+      b.forward(len);
+    }
+  }
+}
+var SectionIter = class {
+  constructor(set) {
+    this.set = set;
+    this.i = 0;
+    this.next();
+  }
+  next() {
+    let { sections } = this.set;
+    if (this.i < sections.length) {
+      this.len = sections[this.i++];
+      this.ins = sections[this.i++];
+    } else {
+      this.len = 0;
+      this.ins = -2;
+    }
+    this.off = 0;
+  }
+  get done() {
+    return this.ins == -2;
+  }
+  get len2() {
+    return this.ins < 0 ? this.len : this.ins;
+  }
+  get text() {
+    let { inserted } = this.set, index = this.i - 2 >> 1;
+    return index >= inserted.length ? Text.empty : inserted[index];
+  }
+  textBit(len) {
+    let { inserted } = this.set, index = this.i - 2 >> 1;
+    return index >= inserted.length && !len ? Text.empty : inserted[index].slice(this.off, len == null ? void 0 : this.off + len);
+  }
+  forward(len) {
+    if (len == this.len)
+      this.next();
+    else {
+      this.len -= len;
+      this.off += len;
+    }
+  }
+  forward2(len) {
+    if (this.ins == -1)
+      this.forward(len);
+    else if (len == this.ins)
+      this.next();
+    else {
+      this.ins -= len;
+      this.off += len;
+    }
+  }
+};
+var SelectionRange = class _SelectionRange {
+  constructor(from, to, flags, goalColumn) {
+    this.from = from;
+    this.to = to;
+    this.flags = flags;
+    this.goalColumn = goalColumn;
+  }
+  /**
+  The anchor of the range—the side that doesn't move when you
+  extend it.
+  */
+  get anchor() {
+    return this.flags & 32 ? this.to : this.from;
+  }
+  /**
+  The head of the range, which is moved when the range is
+  [extended](https://codemirror.net/6/docs/ref/#state.SelectionRange.extend).
+  */
+  get head() {
+    return this.flags & 32 ? this.from : this.to;
+  }
+  /**
+  True when `anchor` and `head` are at the same position.
+  */
+  get empty() {
+    return this.from == this.to;
+  }
+  /**
+  If this is a cursor that is explicitly associated with the
+  character on one of its sides, this returns the side. -1 means
+  the character before its position, 1 the character after, and 0
+  means no association.
+  */
+  get assoc() {
+    return this.flags & 8 ? -1 : this.flags & 16 ? 1 : 0;
+  }
+  /**
+  A flag that, when set, makes some selection-extending commands
+  treat the range's head and anchor as exchangeable, so that for
+  example Shift-ArrowUp will make the lower side of the selection
+  the anchor, even if that was the head before. Used to implement
+  MacOS-style undirectional selections.
+  */
+  get undirectional() {
+    return (this.flags & 64) > 0;
+  }
+  /**
+  The bidirectional text level associated with this cursor, if
+  any.
+  */
+  get bidiLevel() {
+    let level = this.flags & 7;
+    return level == 7 ? null : level;
+  }
+  /**
+  Map this range through a change, producing a valid range in the
+  updated document.
+  */
+  map(change, assoc = -1) {
+    let from, to;
+    if (this.empty) {
+      from = to = change.mapPos(this.from, assoc);
+    } else {
+      from = change.mapPos(this.from, 1);
+      to = change.mapPos(this.to, -1);
+    }
+    return from == this.from && to == this.to ? this : new _SelectionRange(from, to, this.flags, this.goalColumn);
+  }
+  /**
+  Extend this range to cover at least `from` to `to`.
+  */
+  extend(from, to = from, assoc = 0) {
+    if (from <= this.anchor && to >= this.anchor)
+      return EditorSelection.range(from, to, void 0, void 0, assoc);
+    let head = Math.abs(from - this.anchor) > Math.abs(to - this.anchor) ? from : to;
+    return EditorSelection.range(this.anchor, head, void 0, void 0, assoc);
+  }
+  /**
+  Compare this range to another range.
+  */
+  eq(other, includeAssoc = false) {
+    return this.anchor == other.anchor && this.head == other.head && this.goalColumn == other.goalColumn && (!includeAssoc || !this.empty || this.assoc == other.assoc);
+  }
+  /**
+  Return a JSON-serializable object representing the range.
+  */
+  toJSON() {
+    return { anchor: this.anchor, head: this.head };
+  }
+  /**
+  Convert a JSON representation of a range to a `SelectionRange`
+  instance.
+  */
+  static fromJSON(json) {
+    if (!json || typeof json.anchor != "number" || typeof json.head != "number")
+      throw new RangeError("Invalid JSON representation for SelectionRange");
+    return EditorSelection.range(json.anchor, json.head);
+  }
+  /**
+  @internal
+  */
+  static create(from, to, flags, goalColumn) {
+    return new _SelectionRange(from, to, flags, goalColumn);
+  }
+};
+var EditorSelection = class _EditorSelection {
+  constructor(ranges, mainIndex) {
+    this.ranges = ranges;
+    this.mainIndex = mainIndex;
+  }
+  /**
+  Map a selection through a change. Used to adjust the selection
+  position for changes.
+  */
+  map(change, assoc = -1) {
+    if (change.empty)
+      return this;
+    return _EditorSelection.create(this.ranges.map((r2) => r2.map(change, assoc)), this.mainIndex);
+  }
+  /**
+  Compare this selection to another selection. By default, ranges
+  are compared only by position. When `includeAssoc` is true,
+  cursor ranges must also have the same
+  [`assoc`](https://codemirror.net/6/docs/ref/#state.SelectionRange.assoc) value.
+  */
+  eq(other, includeAssoc = false) {
+    if (this.ranges.length != other.ranges.length || this.mainIndex != other.mainIndex)
+      return false;
+    for (let i2 = 0; i2 < this.ranges.length; i2++)
+      if (!this.ranges[i2].eq(other.ranges[i2], includeAssoc))
+        return false;
+    return true;
+  }
+  /**
+  Get the primary selection range. Usually, you should make sure
+  your code applies to _all_ ranges, by using methods like
+  [`changeByRange`](https://codemirror.net/6/docs/ref/#state.EditorState.changeByRange).
+  */
+  get main() {
+    return this.ranges[this.mainIndex];
+  }
+  /**
+  Make sure the selection only has one range. Returns a selection
+  holding only the main range from this selection.
+  */
+  asSingle() {
+    return this.ranges.length == 1 ? this : new _EditorSelection([this.main], 0);
+  }
+  /**
+  Extend this selection with an extra range.
+  */
+  addRange(range, main = true) {
+    return _EditorSelection.create([range].concat(this.ranges), main ? 0 : this.mainIndex + 1);
+  }
+  /**
+  Replace a given range with another range, and then normalize the
+  selection to merge and sort ranges if necessary.
+  */
+  replaceRange(range, which = this.mainIndex) {
+    let ranges = this.ranges.slice();
+    ranges[which] = range;
+    return _EditorSelection.create(ranges, this.mainIndex);
+  }
+  /**
+  Convert this selection to an object that can be serialized to
+  JSON.
+  */
+  toJSON() {
+    return { ranges: this.ranges.map((r2) => r2.toJSON()), main: this.mainIndex };
+  }
+  /**
+  Create a selection from a JSON representation.
+  */
+  static fromJSON(json) {
+    if (!json || !Array.isArray(json.ranges) || typeof json.main != "number" || json.main >= json.ranges.length)
+      throw new RangeError("Invalid JSON representation for EditorSelection");
+    return new _EditorSelection(json.ranges.map((r2) => SelectionRange.fromJSON(r2)), json.main);
+  }
+  /**
+  Create a selection holding a single range.
+  */
+  static single(anchor, head = anchor) {
+    return new _EditorSelection([_EditorSelection.range(anchor, head)], 0);
+  }
+  /**
+  Sort and merge the given set of ranges, creating a valid
+  selection.
+  */
+  static create(ranges, mainIndex = 0) {
+    if (ranges.length == 0)
+      throw new RangeError("A selection needs at least one range");
+    for (let pos = 0, i2 = 0; i2 < ranges.length; i2++) {
+      let range = ranges[i2];
+      if (range.empty ? range.from <= pos : range.from < pos)
+        return _EditorSelection.normalized(ranges.slice(), mainIndex);
+      pos = range.to;
+    }
+    return new _EditorSelection(ranges, mainIndex);
+  }
+  /**
+  Create a cursor selection range at the given position. You can
+  safely ignore the optional arguments in most situations.
+  */
+  static cursor(pos, assoc = 0, bidiLevel, goalColumn) {
+    return SelectionRange.create(pos, pos, (assoc == 0 ? 0 : assoc < 0 ? 8 : 16) | (bidiLevel == null ? 7 : Math.min(6, bidiLevel)), goalColumn);
+  }
+  /**
+  Create a selection range.
+  */
+  static range(anchor, head, goalColumn, bidiLevel, assoc) {
+    let flags = bidiLevel == null ? 7 : Math.min(6, bidiLevel);
+    if (!assoc && anchor != head)
+      assoc = head < anchor ? 1 : -1;
+    if (assoc)
+      flags |= assoc < 0 ? 8 : 16;
+    return head < anchor ? SelectionRange.create(head, anchor, flags | 32, goalColumn) : SelectionRange.create(anchor, head, flags, goalColumn);
+  }
+  /**
+  Create an [undirectional](https://codemirror.net/6/docs/ref/#state.SelectionRange.undirectional)
+  selection range.
+  */
+  static undirectionalRange(from, to) {
+    return SelectionRange.create(from, to, 64, void 0);
+  }
+  /**
+  @internal
+  */
+  static normalized(ranges, mainIndex = 0) {
+    let main = ranges[mainIndex];
+    ranges.sort((a, b) => a.from - b.from);
+    mainIndex = ranges.indexOf(main);
+    for (let i2 = 1; i2 < ranges.length; i2++) {
+      let range = ranges[i2], prev = ranges[i2 - 1];
+      if (range.empty ? range.from <= prev.to : range.from < prev.to) {
+        let from = prev.from, to = Math.max(range.to, prev.to);
+        if (i2 <= mainIndex)
+          mainIndex--;
+        ranges.splice(--i2, 2, range.anchor > range.head ? _EditorSelection.range(to, from) : _EditorSelection.range(from, to));
+      }
+    }
+    return new _EditorSelection(ranges, mainIndex);
+  }
+};
+function checkSelection(selection, docLength) {
+  for (let range of selection.ranges)
+    if (range.to > docLength)
+      throw new RangeError("Selection points outside of document");
+}
+var nextID = 0;
+var Facet = class _Facet {
+  constructor(combine, compareInput, compare2, isStatic, enables) {
+    this.combine = combine;
+    this.compareInput = compareInput;
+    this.compare = compare2;
+    this.isStatic = isStatic;
+    this.id = nextID++;
+    this.default = combine([]);
+    this.extensions = typeof enables == "function" ? enables(this) : enables;
+  }
+  /**
+  Returns a facet reader for this facet, which can be used to
+  [read](https://codemirror.net/6/docs/ref/#state.EditorState.facet) it but not to define values for it.
+  */
+  get reader() {
+    return this;
+  }
+  /**
+  Define a new facet.
+  */
+  static define(config = {}) {
+    return new _Facet(config.combine || ((a) => a), config.compareInput || ((a, b) => a === b), config.compare || (!config.combine ? sameArray : (a, b) => a === b), !!config.static, config.enables);
+  }
+  /**
+  Returns an extension that adds the given value to this facet.
+  */
+  of(value) {
+    return new FacetProvider([], this, 0, value);
+  }
+  /**
+  Create an extension that computes a value for the facet from a
+  state. You must take care to declare the parts of the state that
+  this value depends on, since your function is only called again
+  for a new state when one of those parts changed.
+  
+  In cases where your value depends only on a single field, you'll
+  want to use the [`from`](https://codemirror.net/6/docs/ref/#state.Facet.from) method instead.
+  */
+  compute(deps, get) {
+    if (this.isStatic)
+      throw new Error("Can't compute a static facet");
+    return new FacetProvider(deps, this, 1, get);
+  }
+  /**
+  Create an extension that computes zero or more values for this
+  facet from a state.
+  */
+  computeN(deps, get) {
+    if (this.isStatic)
+      throw new Error("Can't compute a static facet");
+    return new FacetProvider(deps, this, 2, get);
+  }
+  from(field, get) {
+    if (!get)
+      get = (x) => x;
+    return this.compute([field], (state) => get(state.field(field)));
+  }
+};
+function sameArray(a, b) {
+  return a == b || a.length == b.length && a.every((e, i2) => e === b[i2]);
+}
+var FacetProvider = class {
+  constructor(dependencies, facet, type, value) {
+    this.dependencies = dependencies;
+    this.facet = facet;
+    this.type = type;
+    this.value = value;
+    this.id = nextID++;
+  }
+  dynamicSlot(addresses) {
+    var _a2;
+    let getter = this.value;
+    let compare2 = this.facet.compareInput;
+    let id2 = this.id, idx = addresses[id2] >> 1, multi = this.type == 2;
+    let depDoc = false, depSel = false, depAddrs = [];
+    for (let dep of this.dependencies) {
+      if (dep == "doc")
+        depDoc = true;
+      else if (dep == "selection")
+        depSel = true;
+      else if ((((_a2 = addresses[dep.id]) !== null && _a2 !== void 0 ? _a2 : 1) & 1) == 0)
+        depAddrs.push(addresses[dep.id]);
+    }
+    return {
+      create(state) {
+        state.values[idx] = getter(state);
+        return 1;
+      },
+      update(state, tr) {
+        if (depDoc && tr.docChanged || depSel && (tr.docChanged || tr.selection) || ensureAll(state, depAddrs)) {
+          let newVal = getter(state);
+          if (multi ? !compareArray(newVal, state.values[idx], compare2) : !compare2(newVal, state.values[idx])) {
+            state.values[idx] = newVal;
+            return 1;
+          }
+        }
+        return 0;
+      },
+      reconfigure: (state, oldState) => {
+        let newVal, oldAddr = oldState.config.address[id2];
+        if (oldAddr != null) {
+          let oldVal = getAddr(oldState, oldAddr);
+          if (this.dependencies.every((dep) => {
+            return dep instanceof Facet ? oldState.facet(dep) === state.facet(dep) : dep instanceof StateField ? oldState.field(dep, false) == state.field(dep, false) : true;
+          }) || (multi ? compareArray(newVal = getter(state), oldVal, compare2) : compare2(newVal = getter(state), oldVal))) {
+            state.values[idx] = oldVal;
+            return 0;
+          }
+        } else {
+          newVal = getter(state);
+        }
+        state.values[idx] = newVal;
+        return 1;
+      }
+    };
+  }
+};
+function compareArray(a, b, compare2) {
+  if (a.length != b.length)
+    return false;
+  for (let i2 = 0; i2 < a.length; i2++)
+    if (!compare2(a[i2], b[i2]))
+      return false;
+  return true;
+}
+function ensureAll(state, addrs) {
+  let changed = false;
+  for (let addr of addrs)
+    if (ensureAddr(state, addr) & 1)
+      changed = true;
+  return changed;
+}
+function dynamicFacetSlot(addresses, facet, providers) {
+  let providerAddrs = providers.map((p) => addresses[p.id]);
+  let providerTypes = providers.map((p) => p.type);
+  let dynamic = providerAddrs.filter((p) => !(p & 1));
+  let idx = addresses[facet.id] >> 1;
+  function get(state) {
+    let values = [];
+    for (let i2 = 0; i2 < providerAddrs.length; i2++) {
+      let value = getAddr(state, providerAddrs[i2]);
+      if (providerTypes[i2] == 2)
+        for (let val of value)
+          values.push(val);
+      else
+        values.push(value);
+    }
+    return facet.combine(values);
+  }
+  return {
+    create(state) {
+      for (let addr of providerAddrs)
+        ensureAddr(state, addr);
+      state.values[idx] = get(state);
+      return 1;
+    },
+    update(state, tr) {
+      if (!ensureAll(state, dynamic))
+        return 0;
+      let value = get(state);
+      if (facet.compare(value, state.values[idx]))
+        return 0;
+      state.values[idx] = value;
+      return 1;
+    },
+    reconfigure(state, oldState) {
+      let depChanged = ensureAll(state, providerAddrs);
+      let oldProviders = oldState.config.facets[facet.id], oldValue = oldState.facet(facet);
+      if (oldProviders && !depChanged && sameArray(providers, oldProviders)) {
+        state.values[idx] = oldValue;
+        return 0;
+      }
+      let value = get(state);
+      if (facet.compare(value, oldValue)) {
+        state.values[idx] = oldValue;
+        return 0;
+      }
+      state.values[idx] = value;
+      return 1;
+    }
+  };
+}
+var initField = /* @__PURE__ */ Facet.define({ static: true });
+var StateField = class _StateField {
+  constructor(id2, createF, updateF, compareF, spec) {
+    this.id = id2;
+    this.createF = createF;
+    this.updateF = updateF;
+    this.compareF = compareF;
+    this.spec = spec;
+    this.provides = void 0;
+  }
+  /**
+  Define a state field.
+  */
+  static define(config) {
+    let field = new _StateField(nextID++, config.create, config.update, config.compare || ((a, b) => a === b), config);
+    if (config.provide)
+      field.provides = config.provide(field);
+    return field;
+  }
+  create(state) {
+    let init = state.facet(initField).find((i2) => i2.field == this);
+    return ((init === null || init === void 0 ? void 0 : init.create) || this.createF)(state);
+  }
+  /**
+  @internal
+  */
+  slot(addresses) {
+    let idx = addresses[this.id] >> 1;
+    return {
+      create: (state) => {
+        state.values[idx] = this.create(state);
+        return 1;
+      },
+      update: (state, tr) => {
+        let oldVal = state.values[idx];
+        let value = this.updateF(oldVal, tr);
+        if (this.compareF(oldVal, value))
+          return 0;
+        state.values[idx] = value;
+        return 1;
+      },
+      reconfigure: (state, oldState) => {
+        let init = state.facet(initField), oldInit = oldState.facet(initField), reInit;
+        if ((reInit = init.find((i2) => i2.field == this)) && reInit != oldInit.find((i2) => i2.field == this)) {
+          state.values[idx] = reInit.create(state);
+          return 1;
+        }
+        if (oldState.config.address[this.id] != null) {
+          state.values[idx] = oldState.field(this);
+          return 0;
+        }
+        state.values[idx] = this.create(state);
+        return 1;
+      }
+    };
+  }
+  /**
+  Returns an extension that enables this field and overrides the
+  way it is initialized. Can be useful when you need to provide a
+  non-default starting value for the field.
+  */
+  init(create) {
+    return [this, initField.of({ field: this, create })];
+  }
+  /**
+  State field instances can be used as
+  [`Extension`](https://codemirror.net/6/docs/ref/#state.Extension) values to enable the field in a
+  given state.
+  */
+  get extension() {
+    return this;
+  }
+};
+var Prec_ = { lowest: 4, low: 3, default: 2, high: 1, highest: 0 };
+function prec(value) {
+  return (ext) => new PrecExtension(ext, value);
+}
+var Prec = {
+  /**
+  The highest precedence level, for extensions that should end up
+  near the start of the precedence ordering.
+  */
+  highest: /* @__PURE__ */ prec(Prec_.highest),
+  /**
+  A higher-than-default precedence, for extensions that should
+  come before those with default precedence.
+  */
+  high: /* @__PURE__ */ prec(Prec_.high),
+  /**
+  The default precedence, which is also used for extensions
+  without an explicit precedence.
+  */
+  default: /* @__PURE__ */ prec(Prec_.default),
+  /**
+  A lower-than-default precedence.
+  */
+  low: /* @__PURE__ */ prec(Prec_.low),
+  /**
+  The lowest precedence level. Meant for things that should end up
+  near the end of the extension order.
+  */
+  lowest: /* @__PURE__ */ prec(Prec_.lowest)
+};
+var PrecExtension = class {
+  constructor(inner, prec2) {
+    this.inner = inner;
+    this.prec = prec2;
+  }
+};
+var Compartment = class _Compartment {
+  /**
+  Create an instance of this compartment to add to your [state
+  configuration](https://codemirror.net/6/docs/ref/#state.EditorStateConfig.extensions).
+  */
+  of(ext) {
+    return new CompartmentInstance(this, ext);
+  }
+  /**
+  Create an [effect](https://codemirror.net/6/docs/ref/#state.TransactionSpec.effects) that
+  reconfigures this compartment.
+  */
+  reconfigure(content2) {
+    return _Compartment.reconfigure.of({ compartment: this, extension: content2 });
+  }
+  /**
+  Get the current content of the compartment in the state, or
+  `undefined` if it isn't present.
+  */
+  get(state) {
+    return state.config.compartments.get(this);
+  }
+};
+var CompartmentInstance = class {
+  constructor(compartment, inner) {
+    this.compartment = compartment;
+    this.inner = inner;
+  }
+};
+var Configuration = class _Configuration {
+  constructor(base2, compartments, dynamicSlots, address, staticValues, facets) {
+    this.base = base2;
+    this.compartments = compartments;
+    this.dynamicSlots = dynamicSlots;
+    this.address = address;
+    this.staticValues = staticValues;
+    this.facets = facets;
+    this.statusTemplate = [];
+    while (this.statusTemplate.length < dynamicSlots.length)
+      this.statusTemplate.push(
+        0
+        /* SlotStatus.Unresolved */
+      );
+  }
+  staticFacet(facet) {
+    let addr = this.address[facet.id];
+    return addr == null ? facet.default : this.staticValues[addr >> 1];
+  }
+  static resolve(base2, compartments, oldState) {
+    let fields = [];
+    let facets = /* @__PURE__ */ Object.create(null);
+    let newCompartments = /* @__PURE__ */ new Map();
+    for (let ext of flatten(base2, compartments, newCompartments)) {
+      if (ext instanceof StateField)
+        fields.push(ext);
+      else
+        (facets[ext.facet.id] || (facets[ext.facet.id] = [])).push(ext);
+    }
+    let address = /* @__PURE__ */ Object.create(null);
+    let staticValues = [];
+    let dynamicSlots = [];
+    for (let field of fields) {
+      address[field.id] = dynamicSlots.length << 1;
+      dynamicSlots.push((a) => field.slot(a));
+    }
+    let oldFacets = oldState === null || oldState === void 0 ? void 0 : oldState.config.facets;
+    for (let id2 in facets) {
+      let providers = facets[id2], facet = providers[0].facet;
+      let oldProviders = oldFacets && oldFacets[id2] || [];
+      if (providers.every(
+        (p) => p.type == 0
+        /* Provider.Static */
+      )) {
+        address[facet.id] = staticValues.length << 1 | 1;
+        if (sameArray(oldProviders, providers)) {
+          staticValues.push(oldState.facet(facet));
+        } else {
+          let value = facet.combine(providers.map((p) => p.value));
+          staticValues.push(oldState && facet.compare(value, oldState.facet(facet)) ? oldState.facet(facet) : value);
+        }
+      } else {
+        for (let p of providers) {
+          if (p.type == 0) {
+            address[p.id] = staticValues.length << 1 | 1;
+            staticValues.push(p.value);
+          } else {
+            address[p.id] = dynamicSlots.length << 1;
+            dynamicSlots.push((a) => p.dynamicSlot(a));
+          }
+        }
+        address[facet.id] = dynamicSlots.length << 1;
+        dynamicSlots.push((a) => dynamicFacetSlot(a, facet, providers));
+      }
+    }
+    let dynamic = dynamicSlots.map((f) => f(address));
+    return new _Configuration(base2, newCompartments, dynamic, address, staticValues, facets);
+  }
+};
+function flatten(extension, compartments, newCompartments) {
+  let result = [[], [], [], [], []];
+  let seen = /* @__PURE__ */ new Map();
+  function inner(ext, prec2) {
+    let known = seen.get(ext);
+    if (known != null) {
+      if (known <= prec2)
+        return;
+      let found = result[known].indexOf(ext);
+      if (found > -1)
+        result[known].splice(found, 1);
+      if (ext instanceof CompartmentInstance)
+        newCompartments.delete(ext.compartment);
+    }
+    seen.set(ext, prec2);
+    if (Array.isArray(ext)) {
+      for (let e of ext)
+        inner(e, prec2);
+    } else if (ext instanceof CompartmentInstance) {
+      if (newCompartments.has(ext.compartment))
+        throw new RangeError(`Duplicate use of compartment in extensions`);
+      let content2 = compartments.get(ext.compartment) || ext.inner;
+      newCompartments.set(ext.compartment, content2);
+      inner(content2, prec2);
+    } else if (ext instanceof PrecExtension) {
+      inner(ext.inner, ext.prec);
+    } else if (ext instanceof StateField) {
+      result[prec2].push(ext);
+      if (ext.provides)
+        inner(ext.provides, prec2);
+    } else if (ext instanceof FacetProvider) {
+      result[prec2].push(ext);
+      if (ext.facet.extensions)
+        inner(ext.facet.extensions, Prec_.default);
+    } else {
+      let content2 = ext.extension;
+      if (!content2)
+        throw new Error(`Unrecognized extension value in extension set (${ext}). This sometimes happens because multiple instances of @codemirror/state are loaded, breaking instanceof checks.`);
+      inner(content2, prec2);
+    }
+  }
+  inner(extension, Prec_.default);
+  return result.reduce((a, b) => a.concat(b));
+}
+function ensureAddr(state, addr) {
+  if (addr & 1)
+    return 2;
+  let idx = addr >> 1;
+  let status = state.status[idx];
+  if (status == 4)
+    throw new Error("Cyclic dependency between fields and/or facets");
+  if (status & 2)
+    return status;
+  state.status[idx] = 4;
+  let changed = state.computeSlot(state, state.config.dynamicSlots[idx]);
+  return state.status[idx] = 2 | changed;
+}
+function getAddr(state, addr) {
+  return addr & 1 ? state.config.staticValues[addr >> 1] : state.values[addr >> 1];
+}
+var languageData = /* @__PURE__ */ Facet.define();
+var allowMultipleSelections = /* @__PURE__ */ Facet.define({
+  combine: (values) => values.some((v) => v),
+  static: true
+});
+var lineSeparator = /* @__PURE__ */ Facet.define({
+  combine: (values) => values.length ? values[0] : void 0,
+  static: true
+});
+var changeFilter = /* @__PURE__ */ Facet.define();
+var transactionFilter = /* @__PURE__ */ Facet.define();
+var transactionExtender = /* @__PURE__ */ Facet.define();
+var readOnly = /* @__PURE__ */ Facet.define({
+  combine: (values) => values.length ? values[0] : false
+});
+var Annotation = class {
+  /**
+  @internal
+  */
+  constructor(type, value) {
+    this.type = type;
+    this.value = value;
+  }
+  /**
+  Define a new type of annotation.
+  */
+  static define() {
+    return new AnnotationType();
+  }
+};
+var AnnotationType = class {
+  /**
+  Create an instance of this annotation.
+  */
+  of(value) {
+    return new Annotation(this, value);
+  }
+};
+var StateEffectType = class {
+  /**
+  @internal
+  */
+  constructor(map) {
+    this.map = map;
+  }
+  /**
+  Create a [state effect](https://codemirror.net/6/docs/ref/#state.StateEffect) instance of this
+  type.
+  */
+  of(value) {
+    return new StateEffect(this, value);
+  }
+};
+var StateEffect = class _StateEffect {
+  /**
+  @internal
+  */
+  constructor(type, value) {
+    this.type = type;
+    this.value = value;
+  }
+  /**
+  Map this effect through a position mapping. Will return
+  `undefined` when that ends up deleting the effect.
+  */
+  map(mapping) {
+    let mapped = this.type.map(this.value, mapping);
+    return mapped === void 0 ? void 0 : mapped == this.value ? this : new _StateEffect(this.type, mapped);
+  }
+  /**
+  Tells you whether this effect object is of a given
+  [type](https://codemirror.net/6/docs/ref/#state.StateEffectType).
+  */
+  is(type) {
+    return this.type == type;
+  }
+  /**
+  Define a new effect type. The type parameter indicates the type
+  of values that his effect holds. It should be a type that
+  doesn't include `undefined`, since that is used in
+  [mapping](https://codemirror.net/6/docs/ref/#state.StateEffect.map) to indicate that an effect is
+  removed.
+  */
+  static define(spec = {}) {
+    return new StateEffectType(spec.map || ((v) => v));
+  }
+  /**
+  Map an array of effects through a change set.
+  */
+  static mapEffects(effects, mapping) {
+    if (!effects.length)
+      return effects;
+    let result = [];
+    for (let effect of effects) {
+      let mapped = effect.map(mapping);
+      if (mapped)
+        result.push(mapped);
+    }
+    return result;
+  }
+};
+StateEffect.reconfigure = /* @__PURE__ */ StateEffect.define();
+StateEffect.appendConfig = /* @__PURE__ */ StateEffect.define();
+var Transaction = class _Transaction {
+  constructor(startState, changes, selection, effects, annotations, scrollIntoView2) {
+    this.startState = startState;
+    this.changes = changes;
+    this.selection = selection;
+    this.effects = effects;
+    this.annotations = annotations;
+    this.scrollIntoView = scrollIntoView2;
+    this._doc = null;
+    this._state = null;
+    if (selection)
+      checkSelection(selection, changes.newLength);
+    if (!annotations.some((a) => a.type == _Transaction.time))
+      this.annotations = annotations.concat(_Transaction.time.of(Date.now()));
+  }
+  /**
+  @internal
+  */
+  static create(startState, changes, selection, effects, annotations, scrollIntoView2) {
+    return new _Transaction(startState, changes, selection, effects, annotations, scrollIntoView2);
+  }
+  /**
+  The new document produced by the transaction. Contrary to
+  [`.state`](https://codemirror.net/6/docs/ref/#state.Transaction.state)`.doc`, accessing this won't
+  force the entire new state to be computed right away, so it is
+  recommended that [transaction
+  filters](https://codemirror.net/6/docs/ref/#state.EditorState^transactionFilter) use this getter
+  when they need to look at the new document.
+  */
+  get newDoc() {
+    return this._doc || (this._doc = this.changes.apply(this.startState.doc));
+  }
+  /**
+  The new selection produced by the transaction. If
+  [`this.selection`](https://codemirror.net/6/docs/ref/#state.Transaction.selection) is undefined,
+  this will [map](https://codemirror.net/6/docs/ref/#state.EditorSelection.map) the start state's
+  current selection through the changes made by the transaction.
+  */
+  get newSelection() {
+    return this.selection || this.startState.selection.map(this.changes);
+  }
+  /**
+  The new state created by the transaction. Computed on demand
+  (but retained for subsequent access), so it is recommended not to
+  access it in [transaction
+  filters](https://codemirror.net/6/docs/ref/#state.EditorState^transactionFilter) when possible.
+  */
+  get state() {
+    if (!this._state)
+      this.startState.applyTransaction(this);
+    return this._state;
+  }
+  /**
+  Get the value of the given annotation type, if any.
+  */
+  annotation(type) {
+    for (let ann of this.annotations)
+      if (ann.type == type)
+        return ann.value;
+    return void 0;
+  }
+  /**
+  Indicates whether the transaction changed the document.
+  */
+  get docChanged() {
+    return !this.changes.empty;
+  }
+  /**
+  Indicates whether this transaction reconfigures the state
+  (through a [configuration compartment](https://codemirror.net/6/docs/ref/#state.Compartment) or
+  with a top-level configuration
+  [effect](https://codemirror.net/6/docs/ref/#state.StateEffect^reconfigure).
+  */
+  get reconfigured() {
+    return this.startState.config != this.state.config;
+  }
+  /**
+  Returns true if the transaction has a [user
+  event](https://codemirror.net/6/docs/ref/#state.Transaction^userEvent) annotation that is equal to
+  or more specific than `event`. For example, if the transaction
+  has `"select.pointer"` as user event, `"select"` and
+  `"select.pointer"` will match it.
+  */
+  isUserEvent(event) {
+    let e = this.annotation(_Transaction.userEvent);
+    return !!(e && (e == event || e.length > event.length && e.slice(0, event.length) == event && e[event.length] == "."));
+  }
+};
+Transaction.time = /* @__PURE__ */ Annotation.define();
+Transaction.userEvent = /* @__PURE__ */ Annotation.define();
+Transaction.addToHistory = /* @__PURE__ */ Annotation.define();
+Transaction.remote = /* @__PURE__ */ Annotation.define();
+function joinRanges(a, b) {
+  let result = [];
+  for (let iA = 0, iB = 0; ; ) {
+    let from, to;
+    if (iA < a.length && (iB == b.length || b[iB] >= a[iA])) {
+      from = a[iA++];
+      to = a[iA++];
+    } else if (iB < b.length) {
+      from = b[iB++];
+      to = b[iB++];
+    } else
+      return result;
+    if (!result.length || result[result.length - 1] < from)
+      result.push(from, to);
+    else if (result[result.length - 1] < to)
+      result[result.length - 1] = to;
+  }
+}
+function mergeTransaction(a, b, sequential) {
+  var _a2;
+  let mapForA, mapForB, changes;
+  if (sequential) {
+    mapForA = b.changes;
+    mapForB = ChangeSet.empty(b.changes.length);
+    changes = a.changes.compose(b.changes);
+  } else {
+    mapForA = b.changes.map(a.changes);
+    mapForB = a.changes.mapDesc(b.changes, true);
+    changes = a.changes.compose(mapForA);
+  }
+  return {
+    changes,
+    selection: b.selection ? b.selection.map(mapForB) : (_a2 = a.selection) === null || _a2 === void 0 ? void 0 : _a2.map(mapForA),
+    effects: StateEffect.mapEffects(a.effects, mapForA).concat(StateEffect.mapEffects(b.effects, mapForB)),
+    annotations: a.annotations.length ? a.annotations.concat(b.annotations) : b.annotations,
+    scrollIntoView: a.scrollIntoView || b.scrollIntoView
+  };
+}
+function resolveTransactionInner(state, spec, docSize) {
+  let sel = spec.selection, annotations = asArray(spec.annotations);
+  if (spec.userEvent)
+    annotations = annotations.concat(Transaction.userEvent.of(spec.userEvent));
+  return {
+    changes: spec.changes instanceof ChangeSet ? spec.changes : ChangeSet.of(spec.changes || [], docSize, state.facet(lineSeparator)),
+    selection: sel && (sel instanceof EditorSelection ? sel : EditorSelection.single(sel.anchor, sel.head)),
+    effects: asArray(spec.effects),
+    annotations,
+    scrollIntoView: !!spec.scrollIntoView
+  };
+}
+function resolveTransaction(state, specs, filter) {
+  let s = resolveTransactionInner(state, specs.length ? specs[0] : {}, state.doc.length);
+  if (specs.length && specs[0].filter === false)
+    filter = false;
+  for (let i2 = 1; i2 < specs.length; i2++) {
+    if (specs[i2].filter === false)
+      filter = false;
+    let seq = !!specs[i2].sequential;
+    s = mergeTransaction(s, resolveTransactionInner(state, specs[i2], seq ? s.changes.newLength : state.doc.length), seq);
+  }
+  let tr = Transaction.create(state, s.changes, s.selection, s.effects, s.annotations, s.scrollIntoView);
+  return extendTransaction(filter ? filterTransaction(tr) : tr);
+}
+function filterTransaction(tr) {
+  let state = tr.startState;
+  let result = true;
+  for (let filter of state.facet(changeFilter)) {
+    let value = filter(tr);
+    if (value === false) {
+      result = false;
+      break;
+    }
+    if (Array.isArray(value))
+      result = result === true ? value : joinRanges(result, value);
+  }
+  if (result !== true) {
+    let changes, back;
+    if (result === false) {
+      back = tr.changes.invertedDesc;
+      changes = ChangeSet.empty(state.doc.length);
+    } else {
+      let filtered = tr.changes.filter(result);
+      changes = filtered.changes;
+      back = filtered.filtered.mapDesc(filtered.changes).invertedDesc;
+    }
+    tr = Transaction.create(state, changes, tr.selection && tr.selection.map(back), StateEffect.mapEffects(tr.effects, back), tr.annotations, tr.scrollIntoView);
+  }
+  let filters = state.facet(transactionFilter);
+  for (let i2 = filters.length - 1; i2 >= 0; i2--) {
+    let filtered = filters[i2](tr);
+    if (filtered instanceof Transaction)
+      tr = filtered;
+    else if (Array.isArray(filtered) && filtered.length == 1 && filtered[0] instanceof Transaction)
+      tr = filtered[0];
+    else
+      tr = resolveTransaction(state, asArray(filtered), false);
+  }
+  return tr;
+}
+function extendTransaction(tr) {
+  let state = tr.startState, extenders = state.facet(transactionExtender), spec = tr;
+  for (let i2 = extenders.length - 1; i2 >= 0; i2--) {
+    let extension = extenders[i2](tr);
+    if (extension && Object.keys(extension).length)
+      spec = mergeTransaction(spec, resolveTransactionInner(state, extension, tr.changes.newLength), true);
+  }
+  return spec == tr ? tr : Transaction.create(state, tr.changes, tr.selection, spec.effects, spec.annotations, spec.scrollIntoView);
+}
+var none = [];
+function asArray(value) {
+  return value == null ? none : Array.isArray(value) ? value : [value];
+}
+var CharCategory = /* @__PURE__ */ (function(CharCategory2) {
+  CharCategory2[CharCategory2["Word"] = 0] = "Word";
+  CharCategory2[CharCategory2["Space"] = 1] = "Space";
+  CharCategory2[CharCategory2["Other"] = 2] = "Other";
+  return CharCategory2;
+})(CharCategory || (CharCategory = {}));
+var nonASCIISingleCaseWordChar = /[\u00df\u0587\u0590-\u05f4\u0600-\u06ff\u3040-\u309f\u30a0-\u30ff\u3400-\u4db5\u4e00-\u9fcc\uac00-\ud7af]/;
+var wordChar;
+try {
+  wordChar = /* @__PURE__ */ new RegExp("[\\p{Alphabetic}\\p{Number}_]", "u");
+} catch (_) {
+}
+function hasWordChar(str) {
+  if (wordChar)
+    return wordChar.test(str);
+  for (let i2 = 0; i2 < str.length; i2++) {
+    let ch = str[i2];
+    if (/\w/.test(ch) || ch > "\x80" && (ch.toUpperCase() != ch.toLowerCase() || nonASCIISingleCaseWordChar.test(ch)))
+      return true;
+  }
+  return false;
+}
+function makeCategorizer(wordChars) {
+  return (char) => {
+    if (!/\S/.test(char))
+      return CharCategory.Space;
+    if (hasWordChar(char))
+      return CharCategory.Word;
+    for (let i2 = 0; i2 < wordChars.length; i2++)
+      if (char.indexOf(wordChars[i2]) > -1)
+        return CharCategory.Word;
+    return CharCategory.Other;
+  };
+}
+var EditorState = class _EditorState {
+  constructor(config, doc2, selection, values, computeSlot, tr) {
+    this.config = config;
+    this.doc = doc2;
+    this.selection = selection;
+    this.values = values;
+    this.status = config.statusTemplate.slice();
+    this.computeSlot = computeSlot;
+    if (tr)
+      tr._state = this;
+    for (let i2 = 0; i2 < this.config.dynamicSlots.length; i2++)
+      ensureAddr(this, i2 << 1);
+    this.computeSlot = null;
+  }
+  field(field, require2 = true) {
+    let addr = this.config.address[field.id];
+    if (addr == null) {
+      if (require2)
+        throw new RangeError("Field is not present in this state");
+      return void 0;
+    }
+    ensureAddr(this, addr);
+    return getAddr(this, addr);
+  }
+  /**
+  Create a [transaction](https://codemirror.net/6/docs/ref/#state.Transaction) that updates this
+  state. Any number of [transaction specs](https://codemirror.net/6/docs/ref/#state.TransactionSpec)
+  can be passed. Unless
+  [`sequential`](https://codemirror.net/6/docs/ref/#state.TransactionSpec.sequential) is set, the
+  [changes](https://codemirror.net/6/docs/ref/#state.TransactionSpec.changes) (if any) of each spec
+  are assumed to start in the _current_ document (not the document
+  produced by previous specs), and its
+  [selection](https://codemirror.net/6/docs/ref/#state.TransactionSpec.selection) and
+  [effects](https://codemirror.net/6/docs/ref/#state.TransactionSpec.effects) are assumed to refer
+  to the document created by its _own_ changes. The resulting
+  transaction contains the combined effect of all the different
+  specs. For [selection](https://codemirror.net/6/docs/ref/#state.TransactionSpec.selection), later
+  specs take precedence over earlier ones.
+  */
+  update(...specs) {
+    return resolveTransaction(this, specs, true);
+  }
+  /**
+  @internal
+  */
+  applyTransaction(tr) {
+    let conf = this.config, { base: base2, compartments } = conf;
+    for (let effect of tr.effects) {
+      if (effect.is(Compartment.reconfigure)) {
+        if (conf) {
+          compartments = /* @__PURE__ */ new Map();
+          conf.compartments.forEach((val, key) => compartments.set(key, val));
+          conf = null;
+        }
+        compartments.set(effect.value.compartment, effect.value.extension);
+      } else if (effect.is(StateEffect.reconfigure)) {
+        conf = null;
+        base2 = effect.value;
+      } else if (effect.is(StateEffect.appendConfig)) {
+        conf = null;
+        base2 = asArray(base2).concat(effect.value);
+      }
+    }
+    let startValues;
+    if (!conf) {
+      conf = Configuration.resolve(base2, compartments, this);
+      let intermediateState = new _EditorState(conf, this.doc, this.selection, conf.dynamicSlots.map(() => null), (state, slot) => slot.reconfigure(state, this), null);
+      startValues = intermediateState.values;
+    } else {
+      startValues = tr.startState.values.slice();
+    }
+    let selection = tr.startState.facet(allowMultipleSelections) ? tr.newSelection : tr.newSelection.asSingle();
+    new _EditorState(conf, tr.newDoc, selection, startValues, (state, slot) => slot.update(state, tr), tr);
+  }
+  /**
+  Create a [transaction spec](https://codemirror.net/6/docs/ref/#state.TransactionSpec) that
+  replaces every selection range with the given content.
+  */
+  replaceSelection(text) {
+    if (typeof text == "string")
+      text = this.toText(text);
+    return this.changeByRange((range) => ({
+      changes: { from: range.from, to: range.to, insert: text },
+      range: EditorSelection.cursor(range.from + text.length)
+    }));
+  }
+  /**
+  Create a set of changes and a new selection by running the given
+  function for each range in the active selection. The function
+  can return an optional set of changes (in the coordinate space
+  of the start document), plus an updated range (in the coordinate
+  space of the document produced by the call's own changes). This
+  method will merge all the changes and ranges into a single
+  changeset and selection, and return it as a [transaction
+  spec](https://codemirror.net/6/docs/ref/#state.TransactionSpec), which can be passed to
+  [`update`](https://codemirror.net/6/docs/ref/#state.EditorState.update).
+  */
+  changeByRange(f) {
+    let sel = this.selection;
+    let result1 = f(sel.ranges[0]);
+    let changes = this.changes(result1.changes), ranges = [result1.range];
+    let effects = asArray(result1.effects);
+    for (let i2 = 1; i2 < sel.ranges.length; i2++) {
+      let result = f(sel.ranges[i2]);
+      let newChanges = this.changes(result.changes), newMapped = newChanges.map(changes);
+      for (let j = 0; j < i2; j++)
+        ranges[j] = ranges[j].map(newMapped);
+      let mapBy = changes.mapDesc(newChanges, true);
+      ranges.push(result.range.map(mapBy));
+      changes = changes.compose(newMapped);
+      effects = StateEffect.mapEffects(effects, newMapped).concat(StateEffect.mapEffects(asArray(result.effects), mapBy));
+    }
+    return {
+      changes,
+      selection: EditorSelection.create(ranges, sel.mainIndex),
+      effects
+    };
+  }
+  /**
+  Create a [change set](https://codemirror.net/6/docs/ref/#state.ChangeSet) from the given change
+  description, taking the state's document length and line
+  separator into account.
+  */
+  changes(spec = []) {
+    if (spec instanceof ChangeSet)
+      return spec;
+    return ChangeSet.of(spec, this.doc.length, this.facet(_EditorState.lineSeparator));
+  }
+  /**
+  Using the state's [line
+  separator](https://codemirror.net/6/docs/ref/#state.EditorState^lineSeparator), create a
+  [`Text`](https://codemirror.net/6/docs/ref/#state.Text) instance from the given string.
+  */
+  toText(string2) {
+    return Text.of(string2.split(this.facet(_EditorState.lineSeparator) || DefaultSplit));
+  }
+  /**
+  Return the given range of the document as a string.
+  */
+  sliceDoc(from = 0, to = this.doc.length) {
+    return this.doc.sliceString(from, to, this.lineBreak);
+  }
+  /**
+  Get the value of a state [facet](https://codemirror.net/6/docs/ref/#state.Facet).
+  */
+  facet(facet) {
+    let addr = this.config.address[facet.id];
+    if (addr == null)
+      return facet.default;
+    ensureAddr(this, addr);
+    return getAddr(this, addr);
+  }
+  /**
+  Convert this state to a JSON-serializable object. When custom
+  fields should be serialized, you can pass them in as an object
+  mapping property names (in the resulting object, which should
+  not use `doc` or `selection`) to fields.
+  */
+  toJSON(fields) {
+    let result = {
+      doc: this.sliceDoc(),
+      selection: this.selection.toJSON()
+    };
+    if (fields)
+      for (let prop in fields) {
+        let value = fields[prop];
+        if (value instanceof StateField && this.config.address[value.id] != null)
+          result[prop] = value.spec.toJSON(this.field(fields[prop]), this);
+      }
+    return result;
+  }
+  /**
+  Deserialize a state from its JSON representation. When custom
+  fields should be deserialized, pass the same object you passed
+  to [`toJSON`](https://codemirror.net/6/docs/ref/#state.EditorState.toJSON) when serializing as
+  third argument.
+  */
+  static fromJSON(json, config = {}, fields) {
+    if (!json || typeof json.doc != "string")
+      throw new RangeError("Invalid JSON representation for EditorState");
+    let fieldInit = [];
+    if (fields)
+      for (let prop in fields) {
+        if (Object.prototype.hasOwnProperty.call(json, prop)) {
+          let field = fields[prop], value = json[prop];
+          fieldInit.push(field.init((state) => field.spec.fromJSON(value, state)));
+        }
+      }
+    return _EditorState.create({
+      doc: json.doc,
+      selection: EditorSelection.fromJSON(json.selection),
+      extensions: config.extensions ? fieldInit.concat([config.extensions]) : fieldInit
+    });
+  }
+  /**
+  Create a new state. You'll usually only need this when
+  initializing an editor—updated states are created by applying
+  transactions.
+  */
+  static create(config = {}) {
+    let configuration = Configuration.resolve(config.extensions || [], /* @__PURE__ */ new Map());
+    let doc2 = config.doc instanceof Text ? config.doc : Text.of((config.doc || "").split(configuration.staticFacet(_EditorState.lineSeparator) || DefaultSplit));
+    let selection = !config.selection ? EditorSelection.single(0) : config.selection instanceof EditorSelection ? config.selection : EditorSelection.single(config.selection.anchor, config.selection.head);
+    checkSelection(selection, doc2.length);
+    if (!configuration.staticFacet(allowMultipleSelections))
+      selection = selection.asSingle();
+    return new _EditorState(configuration, doc2, selection, configuration.dynamicSlots.map(() => null), (state, slot) => slot.create(state), null);
+  }
+  /**
+  The size (in columns) of a tab in the document, determined by
+  the [`tabSize`](https://codemirror.net/6/docs/ref/#state.EditorState^tabSize) facet.
+  */
+  get tabSize() {
+    return this.facet(_EditorState.tabSize);
+  }
+  /**
+  Get the proper [line-break](https://codemirror.net/6/docs/ref/#state.EditorState^lineSeparator)
+  string for this state.
+  */
+  get lineBreak() {
+    return this.facet(_EditorState.lineSeparator) || "\n";
+  }
+  /**
+  Returns true when the editor is
+  [configured](https://codemirror.net/6/docs/ref/#state.EditorState^readOnly) to be read-only.
+  */
+  get readOnly() {
+    return this.facet(readOnly);
+  }
+  /**
+  Look up a translation for the given phrase (via the
+  [`phrases`](https://codemirror.net/6/docs/ref/#state.EditorState^phrases) facet), or return the
+  original string if no translation is found.
+  
+  If additional arguments are passed, they will be inserted in
+  place of markers like `$1` (for the first value) and `$2`, etc.
+  A single `$` is equivalent to `$1`, and `$$` will produce a
+  literal dollar sign.
+  */
+  phrase(phrase, ...insert2) {
+    for (let map of this.facet(_EditorState.phrases))
+      if (Object.prototype.hasOwnProperty.call(map, phrase)) {
+        phrase = map[phrase];
+        break;
+      }
+    if (insert2.length)
+      phrase = phrase.replace(/\$(\$|\d*)/g, (m, i2) => {
+        if (i2 == "$")
+          return "$";
+        let n = +(i2 || 1);
+        return !n || n > insert2.length ? m : insert2[n - 1];
+      });
+    return phrase;
+  }
+  /**
+  Find the values for a given language data field, provided by the
+  the [`languageData`](https://codemirror.net/6/docs/ref/#state.EditorState^languageData) facet.
+  
+  Examples of language data fields are...
+  
+  - [`"commentTokens"`](https://codemirror.net/6/docs/ref/#commands.CommentTokens) for specifying
+    comment syntax.
+  - [`"autocomplete"`](https://codemirror.net/6/docs/ref/#autocomplete.autocompletion^config.override)
+    for providing language-specific completion sources.
+  - [`"wordChars"`](https://codemirror.net/6/docs/ref/#state.EditorState.charCategorizer) for adding
+    characters that should be considered part of words in this
+    language.
+  - [`"closeBrackets"`](https://codemirror.net/6/docs/ref/#autocomplete.CloseBracketConfig) controls
+    bracket closing behavior.
+  */
+  languageDataAt(name2, pos, side = -1) {
+    let values = [];
+    for (let provider of this.facet(languageData)) {
+      for (let result of provider(this, pos, side)) {
+        if (Object.prototype.hasOwnProperty.call(result, name2))
+          values.push(result[name2]);
+      }
+    }
+    return values;
+  }
+  /**
+  Return a function that can categorize strings (expected to
+  represent a single [grapheme cluster](https://codemirror.net/6/docs/ref/#state.findClusterBreak))
+  into one of:
+  
+   - Word (contains an alphanumeric character or a character
+     explicitly listed in the local language's `"wordChars"`
+     language data, which should be a string)
+   - Space (contains only whitespace)
+   - Other (anything else)
+  */
+  charCategorizer(at) {
+    let chars = this.languageDataAt("wordChars", at);
+    return makeCategorizer(chars.length ? chars[0] : "");
+  }
+  /**
+  Find the word at the given position, meaning the range
+  containing all [word](https://codemirror.net/6/docs/ref/#state.CharCategory.Word) characters
+  around it. If no word characters are adjacent to the position,
+  this returns null.
+  */
+  wordAt(pos) {
+    let { text, from, length } = this.doc.lineAt(pos);
+    let cat = this.charCategorizer(pos);
+    let start = pos - from, end = pos - from;
+    while (start > 0) {
+      let prev = findClusterBreak2(text, start, false);
+      if (cat(text.slice(prev, start)) != CharCategory.Word)
+        break;
+      start = prev;
+    }
+    while (end < length) {
+      let next = findClusterBreak2(text, end);
+      if (cat(text.slice(end, next)) != CharCategory.Word)
+        break;
+      end = next;
+    }
+    return start == end ? null : EditorSelection.range(start + from, end + from);
+  }
+};
+EditorState.allowMultipleSelections = allowMultipleSelections;
+EditorState.tabSize = /* @__PURE__ */ Facet.define({
+  combine: (values) => values.length ? values[0] : 4
+});
+EditorState.lineSeparator = lineSeparator;
+EditorState.readOnly = readOnly;
+EditorState.phrases = /* @__PURE__ */ Facet.define({
+  compare(a, b) {
+    let kA = Object.keys(a), kB = Object.keys(b);
+    return kA.length == kB.length && kA.every((k) => a[k] == b[k]);
+  }
+});
+EditorState.languageData = languageData;
+EditorState.changeFilter = changeFilter;
+EditorState.transactionFilter = transactionFilter;
+EditorState.transactionExtender = transactionExtender;
+Compartment.reconfigure = /* @__PURE__ */ StateEffect.define();
+function combineConfig(configs, defaults, combine = {}) {
+  let result = {};
+  for (let config of configs)
+    for (let key of Object.keys(config)) {
+      let value = config[key], current = result[key];
+      if (current === void 0)
+        result[key] = value;
+      else if (current === value || value === void 0) ;
+      else if (Object.hasOwnProperty.call(combine, key))
+        result[key] = combine[key](current, value);
+      else
+        throw new Error("Config merge conflict for field " + key);
+    }
+  for (let key in defaults)
+    if (result[key] === void 0)
+      result[key] = defaults[key];
+  return result;
+}
+var RangeValue = class {
+  /**
+  Compare this value with another value. Used when comparing
+  rangesets. The default implementation compares by identity.
+  Unless you are only creating a fixed number of unique instances
+  of your value type, it is a good idea to implement this
+  properly.
+  */
+  eq(other) {
+    return this == other;
+  }
+  /**
+  Create a [range](https://codemirror.net/6/docs/ref/#state.Range) with this value.
+  */
+  range(from, to = from) {
+    return Range.create(from, to, this);
+  }
+};
+RangeValue.prototype.startSide = RangeValue.prototype.endSide = 0;
+RangeValue.prototype.point = false;
+RangeValue.prototype.mapMode = MapMode.TrackDel;
+function cmpVal(a, b) {
+  return a == b || a.constructor == b.constructor && a.eq(b);
+}
+var Range = class _Range {
+  constructor(from, to, value) {
+    this.from = from;
+    this.to = to;
+    this.value = value;
+  }
+  /**
+  @internal
+  */
+  static create(from, to, value) {
+    return new _Range(from, to, value);
+  }
+};
+function cmpRange(a, b) {
+  return a.from - b.from || a.value.startSide - b.value.startSide;
+}
+var Chunk = class _Chunk {
+  constructor(from, to, value, maxPoint) {
+    this.from = from;
+    this.to = to;
+    this.value = value;
+    this.maxPoint = maxPoint;
+  }
+  get length() {
+    return this.to[this.to.length - 1];
+  }
+  // Find the index of the given position and side. Use the ranges'
+  // `from` pos when `end == false`, `to` when `end == true`.
+  findIndex(pos, side, end, startAt = 0) {
+    let arr = end ? this.to : this.from;
+    for (let lo = startAt, hi = arr.length; ; ) {
+      if (lo == hi)
+        return lo;
+      let mid = lo + hi >> 1;
+      let diff = arr[mid] - pos || (end ? this.value[mid].endSide : this.value[mid].startSide) - side;
+      if (mid == lo)
+        return diff >= 0 ? lo : hi;
+      if (diff >= 0)
+        hi = mid;
+      else
+        lo = mid + 1;
+    }
+  }
+  between(offset, from, to, f) {
+    for (let i2 = this.findIndex(from, -1e9, true), e = this.findIndex(to, 1e9, false, i2); i2 < e; i2++)
+      if (f(this.from[i2] + offset, this.to[i2] + offset, this.value[i2]) === false)
+        return false;
+  }
+  map(offset, changes) {
+    let value = [], from = [], to = [], newPos = -1, maxPoint = -1;
+    for (let i2 = 0; i2 < this.value.length; i2++) {
+      let val = this.value[i2], curFrom = this.from[i2] + offset, curTo = this.to[i2] + offset, newFrom, newTo;
+      if (curFrom == curTo) {
+        let mapped = changes.mapPos(curFrom, val.startSide, val.mapMode);
+        if (mapped == null)
+          continue;
+        newFrom = newTo = mapped;
+        if (val.startSide != val.endSide) {
+          newTo = changes.mapPos(curFrom, val.endSide);
+          if (newTo < newFrom)
+            continue;
+        }
+      } else {
+        newFrom = changes.mapPos(curFrom, val.startSide);
+        newTo = changes.mapPos(curTo, val.endSide);
+        if (newFrom > newTo || newFrom == newTo && val.startSide > 0 && val.endSide <= 0)
+          continue;
+      }
+      if ((newTo - newFrom || val.endSide - val.startSide) < 0)
+        continue;
+      if (newPos < 0)
+        newPos = newFrom;
+      if (val.point)
+        maxPoint = Math.max(maxPoint, newTo - newFrom);
+      value.push(val);
+      from.push(newFrom - newPos);
+      to.push(newTo - newPos);
+    }
+    return { mapped: value.length ? new _Chunk(from, to, value, maxPoint) : null, pos: newPos };
+  }
+};
+var RangeSet = class _RangeSet {
+  constructor(chunkPos, chunk, nextLayer, maxPoint) {
+    this.chunkPos = chunkPos;
+    this.chunk = chunk;
+    this.nextLayer = nextLayer;
+    this.maxPoint = maxPoint;
+  }
+  /**
+  @internal
+  */
+  static create(chunkPos, chunk, nextLayer, maxPoint) {
+    return new _RangeSet(chunkPos, chunk, nextLayer, maxPoint);
+  }
+  /**
+  @internal
+  */
+  get length() {
+    let last = this.chunk.length - 1;
+    return last < 0 ? 0 : Math.max(this.chunkEnd(last), this.nextLayer.length);
+  }
+  /**
+  The number of ranges in the set.
+  */
+  get size() {
+    if (this.isEmpty)
+      return 0;
+    let size = this.nextLayer.size;
+    for (let chunk of this.chunk)
+      size += chunk.value.length;
+    return size;
+  }
+  /**
+  @internal
+  */
+  chunkEnd(index) {
+    return this.chunkPos[index] + this.chunk[index].length;
+  }
+  /**
+  Update the range set, optionally adding new ranges or filtering
+  out existing ones.
+  
+  (Note: The type parameter is just there as a kludge to work
+  around TypeScript variance issues that prevented `RangeSet<X>`
+  from being a subtype of `RangeSet<Y>` when `X` is a subtype of
+  `Y`.)
+  */
+  update(updateSpec) {
+    let { add = [], sort = false, filterFrom = 0, filterTo = this.length } = updateSpec;
+    let filter = updateSpec.filter;
+    if (add.length == 0 && !filter)
+      return this;
+    if (sort)
+      add = add.slice().sort(cmpRange);
+    if (this.isEmpty)
+      return add.length ? _RangeSet.of(add) : this;
+    let cur = new LayerCursor(this, null, -1).goto(0), i2 = 0, spill = [];
+    let builder = new RangeSetBuilder();
+    while (cur.value || i2 < add.length) {
+      if (i2 < add.length && (cur.from - add[i2].from || cur.startSide - add[i2].value.startSide) >= 0) {
+        let range = add[i2++];
+        if (!builder.addInner(range.from, range.to, range.value))
+          spill.push(range);
+      } else if (cur.rangeIndex == 1 && cur.chunkIndex < this.chunk.length && (i2 == add.length || this.chunkEnd(cur.chunkIndex) < add[i2].from) && (!filter || filterFrom > this.chunkEnd(cur.chunkIndex) || filterTo < this.chunkPos[cur.chunkIndex]) && builder.addChunk(this.chunkPos[cur.chunkIndex], this.chunk[cur.chunkIndex])) {
+        cur.nextChunk();
+      } else {
+        if (!filter || filterFrom > cur.to || filterTo < cur.from || filter(cur.from, cur.to, cur.value)) {
+          if (!builder.addInner(cur.from, cur.to, cur.value))
+            spill.push(Range.create(cur.from, cur.to, cur.value));
+        }
+        cur.next();
+      }
+    }
+    return builder.finishInner(this.nextLayer.isEmpty && !spill.length ? _RangeSet.empty : this.nextLayer.update({ add: spill, filter, filterFrom, filterTo }));
+  }
+  /**
+  Map this range set through a set of changes, return the new set.
+  */
+  map(changes) {
+    if (changes.empty || this.isEmpty)
+      return this;
+    let chunks = [], chunkPos = [], maxPoint = -1;
+    for (let i2 = 0; i2 < this.chunk.length; i2++) {
+      let start = this.chunkPos[i2], chunk = this.chunk[i2];
+      let touch = changes.touchesRange(start, start + chunk.length);
+      if (touch === false) {
+        maxPoint = Math.max(maxPoint, chunk.maxPoint);
+        chunks.push(chunk);
+        chunkPos.push(changes.mapPos(start));
+      } else if (touch === true) {
+        let { mapped, pos } = chunk.map(start, changes);
+        if (mapped) {
+          maxPoint = Math.max(maxPoint, mapped.maxPoint);
+          chunks.push(mapped);
+          chunkPos.push(pos);
+        }
+      }
+    }
+    let next = this.nextLayer.map(changes);
+    return chunks.length == 0 ? next : new _RangeSet(chunkPos, chunks, next || _RangeSet.empty, maxPoint);
+  }
+  /**
+  Iterate over the ranges that touch the region `from` to `to`,
+  calling `f` for each. There is no guarantee that the ranges will
+  be reported in any specific order. When the callback returns
+  `false`, iteration stops.
+  */
+  between(from, to, f) {
+    if (this.isEmpty)
+      return;
+    for (let i2 = 0; i2 < this.chunk.length; i2++) {
+      let start = this.chunkPos[i2], chunk = this.chunk[i2];
+      if (to >= start && from <= start + chunk.length && chunk.between(start, from - start, to - start, f) === false)
+        return;
+    }
+    this.nextLayer.between(from, to, f);
+  }
+  /**
+  Iterate over the ranges in this set, in order, including all
+  ranges that end at or after `from`.
+  */
+  iter(from = 0) {
+    return HeapCursor.from([this]).goto(from);
+  }
+  /**
+  @internal
+  */
+  get isEmpty() {
+    return this.nextLayer == this;
+  }
+  /**
+  Iterate over the ranges in a collection of sets, in order,
+  starting from `from`.
+  */
+  static iter(sets, from = 0) {
+    return HeapCursor.from(sets).goto(from);
+  }
+  /**
+  Iterate over two groups of sets, calling methods on `comparator`
+  to notify it of possible differences.
+  */
+  static compare(oldSets, newSets, textDiff, comparator, minPointSize = -1) {
+    let a = oldSets.filter((set) => set.maxPoint > 0 || !set.isEmpty && set.maxPoint >= minPointSize);
+    let b = newSets.filter((set) => set.maxPoint > 0 || !set.isEmpty && set.maxPoint >= minPointSize);
+    let sharedChunks = findSharedChunks(a, b, textDiff);
+    let sideA = new SpanCursor(a, sharedChunks, minPointSize);
+    let sideB = new SpanCursor(b, sharedChunks, minPointSize);
+    textDiff.iterGaps((fromA, fromB, length) => compare(sideA, fromA, sideB, fromB, length, comparator));
+    if (textDiff.empty && textDiff.length == 0)
+      compare(sideA, 0, sideB, 0, 0, comparator);
+  }
+  /**
+  Compare the contents of two groups of range sets, returning true
+  if they are equivalent in the given range.
+  */
+  static eq(oldSets, newSets, from = 0, to) {
+    if (to == null)
+      to = 1e9 - 1;
+    let a = oldSets.filter((set) => !set.isEmpty && newSets.indexOf(set) < 0);
+    let b = newSets.filter((set) => !set.isEmpty && oldSets.indexOf(set) < 0);
+    if (a.length != b.length)
+      return false;
+    if (!a.length)
+      return true;
+    let sharedChunks = findSharedChunks(a, b);
+    let sideA = new SpanCursor(a, sharedChunks, 0).goto(from), sideB = new SpanCursor(b, sharedChunks, 0).goto(from);
+    for (; ; ) {
+      if (sideA.to != sideB.to || !sameValues(sideA.active, sideB.active) || sideA.point && (!sideB.point || !cmpVal(sideA.point, sideB.point)))
+        return false;
+      if (sideA.to > to)
+        return true;
+      sideA.next();
+      sideB.next();
+    }
+  }
+  /**
+  Iterate over a group of range sets at the same time, notifying
+  the iterator about the ranges covering every given piece of
+  content. Returns the open count (see
+  [`SpanIterator.span`](https://codemirror.net/6/docs/ref/#state.SpanIterator.span)) at the end
+  of the iteration.
+  */
+  static spans(sets, from, to, iterator, minPointSize = -1) {
+    let cursor = new SpanCursor(sets, null, minPointSize).goto(from), pos = from;
+    let openRanges = cursor.openStart;
+    for (; ; ) {
+      let curTo = Math.min(cursor.to, to);
+      if (cursor.point) {
+        let active = cursor.activeForPoint(cursor.to);
+        let openCount = cursor.pointFrom < from ? active.length + 1 : cursor.point.startSide < 0 ? active.length : Math.min(active.length, openRanges);
+        iterator.point(pos, curTo, cursor.point, active, openCount, cursor.pointRank);
+        openRanges = Math.min(cursor.openEnd(curTo), active.length);
+      } else if (curTo > pos) {
+        iterator.span(pos, curTo, cursor.active, openRanges);
+        openRanges = cursor.openEnd(curTo);
+      }
+      if (cursor.to > to)
+        return openRanges + (cursor.point && cursor.to > to ? 1 : 0);
+      pos = cursor.to;
+      cursor.next();
+    }
+  }
+  /**
+  Create a range set for the given range or array of ranges. By
+  default, this expects the ranges to be _sorted_ (by start
+  position and, if two start at the same position,
+  `value.startSide`). You can pass `true` as second argument to
+  cause the method to sort them.
+  */
+  static of(ranges, sort = false) {
+    let build = new RangeSetBuilder();
+    for (let range of ranges instanceof Range ? [ranges] : sort ? lazySort(ranges) : ranges)
+      build.add(range.from, range.to, range.value);
+    return build.finish();
+  }
+  /**
+  Join an array of range sets into a single set.
+  */
+  static join(sets) {
+    if (!sets.length)
+      return _RangeSet.empty;
+    let result = sets[sets.length - 1];
+    for (let i2 = sets.length - 2; i2 >= 0; i2--) {
+      for (let layer = sets[i2]; layer != _RangeSet.empty; layer = layer.nextLayer)
+        result = new _RangeSet(layer.chunkPos, layer.chunk, result, Math.max(layer.maxPoint, result.maxPoint));
+    }
+    return result;
+  }
+};
+RangeSet.empty = /* @__PURE__ */ new RangeSet([], [], null, -1);
+function lazySort(ranges) {
+  if (ranges.length > 1)
+    for (let prev = ranges[0], i2 = 1; i2 < ranges.length; i2++) {
+      let cur = ranges[i2];
+      if (cmpRange(prev, cur) > 0)
+        return ranges.slice().sort(cmpRange);
+      prev = cur;
+    }
+  return ranges;
+}
+RangeSet.empty.nextLayer = RangeSet.empty;
+var RangeSetBuilder = class _RangeSetBuilder {
+  finishChunk(newArrays) {
+    this.chunks.push(new Chunk(this.from, this.to, this.value, this.maxPoint));
+    this.chunkPos.push(this.chunkStart);
+    this.chunkStart = -1;
+    this.setMaxPoint = Math.max(this.setMaxPoint, this.maxPoint);
+    this.maxPoint = -1;
+    if (newArrays) {
+      this.from = [];
+      this.to = [];
+      this.value = [];
+    }
+  }
+  /**
+  Create an empty builder.
+  */
+  constructor() {
+    this.chunks = [];
+    this.chunkPos = [];
+    this.chunkStart = -1;
+    this.last = null;
+    this.lastFrom = -1e9;
+    this.lastTo = -1e9;
+    this.from = [];
+    this.to = [];
+    this.value = [];
+    this.maxPoint = -1;
+    this.setMaxPoint = -1;
+    this.nextLayer = null;
+  }
+  /**
+  Add a range. Ranges should be added in sorted (by `from` and
+  `value.startSide`) order.
+  */
+  add(from, to, value) {
+    if (!this.addInner(from, to, value))
+      (this.nextLayer || (this.nextLayer = new _RangeSetBuilder())).add(from, to, value);
+  }
+  /**
+  @internal
+  */
+  addInner(from, to, value) {
+    let diff = from - this.lastTo || value.startSide - this.last.endSide;
+    if (diff <= 0 && (from - this.lastFrom || value.startSide - this.last.startSide) < 0)
+      throw new Error("Ranges must be added sorted by `from` position and `startSide`");
+    if (diff < 0)
+      return false;
+    if (this.from.length == 250)
+      this.finishChunk(true);
+    if (this.chunkStart < 0)
+      this.chunkStart = from;
+    this.from.push(from - this.chunkStart);
+    this.to.push(to - this.chunkStart);
+    this.last = value;
+    this.lastFrom = from;
+    this.lastTo = to;
+    this.value.push(value);
+    if (value.point)
+      this.maxPoint = Math.max(this.maxPoint, to - from);
+    return true;
+  }
+  /**
+  @internal
+  */
+  addChunk(from, chunk) {
+    if ((from - this.lastTo || chunk.value[0].startSide - this.last.endSide) < 0)
+      return false;
+    if (this.from.length)
+      this.finishChunk(true);
+    this.setMaxPoint = Math.max(this.setMaxPoint, chunk.maxPoint);
+    this.chunks.push(chunk);
+    this.chunkPos.push(from);
+    let last = chunk.value.length - 1;
+    this.last = chunk.value[last];
+    this.lastFrom = chunk.from[last] + from;
+    this.lastTo = chunk.to[last] + from;
+    return true;
+  }
+  /**
+  Finish the range set. Returns the new set. The builder can't be
+  used anymore after this has been called.
+  */
+  finish() {
+    return this.finishInner(RangeSet.empty);
+  }
+  /**
+  @internal
+  */
+  finishInner(next) {
+    if (this.from.length)
+      this.finishChunk(false);
+    if (this.chunks.length == 0)
+      return next;
+    let result = RangeSet.create(this.chunkPos, this.chunks, this.nextLayer ? this.nextLayer.finishInner(next) : next, this.setMaxPoint);
+    this.from = null;
+    return result;
+  }
+};
+function findSharedChunks(a, b, textDiff) {
+  let inA = /* @__PURE__ */ new Map();
+  for (let set of a)
+    for (let i2 = 0; i2 < set.chunk.length; i2++)
+      if (set.chunk[i2].maxPoint <= 0)
+        inA.set(set.chunk[i2], set.chunkPos[i2]);
+  let shared = /* @__PURE__ */ new Set();
+  for (let set of b)
+    for (let i2 = 0; i2 < set.chunk.length; i2++) {
+      let known = inA.get(set.chunk[i2]);
+      if (known != null && (textDiff ? textDiff.mapPos(known) : known) == set.chunkPos[i2] && !(textDiff === null || textDiff === void 0 ? void 0 : textDiff.touchesRange(known, known + set.chunk[i2].length)))
+        shared.add(set.chunk[i2]);
+    }
+  return shared;
+}
+var LayerCursor = class {
+  constructor(layer, skip, minPoint, rank = 0) {
+    this.layer = layer;
+    this.skip = skip;
+    this.minPoint = minPoint;
+    this.rank = rank;
+  }
+  get startSide() {
+    return this.value ? this.value.startSide : 0;
+  }
+  get endSide() {
+    return this.value ? this.value.endSide : 0;
+  }
+  goto(pos, side = -1e9) {
+    this.chunkIndex = this.rangeIndex = 0;
+    this.gotoInner(pos, side, false);
+    return this;
+  }
+  gotoInner(pos, side, forward) {
+    while (this.chunkIndex < this.layer.chunk.length) {
+      let next = this.layer.chunk[this.chunkIndex];
+      if (!(this.skip && this.skip.has(next) || this.layer.chunkEnd(this.chunkIndex) < pos || next.maxPoint < this.minPoint))
+        break;
+      this.chunkIndex++;
+      forward = false;
+    }
+    if (this.chunkIndex < this.layer.chunk.length) {
+      let rangeIndex = this.layer.chunk[this.chunkIndex].findIndex(pos - this.layer.chunkPos[this.chunkIndex], side, true);
+      if (!forward || this.rangeIndex < rangeIndex)
+        this.setRangeIndex(rangeIndex);
+    }
+    this.next();
+  }
+  forward(pos, side) {
+    if ((this.to - pos || this.endSide - side) < 0)
+      this.gotoInner(pos, side, true);
+  }
+  next() {
+    for (; ; ) {
+      if (this.chunkIndex == this.layer.chunk.length) {
+        this.from = this.to = 1e9;
+        this.value = null;
+        break;
+      } else {
+        let chunkPos = this.layer.chunkPos[this.chunkIndex], chunk = this.layer.chunk[this.chunkIndex];
+        let from = chunkPos + chunk.from[this.rangeIndex];
+        this.from = from;
+        this.to = chunkPos + chunk.to[this.rangeIndex];
+        this.value = chunk.value[this.rangeIndex];
+        this.setRangeIndex(this.rangeIndex + 1);
+        if (this.minPoint < 0 || this.value.point && this.to - this.from >= this.minPoint)
+          break;
+      }
+    }
+  }
+  setRangeIndex(index) {
+    if (index == this.layer.chunk[this.chunkIndex].value.length) {
+      this.chunkIndex++;
+      if (this.skip) {
+        while (this.chunkIndex < this.layer.chunk.length && this.skip.has(this.layer.chunk[this.chunkIndex]))
+          this.chunkIndex++;
+      }
+      this.rangeIndex = 0;
+    } else {
+      this.rangeIndex = index;
+    }
+  }
+  nextChunk() {
+    this.chunkIndex++;
+    this.rangeIndex = 0;
+    this.next();
+  }
+  compare(other) {
+    return this.from - other.from || this.startSide - other.startSide || this.rank - other.rank || this.to - other.to || this.endSide - other.endSide;
+  }
+};
+var HeapCursor = class _HeapCursor {
+  constructor(heap) {
+    this.heap = heap;
+  }
+  static from(sets, skip = null, minPoint = -1) {
+    let heap = [];
+    for (let i2 = 0; i2 < sets.length; i2++) {
+      for (let cur = sets[i2]; !cur.isEmpty; cur = cur.nextLayer) {
+        if (cur.maxPoint >= minPoint)
+          heap.push(new LayerCursor(cur, skip, minPoint, i2));
+      }
+    }
+    return heap.length == 1 ? heap[0] : new _HeapCursor(heap);
+  }
+  get startSide() {
+    return this.value ? this.value.startSide : 0;
+  }
+  goto(pos, side = -1e9) {
+    for (let cur of this.heap)
+      cur.goto(pos, side);
+    for (let i2 = this.heap.length >> 1; i2 >= 0; i2--)
+      heapBubble(this.heap, i2);
+    this.next();
+    return this;
+  }
+  forward(pos, side) {
+    for (let cur of this.heap)
+      cur.forward(pos, side);
+    for (let i2 = this.heap.length >> 1; i2 >= 0; i2--)
+      heapBubble(this.heap, i2);
+    if ((this.to - pos || this.value.endSide - side) < 0)
+      this.next();
+  }
+  next() {
+    if (this.heap.length == 0) {
+      this.from = this.to = 1e9;
+      this.value = null;
+      this.rank = -1;
+    } else {
+      let top2 = this.heap[0];
+      this.from = top2.from;
+      this.to = top2.to;
+      this.value = top2.value;
+      this.rank = top2.rank;
+      if (top2.value)
+        top2.next();
+      heapBubble(this.heap, 0);
+    }
+  }
+};
+function heapBubble(heap, index) {
+  for (let cur = heap[index]; ; ) {
+    let childIndex = (index << 1) + 1;
+    if (childIndex >= heap.length)
+      break;
+    let child = heap[childIndex];
+    if (childIndex + 1 < heap.length && child.compare(heap[childIndex + 1]) >= 0) {
+      child = heap[childIndex + 1];
+      childIndex++;
+    }
+    if (cur.compare(child) < 0)
+      break;
+    heap[childIndex] = cur;
+    heap[index] = child;
+    index = childIndex;
+  }
+}
+var SpanCursor = class {
+  constructor(sets, skip, minPoint) {
+    this.minPoint = minPoint;
+    this.active = [];
+    this.activeTo = [];
+    this.activeRank = [];
+    this.minActive = -1;
+    this.point = null;
+    this.pointFrom = 0;
+    this.pointRank = 0;
+    this.to = -1e9;
+    this.endSide = 0;
+    this.openStart = -1;
+    this.cursor = HeapCursor.from(sets, skip, minPoint);
+  }
+  goto(pos, side = -1e9) {
+    this.cursor.goto(pos, side);
+    this.active.length = this.activeTo.length = this.activeRank.length = 0;
+    this.minActive = -1;
+    this.to = pos;
+    this.endSide = side;
+    this.openStart = -1;
+    this.next();
+    return this;
+  }
+  forward(pos, side) {
+    while (this.minActive > -1 && (this.activeTo[this.minActive] - pos || this.active[this.minActive].endSide - side) < 0)
+      this.removeActive(this.minActive);
+    this.cursor.forward(pos, side);
+  }
+  removeActive(index) {
+    remove(this.active, index);
+    remove(this.activeTo, index);
+    remove(this.activeRank, index);
+    this.minActive = findMinIndex(this.active, this.activeTo);
+  }
+  addActive(trackOpen) {
+    let i2 = 0, { value, to, rank } = this.cursor;
+    while (i2 < this.activeRank.length && (rank - this.activeRank[i2] || to - this.activeTo[i2]) > 0)
+      i2++;
+    insert(this.active, i2, value);
+    insert(this.activeTo, i2, to);
+    insert(this.activeRank, i2, rank);
+    if (trackOpen)
+      insert(trackOpen, i2, this.cursor.from);
+    this.minActive = findMinIndex(this.active, this.activeTo);
+  }
+  // After calling this, if `this.point` != null, the next range is a
+  // point. Otherwise, it's a regular range, covered by `this.active`.
+  next() {
+    let from = this.to, wasPoint = this.point;
+    this.point = null;
+    let trackOpen = this.openStart < 0 ? [] : null;
+    for (; ; ) {
+      let a = this.minActive;
+      if (a > -1 && (this.activeTo[a] - this.cursor.from || this.active[a].endSide - this.cursor.startSide) < 0) {
+        if (this.activeTo[a] > from) {
+          this.to = this.activeTo[a];
+          this.endSide = this.active[a].endSide;
+          break;
+        }
+        this.removeActive(a);
+        if (trackOpen)
+          remove(trackOpen, a);
+      } else if (!this.cursor.value) {
+        this.to = this.endSide = 1e9;
+        break;
+      } else if (this.cursor.from > from) {
+        this.to = this.cursor.from;
+        this.endSide = this.cursor.startSide;
+        break;
+      } else {
+        let nextVal = this.cursor.value;
+        if (!nextVal.point) {
+          this.addActive(trackOpen);
+          this.cursor.next();
+        } else if (wasPoint && this.cursor.to == this.to && this.cursor.from < this.cursor.to) {
+          this.cursor.next();
+        } else {
+          this.point = nextVal;
+          this.pointFrom = this.cursor.from;
+          this.pointRank = this.cursor.rank;
+          this.to = this.cursor.to;
+          this.endSide = nextVal.endSide;
+          this.cursor.next();
+          this.forward(this.to, this.endSide);
+          break;
+        }
+      }
+    }
+    if (trackOpen) {
+      this.openStart = 0;
+      for (let i2 = trackOpen.length - 1; i2 >= 0 && trackOpen[i2] < from; i2--)
+        this.openStart++;
+    }
+  }
+  activeForPoint(to) {
+    if (!this.active.length)
+      return this.active;
+    let active = [];
+    for (let i2 = this.active.length - 1; i2 >= 0; i2--) {
+      if (this.activeRank[i2] < this.pointRank)
+        break;
+      if (this.activeTo[i2] > to || this.activeTo[i2] == to && this.active[i2].endSide >= this.point.endSide)
+        active.push(this.active[i2]);
+    }
+    return active.reverse();
+  }
+  openEnd(to) {
+    let open = 0;
+    for (let i2 = this.activeTo.length - 1; i2 >= 0 && this.activeTo[i2] > to; i2--)
+      open++;
+    return open;
+  }
+};
+function compare(a, startA, b, startB, length, comparator) {
+  a.goto(startA);
+  b.goto(startB);
+  let endB = startB + length;
+  let pos = startB, dPos = startB - startA;
+  let bounds = !!comparator.boundChange;
+  for (let boundChange = false; ; ) {
+    let dEnd = a.to + dPos - b.to, diff = dEnd || a.endSide - b.endSide;
+    let end = diff < 0 ? a.to + dPos : b.to, clipEnd = Math.min(end, endB);
+    let point = a.point || b.point;
+    if (point) {
+      if (!(a.point && b.point && cmpVal(a.point, b.point) && sameValues(a.activeForPoint(a.to), b.activeForPoint(b.to))))
+        comparator.comparePoint(pos, clipEnd, a.point, b.point);
+      boundChange = false;
+    } else {
+      if (boundChange)
+        comparator.boundChange(pos);
+      if (clipEnd > pos && !sameValues(a.active, b.active))
+        comparator.compareRange(pos, clipEnd, a.active, b.active);
+      if (bounds && clipEnd < endB && (dEnd || a.openEnd(end) != b.openEnd(end)))
+        boundChange = true;
+    }
+    if (end > endB)
+      break;
+    pos = end;
+    if (diff <= 0)
+      a.next();
+    if (diff >= 0)
+      b.next();
+  }
+}
+function sameValues(a, b) {
+  if (a.length != b.length)
+    return false;
+  for (let i2 = 0; i2 < a.length; i2++)
+    if (a[i2] != b[i2] && !cmpVal(a[i2], b[i2]))
+      return false;
+  return true;
+}
+function remove(array, index) {
+  for (let i2 = index, e = array.length - 1; i2 < e; i2++)
+    array[i2] = array[i2 + 1];
+  array.pop();
+}
+function insert(array, index, value) {
+  for (let i2 = array.length - 1; i2 >= index; i2--)
+    array[i2 + 1] = array[i2];
+  array[index] = value;
+}
+function findMinIndex(value, array) {
+  let found = -1, foundPos = 1e9;
+  for (let i2 = 0; i2 < array.length; i2++)
+    if ((array[i2] - foundPos || value[i2].endSide - value[found].endSide) < 0) {
+      found = i2;
+      foundPos = array[i2];
+    }
+  return found;
+}
+function countColumn(string2, tabSize, to = string2.length) {
+  let n = 0;
+  for (let i2 = 0; i2 < to && i2 < string2.length; ) {
+    if (string2.charCodeAt(i2) == 9) {
+      n += tabSize - n % tabSize;
+      i2++;
+    } else {
+      n++;
+      i2 = findClusterBreak2(string2, i2);
+    }
+  }
+  return n;
+}
+function findColumn(string2, col, tabSize, strict) {
+  for (let i2 = 0, n = 0; ; ) {
+    if (n >= col)
+      return i2;
+    if (i2 == string2.length)
+      break;
+    n += string2.charCodeAt(i2) == 9 ? tabSize - n % tabSize : 1;
+    i2 = findClusterBreak2(string2, i2);
+  }
+  return strict === true ? -1 : string2.length;
+}
+
+// node_modules/style-mod/src/style-mod.js
+var C = "\u037C";
+var COUNT = typeof Symbol == "undefined" ? "__" + C : Symbol.for(C);
+var SET = typeof Symbol == "undefined" ? "__styleSet" + Math.floor(Math.random() * 1e8) : /* @__PURE__ */ Symbol("styleSet");
+var top = typeof globalThis != "undefined" ? globalThis : typeof window != "undefined" ? window : {};
+var StyleModule = class {
+  // :: (Object<Style>, ?{finish: ?(string) → string})
+  // Create a style module from the given spec.
+  //
+  // When `finish` is given, it is called on regular (non-`@`)
+  // selectors (after `&` expansion) to compute the final selector.
+  constructor(spec, options) {
+    this.rules = [];
+    let { finish } = options || {};
+    function splitSelector(selector) {
+      return /^@/.test(selector) ? [selector] : selector.split(/,\s*/);
+    }
+    function render(selectors, spec2, target, isKeyframes) {
+      let local = [], isAt = /^@(\w+)\b/.exec(selectors[0]), keyframes = isAt && isAt[1] == "keyframes";
+      if (isAt && spec2 == null) return target.push(selectors[0] + ";");
+      for (let prop in spec2) {
+        let value = spec2[prop];
+        if (/&/.test(prop)) {
+          render(
+            prop.split(/,\s*/).map((part) => selectors.map((sel) => part.replace(/&/, sel))).reduce((a, b) => a.concat(b)),
+            value,
+            target
+          );
+        } else if (value && typeof value == "object") {
+          if (!isAt) throw new RangeError("The value of a property (" + prop + ") should be a primitive value.");
+          render(splitSelector(prop), value, local, keyframes);
+        } else if (value != null) {
+          local.push(prop.replace(/_.*/, "").replace(/[A-Z]/g, (l) => "-" + l.toLowerCase()) + ": " + value + ";");
+        }
+      }
+      if (local.length || keyframes) {
+        target.push((finish && !isAt && !isKeyframes ? selectors.map(finish) : selectors).join(", ") + " {" + local.join(" ") + "}");
+      }
+    }
+    for (let prop in spec) render(splitSelector(prop), spec[prop], this.rules);
+  }
+  // :: () → string
+  // Returns a string containing the module's CSS rules.
+  getRules() {
+    return this.rules.join("\n");
+  }
+  // :: () → string
+  // Generate a new unique CSS class name.
+  static newName() {
+    let id2 = top[COUNT] || 1;
+    top[COUNT] = id2 + 1;
+    return C + id2.toString(36);
+  }
+  // :: (union<Document, ShadowRoot>, union<[StyleModule], StyleModule>, ?{nonce: ?string})
+  //
+  // Mount the given set of modules in the given DOM root, which ensures
+  // that the CSS rules defined by the module are available in that
+  // context.
+  //
+  // Rules are only added to the document once per root.
+  //
+  // Rule order will follow the order of the modules, so that rules from
+  // modules later in the array take precedence of those from earlier
+  // modules. If you call this function multiple times for the same root
+  // in a way that changes the order of already mounted modules, the old
+  // order will be changed.
+  //
+  // If a Content Security Policy nonce is provided, it is added to
+  // the `<style>` tag generated by the library.
+  static mount(root, modules, options) {
+    let set = root[SET], nonce = options && options.nonce;
+    if (!set) set = new StyleSet(root, nonce);
+    else if (nonce) set.setNonce(nonce);
+    set.mount(Array.isArray(modules) ? modules : [modules], root);
+  }
+};
+var adoptedSet = /* @__PURE__ */ new Map();
+var StyleSet = class {
+  constructor(root, nonce) {
+    let doc2 = root.ownerDocument || root, win = doc2.defaultView;
+    if (!root.head && root.adoptedStyleSheets && win.CSSStyleSheet) {
+      let adopted = adoptedSet.get(doc2);
+      if (adopted) return root[SET] = adopted;
+      this.sheet = new win.CSSStyleSheet();
+      adoptedSet.set(doc2, this);
+    } else {
+      this.styleTag = doc2.createElement("style");
+      if (nonce) this.styleTag.setAttribute("nonce", nonce);
+    }
+    this.modules = [];
+    root[SET] = this;
+  }
+  mount(modules, root) {
+    let sheet = this.sheet;
+    let pos = 0, j = 0;
+    for (let i2 = 0; i2 < modules.length; i2++) {
+      let mod = modules[i2], index = this.modules.indexOf(mod);
+      if (index < j && index > -1) {
+        this.modules.splice(index, 1);
+        j--;
+        index = -1;
+      }
+      if (index == -1) {
+        this.modules.splice(j++, 0, mod);
+        if (sheet) for (let k = 0; k < mod.rules.length; k++)
+          sheet.insertRule(mod.rules[k], pos++);
+      } else {
+        while (j < index) pos += this.modules[j++].rules.length;
+        pos += mod.rules.length;
+        j++;
+      }
+    }
+    if (sheet) {
+      if (root.adoptedStyleSheets.indexOf(this.sheet) < 0)
+        root.adoptedStyleSheets = [this.sheet, ...root.adoptedStyleSheets];
+    } else {
+      let text = "";
+      for (let i2 = 0; i2 < this.modules.length; i2++)
+        text += this.modules[i2].getRules() + "\n";
+      this.styleTag.textContent = text;
+      let target = root.head || root;
+      if (this.styleTag.parentNode != target)
+        target.insertBefore(this.styleTag, target.firstChild);
+    }
+  }
+  setNonce(nonce) {
+    if (this.styleTag && this.styleTag.getAttribute("nonce") != nonce)
+      this.styleTag.setAttribute("nonce", nonce);
+  }
+};
+
+// node_modules/w3c-keyname/index.js
+var base = {
+  8: "Backspace",
+  9: "Tab",
+  10: "Enter",
+  12: "NumLock",
+  13: "Enter",
+  16: "Shift",
+  17: "Control",
+  18: "Alt",
+  20: "CapsLock",
+  27: "Escape",
+  32: " ",
+  33: "PageUp",
+  34: "PageDown",
+  35: "End",
+  36: "Home",
+  37: "ArrowLeft",
+  38: "ArrowUp",
+  39: "ArrowRight",
+  40: "ArrowDown",
+  44: "PrintScreen",
+  45: "Insert",
+  46: "Delete",
+  59: ";",
+  61: "=",
+  91: "Meta",
+  92: "Meta",
+  106: "*",
+  107: "+",
+  108: ",",
+  109: "-",
+  110: ".",
+  111: "/",
+  144: "NumLock",
+  145: "ScrollLock",
+  160: "Shift",
+  161: "Shift",
+  162: "Control",
+  163: "Control",
+  164: "Alt",
+  165: "Alt",
+  173: "-",
+  186: ";",
+  187: "=",
+  188: ",",
+  189: "-",
+  190: ".",
+  191: "/",
+  192: "`",
+  219: "[",
+  220: "\\",
+  221: "]",
+  222: "'"
+};
+var shift = {
+  48: ")",
+  49: "!",
+  50: "@",
+  51: "#",
+  52: "$",
+  53: "%",
+  54: "^",
+  55: "&",
+  56: "*",
+  57: "(",
+  59: ":",
+  61: "+",
+  173: "_",
+  186: ":",
+  187: "+",
+  188: "<",
+  189: "_",
+  190: ">",
+  191: "?",
+  192: "~",
+  219: "{",
+  220: "|",
+  221: "}",
+  222: '"'
+};
+var mac = typeof navigator != "undefined" && /Mac/.test(navigator.platform);
+var ie = typeof navigator != "undefined" && /MSIE \d|Trident\/(?:[7-9]|\d{2,})\..*rv:(\d+)/.exec(navigator.userAgent);
+for (i = 0; i < 10; i++) base[48 + i] = base[96 + i] = String(i);
+var i;
+for (i = 1; i <= 24; i++) base[i + 111] = "F" + i;
+var i;
+for (i = 65; i <= 90; i++) {
+  base[i] = String.fromCharCode(i + 32);
+  shift[i] = String.fromCharCode(i);
+}
+var i;
+for (code in base) if (!shift.hasOwnProperty(code)) shift[code] = base[code];
+var code;
+function keyName(event) {
+  var ignoreKey = mac && event.metaKey && event.shiftKey && !event.ctrlKey && !event.altKey || ie && event.shiftKey && event.key && event.key.length == 1 || event.key == "Unidentified";
+  var name2 = !ignoreKey && event.key || (event.shiftKey ? shift : base)[event.keyCode] || event.key || "Unidentified";
+  if (name2 == "Esc") name2 = "Escape";
+  if (name2 == "Del") name2 = "Delete";
+  if (name2 == "Left") name2 = "ArrowLeft";
+  if (name2 == "Up") name2 = "ArrowUp";
+  if (name2 == "Right") name2 = "ArrowRight";
+  if (name2 == "Down") name2 = "ArrowDown";
+  return name2;
+}
+
+// node_modules/@codemirror/view/dist/index.js
+var nav = typeof navigator != "undefined" ? navigator : { userAgent: "", vendor: "", platform: "" };
+var doc = typeof document != "undefined" ? document : { documentElement: { style: {} } };
+var ie_edge = /* @__PURE__ */ /Edge\/(\d+)/.exec(nav.userAgent);
+var ie_upto10 = /* @__PURE__ */ /MSIE \d/.test(nav.userAgent);
+var ie_11up = /* @__PURE__ */ /Trident\/(?:[7-9]|\d{2,})\..*rv:(\d+)/.exec(nav.userAgent);
+var ie2 = !!(ie_upto10 || ie_11up || ie_edge);
+var gecko = !ie2 && /* @__PURE__ */ /gecko\/(\d+)/i.test(nav.userAgent);
+var chrome = !ie2 && /* @__PURE__ */ /Chrome\/(\d+)/.exec(nav.userAgent);
+var webkit = "webkitFontSmoothing" in doc.documentElement.style;
+var safari = !ie2 && /* @__PURE__ */ /Apple Computer/.test(nav.vendor);
+var ios = safari && (/* @__PURE__ */ /Mobile\/\w+/.test(nav.userAgent) || nav.maxTouchPoints > 2);
+var browser = {
+  mac: ios || /* @__PURE__ */ /Mac/.test(nav.platform),
+  windows: /* @__PURE__ */ /Win/.test(nav.platform),
+  linux: /* @__PURE__ */ /Linux|X11/.test(nav.platform),
+  ie: ie2,
+  ie_version: ie_upto10 ? doc.documentMode || 6 : ie_11up ? +ie_11up[1] : ie_edge ? +ie_edge[1] : 0,
+  gecko,
+  gecko_version: gecko ? +(/* @__PURE__ */ /Firefox\/(\d+)/.exec(nav.userAgent) || [0, 0])[1] : 0,
+  chrome: !!chrome,
+  chrome_version: chrome ? +chrome[1] : 0,
+  ios,
+  android: /* @__PURE__ */ /Android\b/.test(nav.userAgent),
+  webkit,
+  webkit_version: webkit ? +(/* @__PURE__ */ /\bAppleWebKit\/(\d+)/.exec(nav.userAgent) || [0, 0])[1] : 0,
+  safari,
+  safari_version: safari ? +(/* @__PURE__ */ /\bVersion\/(\d+(\.\d+)?)/.exec(nav.userAgent) || [0, 0])[1] : 0,
+  tabSize: doc.documentElement.style.tabSize != null ? "tab-size" : "-moz-tab-size"
+};
+function combineAttrs(source, target) {
+  for (let name2 in source) {
+    if (name2 == "class" && target.class)
+      target.class += " " + source.class;
+    else if (name2 == "style" && target.style)
+      target.style += ";" + source.style;
+    else
+      target[name2] = source[name2];
+  }
+  return target;
+}
+var noAttrs = /* @__PURE__ */ Object.create(null);
+function attrsEq(a, b, ignore) {
+  if (a == b)
+    return true;
+  if (!a)
+    a = noAttrs;
+  if (!b)
+    b = noAttrs;
+  let keysA = Object.keys(a), keysB = Object.keys(b);
+  if (keysA.length - (ignore && keysA.indexOf(ignore) > -1 ? 1 : 0) != keysB.length - (ignore && keysB.indexOf(ignore) > -1 ? 1 : 0))
+    return false;
+  for (let key of keysA) {
+    if (key != ignore && (keysB.indexOf(key) == -1 || a[key] !== b[key]))
+      return false;
+  }
+  return true;
+}
+function setAttrs(dom, attrs) {
+  for (let i2 = dom.attributes.length - 1; i2 >= 0; i2--) {
+    let name2 = dom.attributes[i2].name;
+    if (attrs[name2] == null)
+      dom.removeAttribute(name2);
+  }
+  for (let name2 in attrs) {
+    let value = attrs[name2];
+    if (name2 == "style")
+      dom.style.cssText = value;
+    else if (dom.getAttribute(name2) != value)
+      dom.setAttribute(name2, value);
+  }
+}
+function updateAttrs(dom, prev, attrs) {
+  let changed = false;
+  if (prev) {
+    for (let name2 in prev)
+      if (!(attrs && name2 in attrs)) {
+        changed = true;
+        if (name2 == "style")
+          dom.style.cssText = "";
+        else
+          dom.removeAttribute(name2);
+      }
+  }
+  if (attrs) {
+    for (let name2 in attrs)
+      if (!(prev && prev[name2] == attrs[name2])) {
+        changed = true;
+        if (name2 == "style")
+          dom.style.cssText = attrs[name2];
+        else
+          dom.setAttribute(name2, attrs[name2]);
+      }
+  }
+  return changed;
+}
+function getAttrs(dom) {
+  let attrs = /* @__PURE__ */ Object.create(null);
+  for (let i2 = 0; i2 < dom.attributes.length; i2++) {
+    let attr = dom.attributes[i2];
+    attrs[attr.name] = attr.value;
+  }
+  return attrs;
+}
+var WidgetType = class {
+  /**
+  Compare this instance to another instance of the same type.
+  (TypeScript can't express this, but only instances of the same
+  specific class will be passed to this method.) This is used to
+  avoid redrawing widgets when they are replaced by a new
+  decoration of the same type. The default implementation just
+  returns `false`, which will cause new instances of the widget to
+  always be redrawn.
+  */
+  eq(widget) {
+    return false;
+  }
+  /**
+  Update a DOM element created by a widget of the same type (but
+  different, non-`eq` content) to reflect this widget. May return
+  true to indicate that it could update, false to indicate it
+  couldn't (in which case the widget will be redrawn). The default
+  implementation just returns false.
+  */
+  updateDOM(dom, view, from) {
+    return false;
+  }
+  /**
+  @internal
+  */
+  compare(other) {
+    return this == other || this.constructor == other.constructor && this.eq(other);
+  }
+  /**
+  The estimated height this widget will have, to be used when
+  estimating the height of content that hasn't been drawn. May
+  return -1 to indicate you don't know. The default implementation
+  returns -1.
+  */
+  get estimatedHeight() {
+    return -1;
+  }
+  /**
+  For inline widgets that are displayed inline (as opposed to
+  `inline-block`) and introduce line breaks (through `<br>` tags
+  or textual newlines), this must indicate the amount of line
+  breaks they introduce. Defaults to 0.
+  */
+  get lineBreaks() {
+    return 0;
+  }
+  /**
+  Can be used to configure which kinds of events inside the widget
+  should be ignored by the editor. The default is to ignore all
+  events.
+  */
+  ignoreEvent(event) {
+    return true;
+  }
+  /**
+  Override the way screen coordinates for positions at/in the
+  widget are found. `pos` will be the offset into the widget, and
+  `side` the side of the position that is being queried—less than
+  zero for before, greater than zero for after, and zero for
+  directly at that position.
+  */
+  coordsAt(dom, pos, side) {
+    return null;
+  }
+  /**
+  @internal
+  */
+  get isHidden() {
+    return false;
+  }
+  /**
+  @internal
+  */
+  get editable() {
+    return false;
+  }
+  /**
+  This is called when the an instance of the widget is removed
+  from the editor view.
+  */
+  destroy(dom) {
+  }
+};
+var BlockType = /* @__PURE__ */ (function(BlockType2) {
+  BlockType2[BlockType2["Text"] = 0] = "Text";
+  BlockType2[BlockType2["WidgetBefore"] = 1] = "WidgetBefore";
+  BlockType2[BlockType2["WidgetAfter"] = 2] = "WidgetAfter";
+  BlockType2[BlockType2["WidgetRange"] = 3] = "WidgetRange";
+  return BlockType2;
+})(BlockType || (BlockType = {}));
+var Decoration = class extends RangeValue {
+  constructor(startSide, endSide, widget, spec) {
+    super();
+    this.startSide = startSide;
+    this.endSide = endSide;
+    this.widget = widget;
+    this.spec = spec;
+  }
+  /**
+  @internal
+  */
+  get heightRelevant() {
+    return false;
+  }
+  /**
+  Create a mark decoration, which influences the styling of the
+  content in its range. Nested mark decorations will cause nested
+  DOM elements to be created. Nesting order is determined by
+  precedence of the [facet](https://codemirror.net/6/docs/ref/#view.EditorView^decorations), with
+  the higher-precedence decorations creating the inner DOM nodes.
+  Such elements are split on line boundaries and on the boundaries
+  of lower-precedence decorations.
+  */
+  static mark(spec) {
+    return new MarkDecoration(spec);
+  }
+  /**
+  Create a widget decoration, which displays a DOM element at the
+  given position.
+  */
+  static widget(spec) {
+    let side = Math.max(-1e4, Math.min(1e4, spec.side || 0)), block = !!spec.block;
+    side += block && !spec.inlineOrder ? side > 0 ? 3e8 : -4e8 : side > 0 ? 1e8 : -1e8;
+    return new PointDecoration(spec, side, side, block, spec.widget || null, false);
+  }
+  /**
+  Create a replace decoration which replaces the given range with
+  a widget, or simply hides it.
+  */
+  static replace(spec) {
+    let block = !!spec.block, startSide, endSide;
+    if (spec.isBlockGap) {
+      startSide = -5e8;
+      endSide = 4e8;
+    } else {
+      let { start, end } = getInclusive(spec, block);
+      startSide = (start ? block ? -3e8 : -1 : 5e8) - 1;
+      endSide = (end ? block ? 2e8 : 1 : -6e8) + 1;
+    }
+    return new PointDecoration(spec, startSide, endSide, block, spec.widget || null, true);
+  }
+  /**
+  Create a line decoration, which can add DOM attributes to the
+  line starting at the given position.
+  */
+  static line(spec) {
+    return new LineDecoration(spec);
+  }
+  /**
+  Build a [`DecorationSet`](https://codemirror.net/6/docs/ref/#view.DecorationSet) from the given
+  decorated range or ranges. If the ranges aren't already sorted,
+  pass `true` for `sort` to make the library sort them for you.
+  */
+  static set(of, sort = false) {
+    return RangeSet.of(of, sort);
+  }
+  /**
+  @internal
+  */
+  hasHeight() {
+    return this.widget ? this.widget.estimatedHeight > -1 : false;
+  }
+};
+Decoration.none = RangeSet.empty;
+var MarkDecoration = class _MarkDecoration extends Decoration {
+  constructor(spec) {
+    let { start, end } = getInclusive(spec);
+    super(start ? -1 : 5e8, end ? 1 : -6e8, null, spec);
+    this.tagName = spec.tagName || "span";
+    this.attrs = spec.class && spec.attributes ? combineAttrs(spec.attributes, { class: spec.class }) : spec.class ? { class: spec.class } : spec.attributes || noAttrs;
+  }
+  eq(other) {
+    return this == other || other instanceof _MarkDecoration && this.tagName == other.tagName && attrsEq(this.attrs, other.attrs);
+  }
+  range(from, to = from) {
+    if (from >= to)
+      throw new RangeError("Mark decorations may not be empty");
+    return super.range(from, to);
+  }
+};
+MarkDecoration.prototype.point = false;
+var LineDecoration = class _LineDecoration extends Decoration {
+  constructor(spec) {
+    super(-2e8, -2e8, null, spec);
+  }
+  eq(other) {
+    return other instanceof _LineDecoration && this.spec.class == other.spec.class && attrsEq(this.spec.attributes, other.spec.attributes);
+  }
+  range(from, to = from) {
+    if (to != from)
+      throw new RangeError("Line decoration ranges must be zero-length");
+    return super.range(from, to);
+  }
+};
+LineDecoration.prototype.mapMode = MapMode.TrackBefore;
+LineDecoration.prototype.point = true;
+var PointDecoration = class _PointDecoration extends Decoration {
+  constructor(spec, startSide, endSide, block, widget, isReplace) {
+    super(startSide, endSide, widget, spec);
+    this.block = block;
+    this.isReplace = isReplace;
+    this.mapMode = !block ? MapMode.TrackDel : startSide <= 0 ? MapMode.TrackBefore : MapMode.TrackAfter;
+  }
+  // Only relevant when this.block == true
+  get type() {
+    return this.startSide != this.endSide ? BlockType.WidgetRange : this.startSide <= 0 ? BlockType.WidgetBefore : BlockType.WidgetAfter;
+  }
+  get heightRelevant() {
+    return this.block || !!this.widget && (this.widget.estimatedHeight >= 5 || this.widget.lineBreaks > 0);
+  }
+  eq(other) {
+    return other instanceof _PointDecoration && widgetsEq(this.widget, other.widget) && this.block == other.block && this.startSide == other.startSide && this.endSide == other.endSide;
+  }
+  range(from, to = from) {
+    if (this.isReplace && (from > to || from == to && this.startSide > 0 && this.endSide <= 0))
+      throw new RangeError("Invalid range for replacement decoration");
+    if (!this.isReplace && to != from)
+      throw new RangeError("Widget decorations can only have zero-length ranges");
+    return super.range(from, to);
+  }
+};
+PointDecoration.prototype.point = true;
+function getInclusive(spec, block = false) {
+  let { inclusiveStart: start, inclusiveEnd: end } = spec;
+  if (start == null)
+    start = spec.inclusive;
+  if (end == null)
+    end = spec.inclusive;
+  return { start: start !== null && start !== void 0 ? start : block, end: end !== null && end !== void 0 ? end : block };
+}
+function widgetsEq(a, b) {
+  return a == b || !!(a && b && a.compare(b));
+}
+function addRange(from, to, ranges, margin = 0) {
+  let last = ranges.length - 1;
+  if (last >= 0 && ranges[last] + margin >= from)
+    ranges[last] = Math.max(ranges[last], to);
+  else
+    ranges.push(from, to);
+}
+var BlockWrapper = class _BlockWrapper extends RangeValue {
+  constructor(tagName, attributes, rank) {
+    super();
+    this.tagName = tagName;
+    this.attributes = attributes;
+    this.rank = rank;
+  }
+  eq(other) {
+    return other == this || other instanceof _BlockWrapper && this.tagName == other.tagName && attrsEq(this.attributes, other.attributes);
+  }
+  /**
+  Create a block wrapper object with the given tag name and
+  attributes.
+  */
+  static create(spec) {
+    return new _BlockWrapper(spec.tagName, spec.attributes || noAttrs, spec.rank == null ? 50 : Math.max(0, Math.min(spec.rank, 100)));
+  }
+  /**
+  Create a range set from the given block wrapper ranges.
+  */
+  static set(of, sort = false) {
+    return RangeSet.of(of, sort);
+  }
+};
+BlockWrapper.prototype.startSide = BlockWrapper.prototype.endSide = -1;
+function getSelection(root) {
+  let target;
+  if (root.nodeType == 11) {
+    target = root.getSelection ? root : root.ownerDocument;
+  } else {
+    target = root;
+  }
+  return target.getSelection();
+}
+function contains(dom, node) {
+  return node ? dom == node || dom.contains(node.nodeType != 1 ? node.parentNode : node) : false;
+}
+function hasSelection(dom, selection) {
+  if (!selection.anchorNode)
+    return false;
+  try {
+    return contains(dom, selection.anchorNode);
+  } catch (_) {
+    return false;
+  }
+}
+function clientRectsFor(dom) {
+  if (dom.nodeType == 3)
+    return textRange(dom, 0, dom.nodeValue.length).getClientRects();
+  else if (dom.nodeType == 1)
+    return dom.getClientRects();
+  else
+    return [];
+}
+function isEquivalentPosition(node, off, targetNode, targetOff) {
+  return targetNode ? scanFor(node, off, targetNode, targetOff, -1) || scanFor(node, off, targetNode, targetOff, 1) : false;
+}
+function domIndex(node) {
+  for (var index = 0; ; index++) {
+    node = node.previousSibling;
+    if (!node)
+      return index;
+  }
+}
+function isBlockElement(node) {
+  return node.nodeType == 1 && /^(DIV|P|LI|UL|OL|BLOCKQUOTE|DD|DT|H\d|SECTION|PRE)$/.test(node.nodeName);
+}
+function scanFor(node, off, targetNode, targetOff, dir) {
+  for (; ; ) {
+    if (node == targetNode && off == targetOff)
+      return true;
+    if (off == (dir < 0 ? 0 : maxOffset(node))) {
+      if (node.nodeName == "DIV")
+        return false;
+      let parent = node.parentNode;
+      if (!parent || parent.nodeType != 1)
+        return false;
+      off = domIndex(node) + (dir < 0 ? 0 : 1);
+      node = parent;
+    } else if (node.nodeType == 1) {
+      node = node.childNodes[off + (dir < 0 ? -1 : 0)];
+      if (node.nodeType == 1 && node.contentEditable == "false")
+        return false;
+      off = dir < 0 ? maxOffset(node) : 0;
+    } else {
+      return false;
+    }
+  }
+}
+function maxOffset(node) {
+  return node.nodeType == 3 ? node.nodeValue.length : node.childNodes.length;
+}
+function flattenRect(rect, left) {
+  let x = left ? rect.left : rect.right;
+  return { left: x, right: x, top: rect.top, bottom: rect.bottom };
+}
+function windowRect(win) {
+  let vp = win.visualViewport;
+  if (vp)
+    return {
+      left: 0,
+      right: vp.width,
+      top: 0,
+      bottom: vp.height
+    };
+  return {
+    left: 0,
+    right: win.innerWidth,
+    top: 0,
+    bottom: win.innerHeight
+  };
+}
+function getScale(elt, rect) {
+  let scaleX = rect.width / elt.offsetWidth;
+  let scaleY = rect.height / elt.offsetHeight;
+  if (scaleX > 0.995 && scaleX < 1.005 || !isFinite(scaleX) || Math.abs(rect.width - elt.offsetWidth) < 1)
+    scaleX = 1;
+  if (scaleY > 0.995 && scaleY < 1.005 || !isFinite(scaleY) || Math.abs(rect.height - elt.offsetHeight) < 1)
+    scaleY = 1;
+  return { scaleX, scaleY };
+}
+function scrollRectIntoView(dom, rect, side, x, y, xMargin, yMargin, ltr) {
+  let doc2 = dom.ownerDocument, win = doc2.defaultView || window;
+  for (let cur = dom, stop = false; cur && !stop; ) {
+    if (cur.nodeType == 1) {
+      let bounding, top2 = cur == doc2.body;
+      let scaleX = 1, scaleY = 1;
+      if (top2) {
+        bounding = windowRect(win);
+      } else {
+        if (/^(fixed|sticky)$/.test(getComputedStyle(cur).position))
+          stop = true;
+        if (cur.scrollHeight <= cur.clientHeight && cur.scrollWidth <= cur.clientWidth) {
+          cur = cur.assignedSlot || cur.parentNode;
+          continue;
+        }
+        let rect2 = cur.getBoundingClientRect();
+        ({ scaleX, scaleY } = getScale(cur, rect2));
+        bounding = {
+          left: rect2.left,
+          right: rect2.left + cur.clientWidth * scaleX,
+          top: rect2.top,
+          bottom: rect2.top + cur.clientHeight * scaleY
+        };
+      }
+      let moveX = 0, moveY = 0;
+      if (y == "nearest") {
+        if (rect.top < bounding.top + yMargin) {
+          moveY = rect.top - (bounding.top + yMargin);
+          if (side > 0 && rect.bottom > bounding.bottom + moveY)
+            moveY = rect.bottom - bounding.bottom + yMargin;
+        } else if (rect.bottom > bounding.bottom - yMargin) {
+          moveY = rect.bottom - bounding.bottom + yMargin;
+          if (side < 0 && rect.top - moveY < bounding.top)
+            moveY = rect.top - (bounding.top + yMargin);
+        }
+      } else {
+        let rectHeight = rect.bottom - rect.top, boundingHeight = bounding.bottom - bounding.top;
+        let targetTop = y == "center" && rectHeight <= boundingHeight ? rect.top + rectHeight / 2 - boundingHeight / 2 : y == "start" || y == "center" && side < 0 ? rect.top - yMargin : rect.bottom - boundingHeight + yMargin;
+        moveY = targetTop - bounding.top;
+      }
+      if (x == "nearest") {
+        if (rect.left < bounding.left + xMargin) {
+          moveX = rect.left - (bounding.left + xMargin);
+          if (side > 0 && rect.right > bounding.right + moveX)
+            moveX = rect.right - bounding.right + xMargin;
+        } else if (rect.right > bounding.right - xMargin) {
+          moveX = rect.right - bounding.right + xMargin;
+          if (side < 0 && rect.left < bounding.left + moveX)
+            moveX = rect.left - (bounding.left + xMargin);
+        }
+      } else {
+        let targetLeft = x == "center" ? rect.left + (rect.right - rect.left) / 2 - (bounding.right - bounding.left) / 2 : x == "start" == ltr ? rect.left - xMargin : rect.right - (bounding.right - bounding.left) + xMargin;
+        moveX = targetLeft - bounding.left;
+      }
+      if (moveX || moveY) {
+        if (top2) {
+          win.scrollBy(moveX, moveY);
+        } else {
+          let movedX = 0, movedY = 0;
+          if (moveY) {
+            let start = cur.scrollTop;
+            cur.scrollTop += moveY / scaleY;
+            movedY = (cur.scrollTop - start) * scaleY;
+          }
+          if (moveX) {
+            let start = cur.scrollLeft;
+            cur.scrollLeft += moveX / scaleX;
+            movedX = (cur.scrollLeft - start) * scaleX;
+          }
+          rect = {
+            left: rect.left - movedX,
+            top: rect.top - movedY,
+            right: rect.right - movedX,
+            bottom: rect.bottom - movedY
+          };
+          if (movedX && Math.abs(movedX - moveX) < 1)
+            x = "nearest";
+          if (movedY && Math.abs(movedY - moveY) < 1)
+            y = "nearest";
+        }
+      }
+      if (top2)
+        break;
+      if (rect.top < bounding.top || rect.bottom > bounding.bottom || rect.left < bounding.left || rect.right > bounding.right)
+        rect = {
+          left: Math.max(rect.left, bounding.left),
+          right: Math.min(rect.right, bounding.right),
+          top: Math.max(rect.top, bounding.top),
+          bottom: Math.min(rect.bottom, bounding.bottom)
+        };
+      cur = cur.assignedSlot || cur.parentNode;
+    } else if (cur.nodeType == 11) {
+      cur = cur.host;
+    } else {
+      break;
+    }
+  }
+}
+function scrollableParents(dom, getX = true) {
+  let doc2 = dom.ownerDocument, x = null, y = null;
+  for (let cur = dom.parentNode; cur; ) {
+    if (cur == doc2.body || (!getX || x) && y) {
+      break;
+    } else if (cur.nodeType == 1) {
+      if (!y && cur.scrollHeight > cur.clientHeight)
+        y = cur;
+      if (getX && !x && cur.scrollWidth > cur.clientWidth)
+        x = cur;
+      cur = cur.assignedSlot || cur.parentNode;
+    } else if (cur.nodeType == 11) {
+      cur = cur.host;
+    } else {
+      break;
+    }
+  }
+  return { x, y };
+}
+var DOMSelectionState = class {
+  constructor() {
+    this.anchorNode = null;
+    this.anchorOffset = 0;
+    this.focusNode = null;
+    this.focusOffset = 0;
+  }
+  eq(domSel) {
+    return this.anchorNode == domSel.anchorNode && this.anchorOffset == domSel.anchorOffset && this.focusNode == domSel.focusNode && this.focusOffset == domSel.focusOffset;
+  }
+  setRange(range) {
+    let { anchorNode, focusNode } = range;
+    this.set(anchorNode, Math.min(range.anchorOffset, anchorNode ? maxOffset(anchorNode) : 0), focusNode, Math.min(range.focusOffset, focusNode ? maxOffset(focusNode) : 0));
+  }
+  set(anchorNode, anchorOffset, focusNode, focusOffset) {
+    this.anchorNode = anchorNode;
+    this.anchorOffset = anchorOffset;
+    this.focusNode = focusNode;
+    this.focusOffset = focusOffset;
+  }
+};
+var preventScrollSupported = null;
+if (browser.safari && browser.safari_version >= 26)
+  preventScrollSupported = false;
+function focusPreventScroll(dom) {
+  if (dom.setActive)
+    return dom.setActive();
+  if (preventScrollSupported)
+    return dom.focus(preventScrollSupported);
+  let stack = [];
+  for (let cur = dom; cur; cur = cur.parentNode) {
+    stack.push(cur, cur.scrollTop, cur.scrollLeft);
+    if (cur == cur.ownerDocument)
+      break;
+  }
+  dom.focus(preventScrollSupported == null ? {
+    get preventScroll() {
+      preventScrollSupported = { preventScroll: true };
+      return true;
+    }
+  } : void 0);
+  if (!preventScrollSupported) {
+    preventScrollSupported = false;
+    for (let i2 = 0; i2 < stack.length; ) {
+      let elt = stack[i2++], top2 = stack[i2++], left = stack[i2++];
+      if (elt.scrollTop != top2)
+        elt.scrollTop = top2;
+      if (elt.scrollLeft != left)
+        elt.scrollLeft = left;
+    }
+  }
+}
+var scratchRange;
+function textRange(node, from, to = from) {
+  let range = scratchRange || (scratchRange = document.createRange());
+  range.setEnd(node, to);
+  range.setStart(node, from);
+  return range;
+}
+function dispatchKey(elt, name2, code2, mods) {
+  let options = { key: name2, code: name2, keyCode: code2, which: code2, cancelable: true };
+  if (mods)
+    ({ altKey: options.altKey, ctrlKey: options.ctrlKey, shiftKey: options.shiftKey, metaKey: options.metaKey } = mods);
+  let down = new KeyboardEvent("keydown", options);
+  down.synthetic = true;
+  elt.dispatchEvent(down);
+  let up = new KeyboardEvent("keyup", options);
+  up.synthetic = true;
+  elt.dispatchEvent(up);
+  return down.defaultPrevented || up.defaultPrevented;
+}
+function getRoot(node) {
+  while (node) {
+    if (node && (node.nodeType == 9 || node.nodeType == 11 && node.host))
+      return node;
+    node = node.assignedSlot || node.parentNode;
+  }
+  return null;
+}
+function atElementStart(doc2, selection) {
+  let node = selection.focusNode, offset = selection.focusOffset;
+  if (!node || selection.anchorNode != node || selection.anchorOffset != offset)
+    return false;
+  offset = Math.min(offset, maxOffset(node));
+  for (; ; ) {
+    if (offset) {
+      if (node.nodeType != 1)
+        return false;
+      let prev = node.childNodes[offset - 1];
+      if (prev.contentEditable == "false")
+        offset--;
+      else {
+        node = prev;
+        offset = maxOffset(node);
+      }
+    } else if (node == doc2) {
+      return true;
+    } else {
+      offset = domIndex(node);
+      node = node.parentNode;
+    }
+  }
+}
+function isScrolledToBottom(elt) {
+  if (elt instanceof Window)
+    return elt.pageYOffset > Math.max(0, elt.document.documentElement.scrollHeight - elt.innerHeight - 4);
+  return elt.scrollTop > Math.max(1, elt.scrollHeight - elt.clientHeight - 4);
+}
+function textNodeBefore(startNode, startOffset) {
+  for (let node = startNode, offset = startOffset; ; ) {
+    if (node.nodeType == 3 && offset > 0) {
+      return { node, offset };
+    } else if (node.nodeType == 1 && offset > 0) {
+      if (node.contentEditable == "false")
+        return null;
+      node = node.childNodes[offset - 1];
+      offset = maxOffset(node);
+    } else if (node.parentNode && !isBlockElement(node)) {
+      offset = domIndex(node);
+      node = node.parentNode;
+    } else {
+      return null;
+    }
+  }
+}
+function textNodeAfter(startNode, startOffset) {
+  for (let node = startNode, offset = startOffset; ; ) {
+    if (node.nodeType == 3 && offset < node.nodeValue.length) {
+      return { node, offset };
+    } else if (node.nodeType == 1 && offset < node.childNodes.length) {
+      if (node.contentEditable == "false")
+        return null;
+      node = node.childNodes[offset];
+      offset = 0;
+    } else if (node.parentNode && !isBlockElement(node)) {
+      offset = domIndex(node) + 1;
+      node = node.parentNode;
+    } else {
+      return null;
+    }
+  }
+}
+var DOMPos = class _DOMPos {
+  constructor(node, offset, precise = true) {
+    this.node = node;
+    this.offset = offset;
+    this.precise = precise;
+  }
+  static before(dom, precise) {
+    return new _DOMPos(dom.parentNode, domIndex(dom), precise);
+  }
+  static after(dom, precise) {
+    return new _DOMPos(dom.parentNode, domIndex(dom) + 1, precise);
+  }
+};
+var Direction = /* @__PURE__ */ (function(Direction2) {
+  Direction2[Direction2["LTR"] = 0] = "LTR";
+  Direction2[Direction2["RTL"] = 1] = "RTL";
+  return Direction2;
+})(Direction || (Direction = {}));
+var LTR = Direction.LTR;
+var RTL = Direction.RTL;
+function dec(str) {
+  let result = [];
+  for (let i2 = 0; i2 < str.length; i2++)
+    result.push(1 << +str[i2]);
+  return result;
+}
+var LowTypes = /* @__PURE__ */ dec("88888888888888888888888888888888888666888888787833333333337888888000000000000000000000000008888880000000000000000000000000088888888888888888888888888888888888887866668888088888663380888308888800000000000000000000000800000000000000000000000000000008");
+var ArabicTypes = /* @__PURE__ */ dec("4444448826627288999999999992222222222222222222222222222222222222222222222229999999999999999999994444444444644222822222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222999999949999999229989999223333333333");
+var Brackets = /* @__PURE__ */ Object.create(null);
+var BracketStack = [];
+for (let p of ["()", "[]", "{}"]) {
+  let l = /* @__PURE__ */ p.charCodeAt(0), r2 = /* @__PURE__ */ p.charCodeAt(1);
+  Brackets[l] = r2;
+  Brackets[r2] = -l;
+}
+function charType(ch) {
+  return ch <= 247 ? LowTypes[ch] : 1424 <= ch && ch <= 1524 ? 2 : 1536 <= ch && ch <= 1785 ? ArabicTypes[ch - 1536] : 1774 <= ch && ch <= 2220 ? 4 : 8192 <= ch && ch <= 8204 ? 256 : 64336 <= ch && ch <= 65023 ? 4 : 1;
+}
+var BidiRE = /[\u0590-\u05f4\u0600-\u06ff\u0700-\u08ac\ufb50-\ufdff]/;
+var BidiSpan = class {
+  /**
+  The direction of this span.
+  */
+  get dir() {
+    return this.level % 2 ? RTL : LTR;
+  }
+  /**
+  @internal
+  */
+  constructor(from, to, level) {
+    this.from = from;
+    this.to = to;
+    this.level = level;
+  }
+  /**
+  @internal
+  */
+  side(end, dir) {
+    return this.dir == dir == end ? this.to : this.from;
+  }
+  /**
+  @internal
+  */
+  forward(forward, dir) {
+    return forward == (this.dir == dir);
+  }
+  /**
+  @internal
+  */
+  static find(order, index, level, assoc) {
+    let maybe = -1;
+    for (let i2 = 0; i2 < order.length; i2++) {
+      let span = order[i2];
+      if (span.from <= index && span.to >= index) {
+        if (span.level == level)
+          return i2;
+        if (maybe < 0 || (assoc != 0 ? assoc < 0 ? span.from < index : span.to > index : order[maybe].level > span.level))
+          maybe = i2;
+      }
+    }
+    if (maybe < 0)
+      throw new RangeError("Index out of range");
+    return maybe;
+  }
+};
+function isolatesEq(a, b) {
+  if (a.length != b.length)
+    return false;
+  for (let i2 = 0; i2 < a.length; i2++) {
+    let iA = a[i2], iB = b[i2];
+    if (iA.from != iB.from || iA.to != iB.to || iA.direction != iB.direction || !isolatesEq(iA.inner, iB.inner))
+      return false;
+  }
+  return true;
+}
+var types = [];
+function computeCharTypes(line, rFrom, rTo, isolates, outerType) {
+  for (let iI = 0; iI <= isolates.length; iI++) {
+    let from = iI ? isolates[iI - 1].to : rFrom, to = iI < isolates.length ? isolates[iI].from : rTo;
+    let prevType = iI ? 256 : outerType;
+    for (let i2 = from, prev = prevType, prevStrong = prevType; i2 < to; i2++) {
+      let type = charType(line.charCodeAt(i2));
+      if (type == 512)
+        type = prev;
+      else if (type == 8 && prevStrong == 4)
+        type = 16;
+      types[i2] = type == 4 ? 2 : type;
+      if (type & 7)
+        prevStrong = type;
+      prev = type;
+    }
+    for (let i2 = from, prev = prevType, prevStrong = prevType; i2 < to; i2++) {
+      let type = types[i2];
+      if (type == 128) {
+        if (i2 < to - 1 && prev == types[i2 + 1] && prev & 24)
+          type = types[i2] = prev;
+        else
+          types[i2] = 256;
+      } else if (type == 64) {
+        let end = i2 + 1;
+        while (end < to && types[end] == 64)
+          end++;
+        let replace2 = i2 && prev == 8 || end < rTo && types[end] == 8 ? prevStrong == 1 ? 1 : 8 : 256;
+        for (let j = i2; j < end; j++)
+          types[j] = replace2;
+        i2 = end - 1;
+      } else if (type == 8 && prevStrong == 1) {
+        types[i2] = 1;
+      }
+      prev = type;
+      if (type & 7)
+        prevStrong = type;
+    }
+  }
+}
+function processBracketPairs(line, rFrom, rTo, isolates, outerType) {
+  let oppositeType = outerType == 1 ? 2 : 1;
+  for (let iI = 0, sI = 0, context = 0; iI <= isolates.length; iI++) {
+    let from = iI ? isolates[iI - 1].to : rFrom, to = iI < isolates.length ? isolates[iI].from : rTo;
+    for (let i2 = from, ch, br, type; i2 < to; i2++) {
+      if (br = Brackets[ch = line.charCodeAt(i2)]) {
+        if (br < 0) {
+          for (let sJ = sI - 3; sJ >= 0; sJ -= 3) {
+            if (BracketStack[sJ + 1] == -br) {
+              let flags = BracketStack[sJ + 2];
+              let type2 = flags & 2 ? outerType : !(flags & 4) ? 0 : flags & 1 ? oppositeType : outerType;
+              if (type2)
+                types[i2] = types[BracketStack[sJ]] = type2;
+              sI = sJ;
+              break;
+            }
+          }
+        } else if (BracketStack.length == 189) {
+          break;
+        } else {
+          BracketStack[sI++] = i2;
+          BracketStack[sI++] = ch;
+          BracketStack[sI++] = context;
+        }
+      } else if ((type = types[i2]) == 2 || type == 1) {
+        let embed = type == outerType;
+        context = embed ? 0 : 1;
+        for (let sJ = sI - 3; sJ >= 0; sJ -= 3) {
+          let cur = BracketStack[sJ + 2];
+          if (cur & 2)
+            break;
+          if (embed) {
+            BracketStack[sJ + 2] |= 2;
+          } else {
+            if (cur & 4)
+              break;
+            BracketStack[sJ + 2] |= 4;
+          }
+        }
+      }
+    }
+  }
+}
+function processNeutrals(rFrom, rTo, isolates, outerType) {
+  for (let iI = 0, prev = outerType; iI <= isolates.length; iI++) {
+    let from = iI ? isolates[iI - 1].to : rFrom, to = iI < isolates.length ? isolates[iI].from : rTo;
+    for (let i2 = from; i2 < to; ) {
+      let type = types[i2];
+      if (type == 256) {
+        let end = i2 + 1;
+        for (; ; ) {
+          if (end == to) {
+            if (iI == isolates.length)
+              break;
+            end = isolates[iI++].to;
+            to = iI < isolates.length ? isolates[iI].from : rTo;
+          } else if (types[end] == 256) {
+            end++;
+          } else {
+            break;
+          }
+        }
+        let beforeL = prev == 1;
+        let afterL = (end < rTo ? types[end] : outerType) == 1;
+        let replace2 = beforeL == afterL ? beforeL ? 1 : 2 : outerType;
+        for (let j = end, jI = iI, fromJ = jI ? isolates[jI - 1].to : rFrom; j > i2; ) {
+          if (j == fromJ) {
+            j = isolates[--jI].from;
+            fromJ = jI ? isolates[jI - 1].to : rFrom;
+          }
+          types[--j] = replace2;
+        }
+        i2 = end;
+      } else {
+        prev = type;
+        i2++;
+      }
+    }
+  }
+}
+function emitSpans(line, from, to, level, baseLevel, isolates, order) {
+  let ourType = level % 2 ? 2 : 1;
+  if (level % 2 == baseLevel % 2) {
+    for (let iCh = from, iI = 0; iCh < to; ) {
+      let sameDir = true, isNum = false;
+      if (iI == isolates.length || iCh < isolates[iI].from) {
+        let next = types[iCh];
+        if (next != ourType) {
+          sameDir = false;
+          isNum = next == 16;
+        }
+      }
+      let recurse = !sameDir && ourType == 1 ? [] : null;
+      let localLevel = sameDir ? level : level + 1;
+      let iScan = iCh;
+      run: for (; ; ) {
+        if (iI < isolates.length && iScan == isolates[iI].from) {
+          if (isNum)
+            break run;
+          let iso = isolates[iI];
+          if (!sameDir)
+            for (let upto = iso.to, jI = iI + 1; ; ) {
+              if (upto == to)
+                break run;
+              if (jI < isolates.length && isolates[jI].from == upto)
+                upto = isolates[jI++].to;
+              else if (types[upto] == ourType)
+                break run;
+              else
+                break;
+            }
+          iI++;
+          if (recurse) {
+            recurse.push(iso);
+          } else {
+            if (iso.from > iCh)
+              order.push(new BidiSpan(iCh, iso.from, localLevel));
+            let dirSwap = iso.direction == LTR != !(localLevel % 2);
+            computeSectionOrder(line, dirSwap ? level + 1 : level, baseLevel, iso.inner, iso.from, iso.to, order);
+            iCh = iso.to;
+          }
+          iScan = iso.to;
+        } else if (iScan == to || (sameDir ? types[iScan] != ourType : types[iScan] == ourType)) {
+          break;
+        } else {
+          iScan++;
+        }
+      }
+      if (recurse)
+        emitSpans(line, iCh, iScan, level + 1, baseLevel, recurse, order);
+      else if (iCh < iScan)
+        order.push(new BidiSpan(iCh, iScan, localLevel));
+      iCh = iScan;
+    }
+  } else {
+    for (let iCh = to, iI = isolates.length; iCh > from; ) {
+      let sameDir = true, isNum = false;
+      if (!iI || iCh > isolates[iI - 1].to) {
+        let next = types[iCh - 1];
+        if (next != ourType) {
+          sameDir = false;
+          isNum = next == 16;
+        }
+      }
+      let recurse = !sameDir && ourType == 1 ? [] : null;
+      let localLevel = sameDir ? level : level + 1;
+      let iScan = iCh;
+      run: for (; ; ) {
+        if (iI && iScan == isolates[iI - 1].to) {
+          if (isNum)
+            break run;
+          let iso = isolates[--iI];
+          if (!sameDir)
+            for (let upto = iso.from, jI = iI; ; ) {
+              if (upto == from)
+                break run;
+              if (jI && isolates[jI - 1].to == upto)
+                upto = isolates[--jI].from;
+              else if (types[upto - 1] == ourType)
+                break run;
+              else
+                break;
+            }
+          if (recurse) {
+            recurse.push(iso);
+          } else {
+            if (iso.to < iCh)
+              order.push(new BidiSpan(iso.to, iCh, localLevel));
+            let dirSwap = iso.direction == LTR != !(localLevel % 2);
+            computeSectionOrder(line, dirSwap ? level + 1 : level, baseLevel, iso.inner, iso.from, iso.to, order);
+            iCh = iso.from;
+          }
+          iScan = iso.from;
+        } else if (iScan == from || (sameDir ? types[iScan - 1] != ourType : types[iScan - 1] == ourType)) {
+          break;
+        } else {
+          iScan--;
+        }
+      }
+      if (recurse)
+        emitSpans(line, iScan, iCh, level + 1, baseLevel, recurse, order);
+      else if (iScan < iCh)
+        order.push(new BidiSpan(iScan, iCh, localLevel));
+      iCh = iScan;
+    }
+  }
+}
+function computeSectionOrder(line, level, baseLevel, isolates, from, to, order) {
+  let outerType = level % 2 ? 2 : 1;
+  computeCharTypes(line, from, to, isolates, outerType);
+  processBracketPairs(line, from, to, isolates, outerType);
+  processNeutrals(from, to, isolates, outerType);
+  emitSpans(line, from, to, level, baseLevel, isolates, order);
+}
+function computeOrder(line, direction, isolates) {
+  if (!line)
+    return [new BidiSpan(0, 0, direction == RTL ? 1 : 0)];
+  if (direction == LTR && !isolates.length && !BidiRE.test(line))
+    return trivialOrder(line.length);
+  if (isolates.length)
+    while (line.length > types.length)
+      types[types.length] = 256;
+  let order = [], level = direction == LTR ? 0 : 1;
+  computeSectionOrder(line, level, level, isolates, 0, line.length, order);
+  return order;
+}
+function trivialOrder(length) {
+  return [new BidiSpan(0, length, 0)];
+}
+var movedOver = "";
+function moveVisually(line, order, dir, start, forward) {
+  var _a2;
+  let startIndex = start.head - line.from;
+  let spanI = BidiSpan.find(order, startIndex, (_a2 = start.bidiLevel) !== null && _a2 !== void 0 ? _a2 : -1, start.assoc);
+  let span = order[spanI], spanEnd = span.side(forward, dir);
+  if (startIndex == spanEnd) {
+    let nextI = spanI += forward ? 1 : -1;
+    if (nextI < 0 || nextI >= order.length)
+      return null;
+    span = order[spanI = nextI];
+    startIndex = span.side(!forward, dir);
+    spanEnd = span.side(forward, dir);
+  }
+  let nextIndex = findClusterBreak2(line.text, startIndex, span.forward(forward, dir));
+  if (nextIndex < span.from || nextIndex > span.to)
+    nextIndex = spanEnd;
+  movedOver = line.text.slice(Math.min(startIndex, nextIndex), Math.max(startIndex, nextIndex));
+  let nextSpan = spanI == (forward ? order.length - 1 : 0) ? null : order[spanI + (forward ? 1 : -1)];
+  if (nextSpan && nextIndex == spanEnd && nextSpan.level + (forward ? 0 : 1) < span.level)
+    return EditorSelection.cursor(nextSpan.side(!forward, dir) + line.from, nextSpan.forward(forward, dir) ? 1 : -1, nextSpan.level);
+  return EditorSelection.cursor(nextIndex + line.from, span.forward(forward, dir) ? -1 : 1, span.level);
+}
+function autoDirection(text, from, to) {
+  for (let i2 = from; i2 < to; i2++) {
+    let type = charType(text.charCodeAt(i2));
+    if (type == 1)
+      return LTR;
+    if (type == 2 || type == 4)
+      return RTL;
+  }
+  return LTR;
+}
+var clickAddsSelectionRange = /* @__PURE__ */ Facet.define();
+var dragMovesSelection$1 = /* @__PURE__ */ Facet.define();
+var mouseSelectionStyle = /* @__PURE__ */ Facet.define();
+var exceptionSink = /* @__PURE__ */ Facet.define();
+var updateListener = /* @__PURE__ */ Facet.define();
+var inputHandler = /* @__PURE__ */ Facet.define();
+var focusChangeEffect = /* @__PURE__ */ Facet.define();
+var clipboardInputFilter = /* @__PURE__ */ Facet.define();
+var clipboardOutputFilter = /* @__PURE__ */ Facet.define();
+var perLineTextDirection = /* @__PURE__ */ Facet.define({
+  combine: (values) => values.some((x) => x)
+});
+var nativeSelectionHidden = /* @__PURE__ */ Facet.define({
+  combine: (values) => values.some((x) => x)
+});
+var scrollHandler = /* @__PURE__ */ Facet.define();
+var ScrollTarget = class _ScrollTarget {
+  constructor(range, y, x, yMargin, xMargin, isSnapshot = false) {
+    this.range = range;
+    this.y = y;
+    this.x = x;
+    this.yMargin = yMargin;
+    this.xMargin = xMargin;
+    this.isSnapshot = isSnapshot;
+  }
+  map(changes) {
+    return changes.empty ? this : new _ScrollTarget(this.range.map(changes), this.y, this.x, this.yMargin, this.xMargin, this.isSnapshot);
+  }
+  clip(state) {
+    return this.range.to <= state.doc.length ? this : new _ScrollTarget(EditorSelection.cursor(state.doc.length), this.y, this.x, this.yMargin, this.xMargin, this.isSnapshot);
+  }
+};
+var scrollIntoView = /* @__PURE__ */ StateEffect.define({ map: (t2, ch) => t2.map(ch) });
+var setEditContextFormatting = /* @__PURE__ */ StateEffect.define();
+function logException(state, exception, context) {
+  let handler = state.facet(exceptionSink);
+  if (handler.length)
+    handler[0](exception);
+  else if (window.onerror && window.onerror(String(exception), context, void 0, void 0, exception)) ;
+  else if (context)
+    console.error(context + ":", exception);
+  else
+    console.error(exception);
+}
+var editable = /* @__PURE__ */ Facet.define({ combine: (values) => values.length ? values[0] : true });
+var nextPluginID = 0;
+var viewPlugin = /* @__PURE__ */ Facet.define({
+  combine(plugins) {
+    return plugins.filter((p, i2) => {
+      for (let j = 0; j < i2; j++)
+        if (plugins[j].plugin == p.plugin)
+          return false;
+      return true;
+    });
+  }
+});
+var ViewPlugin = class _ViewPlugin {
+  constructor(id2, create, domEventHandlers, domEventObservers, buildExtensions) {
+    this.id = id2;
+    this.create = create;
+    this.domEventHandlers = domEventHandlers;
+    this.domEventObservers = domEventObservers;
+    this.baseExtensions = buildExtensions(this);
+    this.extension = this.baseExtensions.concat(viewPlugin.of({ plugin: this, arg: void 0 }));
+  }
+  /**
+  Create an extension for this plugin with the given argument.
+  */
+  of(arg) {
+    return this.baseExtensions.concat(viewPlugin.of({ plugin: this, arg }));
+  }
+  /**
+  Define a plugin from a constructor function that creates the
+  plugin's value, given an editor view.
+  */
+  static define(create, spec) {
+    const { eventHandlers, eventObservers, provide, decorations: deco } = spec || {};
+    return new _ViewPlugin(nextPluginID++, create, eventHandlers, eventObservers, (plugin) => {
+      let ext = [];
+      if (deco)
+        ext.push(decorations.of((view) => {
+          let pluginInst = view.plugin(plugin);
+          return pluginInst ? deco(pluginInst) : Decoration.none;
+        }));
+      if (provide)
+        ext.push(provide(plugin));
+      return ext;
+    });
+  }
+  /**
+  Create a plugin for a class whose constructor takes a single
+  editor view as argument.
+  */
+  static fromClass(cls, spec) {
+    return _ViewPlugin.define((view, arg) => new cls(view, arg), spec);
+  }
+};
+var PluginInstance = class {
+  constructor(spec) {
+    this.spec = spec;
+    this.mustUpdate = null;
+    this.value = null;
+  }
+  get plugin() {
+    return this.spec && this.spec.plugin;
+  }
+  update(view) {
+    if (!this.value) {
+      if (this.spec) {
+        try {
+          this.value = this.spec.plugin.create(view, this.spec.arg);
+        } catch (e) {
+          logException(view.state, e, "CodeMirror plugin crashed");
+          this.deactivate();
+        }
+      }
+    } else if (this.mustUpdate) {
+      let update = this.mustUpdate;
+      this.mustUpdate = null;
+      if (this.value.update) {
+        try {
+          this.value.update(update);
+        } catch (e) {
+          logException(update.state, e, "CodeMirror plugin crashed");
+          if (this.value.destroy)
+            try {
+              this.value.destroy();
+            } catch (_) {
+            }
+          this.deactivate();
+        }
+      }
+    }
+    return this;
+  }
+  destroy(view) {
+    var _a2;
+    if ((_a2 = this.value) === null || _a2 === void 0 ? void 0 : _a2.destroy) {
+      try {
+        this.value.destroy();
+      } catch (e) {
+        logException(view.state, e, "CodeMirror plugin crashed");
+      }
+    }
+  }
+  deactivate() {
+    this.spec = this.value = null;
+  }
+};
+var editorAttributes = /* @__PURE__ */ Facet.define();
+var contentAttributes = /* @__PURE__ */ Facet.define();
+var decorations = /* @__PURE__ */ Facet.define();
+var blockWrappers = /* @__PURE__ */ Facet.define();
+var outerDecorations = /* @__PURE__ */ Facet.define();
+var atomicRanges = /* @__PURE__ */ Facet.define();
+var bidiIsolatedRanges = /* @__PURE__ */ Facet.define();
+function getIsolatedRanges(view, line) {
+  let isolates = view.state.facet(bidiIsolatedRanges);
+  if (!isolates.length)
+    return isolates;
+  let sets = isolates.map((i2) => i2 instanceof Function ? i2(view) : i2);
+  let result = [];
+  RangeSet.spans(sets, line.from, line.to, {
+    point() {
+    },
+    span(fromDoc, toDoc, active, open) {
+      let from = fromDoc - line.from, to = toDoc - line.from;
+      let level = result;
+      for (let i2 = active.length - 1; i2 >= 0; i2--, open--) {
+        let direction = active[i2].spec.bidiIsolate, update;
+        if (direction == null)
+          direction = autoDirection(line.text, from, to);
+        if (open > 0 && level.length && (update = level[level.length - 1]).to == from && update.direction == direction) {
+          update.to = to;
+          level = update.inner;
+        } else {
+          let add = { from, to, direction, inner: [] };
+          level.push(add);
+          level = add.inner;
+        }
+      }
+    }
+  });
+  return result;
+}
+var scrollMargins = /* @__PURE__ */ Facet.define();
+function getScrollMargins(view) {
+  let left = 0, right = 0, top2 = 0, bottom = 0;
+  for (let source of view.state.facet(scrollMargins)) {
+    let m = source(view);
+    if (m) {
+      if (m.left != null)
+        left = Math.max(left, m.left);
+      if (m.right != null)
+        right = Math.max(right, m.right);
+      if (m.top != null)
+        top2 = Math.max(top2, m.top);
+      if (m.bottom != null)
+        bottom = Math.max(bottom, m.bottom);
+    }
+  }
+  return { left, right, top: top2, bottom };
+}
+var styleModule = /* @__PURE__ */ Facet.define();
+var ChangedRange = class _ChangedRange {
+  constructor(fromA, toA, fromB, toB) {
+    this.fromA = fromA;
+    this.toA = toA;
+    this.fromB = fromB;
+    this.toB = toB;
+  }
+  join(other) {
+    return new _ChangedRange(Math.min(this.fromA, other.fromA), Math.max(this.toA, other.toA), Math.min(this.fromB, other.fromB), Math.max(this.toB, other.toB));
+  }
+  addToSet(set) {
+    let i2 = set.length, me = this;
+    for (; i2 > 0; i2--) {
+      let range = set[i2 - 1];
+      if (range.fromA > me.toA)
+        continue;
+      if (range.toA < me.fromA)
+        break;
+      me = me.join(range);
+      set.splice(i2 - 1, 1);
+    }
+    set.splice(i2, 0, me);
+    return set;
+  }
+  // Extend a set to cover all the content in `ranges`, which is a
+  // flat array with each pair of numbers representing fromB/toB
+  // positions. These pairs are generated in unchanged ranges, so the
+  // offset between doc A and doc B is the same for their start and
+  // end points.
+  static extendWithRanges(diff, ranges) {
+    if (ranges.length == 0)
+      return diff;
+    let result = [];
+    for (let dI = 0, rI = 0, off = 0; ; ) {
+      let nextD = dI < diff.length ? diff[dI].fromB : 1e9;
+      let nextR = rI < ranges.length ? ranges[rI] : 1e9;
+      let fromB = Math.min(nextD, nextR);
+      if (fromB == 1e9)
+        break;
+      let fromA = fromB + off, toB = fromB, toA = fromA;
+      for (; ; ) {
+        if (rI < ranges.length && ranges[rI] <= toB) {
+          let end = ranges[rI + 1];
+          rI += 2;
+          toB = Math.max(toB, end);
+          for (let i2 = dI; i2 < diff.length && diff[i2].fromB <= toB; i2++)
+            off = diff[i2].toA - diff[i2].toB;
+          toA = Math.max(toA, end + off);
+        } else if (dI < diff.length && diff[dI].fromB <= toB) {
+          let next = diff[dI++];
+          toB = Math.max(toB, next.toB);
+          toA = Math.max(toA, next.toA);
+          off = next.toA - next.toB;
+        } else {
+          break;
+        }
+      }
+      result.push(new _ChangedRange(fromA, toA, fromB, toB));
+    }
+    return result;
+  }
+};
+var ViewUpdate = class _ViewUpdate {
+  constructor(view, state, transactions) {
+    this.view = view;
+    this.state = state;
+    this.transactions = transactions;
+    this.flags = 0;
+    this.startState = view.state;
+    this.changes = ChangeSet.empty(this.startState.doc.length);
+    for (let tr of transactions)
+      this.changes = this.changes.compose(tr.changes);
+    let changedRanges = [];
+    this.changes.iterChangedRanges((fromA, toA, fromB, toB) => changedRanges.push(new ChangedRange(fromA, toA, fromB, toB)));
+    this.changedRanges = changedRanges;
+  }
+  /**
+  @internal
+  */
+  static create(view, state, transactions) {
+    return new _ViewUpdate(view, state, transactions);
+  }
+  /**
+  Tells you whether the [viewport](https://codemirror.net/6/docs/ref/#view.EditorView.viewport) or
+  [visible ranges](https://codemirror.net/6/docs/ref/#view.EditorView.visibleRanges) changed in this
+  update.
+  */
+  get viewportChanged() {
+    return (this.flags & 4) > 0;
+  }
+  /**
+  Returns true when
+  [`viewportChanged`](https://codemirror.net/6/docs/ref/#view.ViewUpdate.viewportChanged) is true
+  and the viewport change is not just the result of mapping it in
+  response to document changes.
+  */
+  get viewportMoved() {
+    return (this.flags & 8) > 0;
+  }
+  /**
+  Indicates whether the height of a block element in the editor
+  changed in this update.
+  */
+  get heightChanged() {
+    return (this.flags & 2) > 0;
+  }
+  /**
+  Returns true when the document was modified or the size of the
+  editor, or elements within the editor, changed.
+  */
+  get geometryChanged() {
+    return this.docChanged || (this.flags & (16 | 2)) > 0;
+  }
+  /**
+  True when this update indicates a focus change.
+  */
+  get focusChanged() {
+    return (this.flags & 1) > 0;
+  }
+  /**
+  Whether the document changed in this update.
+  */
+  get docChanged() {
+    return !this.changes.empty;
+  }
+  /**
+  Whether the selection was explicitly set in this update.
+  */
+  get selectionSet() {
+    return this.transactions.some((tr) => tr.selection);
+  }
+  /**
+  @internal
+  */
+  get empty() {
+    return this.flags == 0 && this.transactions.length == 0;
+  }
+};
+var noChildren = [];
+var Tile = class {
+  constructor(dom, length, flags = 0) {
+    this.dom = dom;
+    this.length = length;
+    this.flags = flags;
+    this.parent = null;
+    dom.cmTile = this;
+  }
+  get breakAfter() {
+    return this.flags & 1;
+  }
+  get children() {
+    return noChildren;
+  }
+  isWidget() {
+    return false;
+  }
+  get isHidden() {
+    return false;
+  }
+  isComposite() {
+    return false;
+  }
+  isLine() {
+    return false;
+  }
+  isText() {
+    return false;
+  }
+  isBlock() {
+    return false;
+  }
+  get domAttrs() {
+    return null;
+  }
+  sync(track) {
+    this.flags |= 2;
+    if (this.flags & 4) {
+      this.flags &= ~4;
+      let attrs = this.domAttrs;
+      if (attrs)
+        setAttrs(this.dom, attrs);
+    }
+  }
+  toString() {
+    return this.constructor.name + (this.children.length ? `(${this.children})` : "") + (this.breakAfter ? "#" : "");
+  }
+  destroy() {
+    this.parent = null;
+  }
+  setDOM(dom) {
+    this.dom = dom;
+    dom.cmTile = this;
+  }
+  get posAtStart() {
+    return this.parent ? this.parent.posBefore(this) : 0;
+  }
+  get posAtEnd() {
+    return this.posAtStart + this.length;
+  }
+  posBefore(tile, start = this.posAtStart) {
+    let pos = start;
+    for (let child of this.children) {
+      if (child == tile)
+        return pos;
+      pos += child.length + child.breakAfter;
+    }
+    throw new RangeError("Invalid child in posBefore");
+  }
+  posAfter(tile) {
+    return this.posBefore(tile) + tile.length;
+  }
+  covers(side) {
+    return true;
+  }
+  coordsIn(pos, side) {
+    return null;
+  }
+  domPosFor(off, side) {
+    let index = domIndex(this.dom);
+    let after = this.length ? off > 0 : side > 0;
+    return new DOMPos(this.parent.dom, index + (after ? 1 : 0), off == 0 || off == this.length);
+  }
+  markDirty(attrs) {
+    this.flags &= ~2;
+    if (attrs)
+      this.flags |= 4;
+    if (this.parent && this.parent.flags & 2)
+      this.parent.markDirty(false);
+  }
+  get overrideDOMText() {
+    return null;
+  }
+  get root() {
+    for (let t2 = this; t2; t2 = t2.parent)
+      if (t2 instanceof DocTile)
+        return t2;
+    return null;
+  }
+  static get(dom) {
+    return dom.cmTile;
+  }
+};
+var CompositeTile = class extends Tile {
+  constructor(dom) {
+    super(dom, 0);
+    this._children = [];
+  }
+  isComposite() {
+    return true;
+  }
+  get children() {
+    return this._children;
+  }
+  get lastChild() {
+    return this.children.length ? this.children[this.children.length - 1] : null;
+  }
+  append(child) {
+    this.children.push(child);
+    child.parent = this;
+  }
+  sync(track) {
+    if (this.flags & 2)
+      return;
+    super.sync(track);
+    let parent = this.dom, prev = null, next;
+    let tracking = (track === null || track === void 0 ? void 0 : track.node) == parent ? track : null;
+    let length = 0;
+    for (let child of this.children) {
+      child.sync(track);
+      length += child.length + child.breakAfter;
+      next = prev ? prev.nextSibling : parent.firstChild;
+      if (tracking && next != child.dom)
+        tracking.written = true;
+      if (child.dom.parentNode == parent) {
+        while (next && next != child.dom)
+          next = rm$1(next);
+      } else {
+        parent.insertBefore(child.dom, next);
+      }
+      prev = child.dom;
+    }
+    next = prev ? prev.nextSibling : parent.firstChild;
+    if (tracking && next)
+      tracking.written = true;
+    while (next)
+      next = rm$1(next);
+    this.length = length;
+  }
+};
+function rm$1(dom) {
+  let next = dom.nextSibling;
+  dom.parentNode.removeChild(dom);
+  return next;
+}
+var DocTile = class extends CompositeTile {
+  constructor(view, dom) {
+    super(dom);
+    this.view = view;
+  }
+  owns(tile) {
+    for (; tile; tile = tile.parent)
+      if (tile == this)
+        return true;
+    return false;
+  }
+  isBlock() {
+    return true;
+  }
+  nearest(dom) {
+    for (; ; ) {
+      if (!dom)
+        return null;
+      let tile = Tile.get(dom);
+      if (tile && this.owns(tile))
+        return tile;
+      dom = dom.parentNode;
+    }
+  }
+  blockTiles(f) {
+    for (let stack = [], cur = this, i2 = 0, pos = 0; ; ) {
+      if (i2 == cur.children.length) {
+        if (!stack.length)
+          return;
+        cur = cur.parent;
+        if (cur.breakAfter)
+          pos++;
+        i2 = stack.pop();
+      } else {
+        let next = cur.children[i2++];
+        if (next instanceof BlockWrapperTile) {
+          stack.push(i2);
+          cur = next;
+          i2 = 0;
+        } else {
+          let end = pos + next.length;
+          let result = f(next, pos);
+          if (result !== void 0)
+            return result;
+          pos = end + next.breakAfter;
+        }
+      }
+    }
+  }
+  // Find the block at the given position. If side < -1, make sure to
+  // stay before block widgets at that position, if side > 1, after
+  // such widgets (used for selection drawing, which needs to be able
+  // to get coordinates for positions that aren't valid cursor positions).
+  resolveBlock(pos, side) {
+    let before, beforeOff = -1, after, afterOff = -1;
+    this.blockTiles((tile, off) => {
+      let end = off + tile.length;
+      if (pos >= off && pos <= end) {
+        if (tile.isWidget() && side >= -1 && side <= 1) {
+          if (tile.flags & 32)
+            return true;
+          if (tile.flags & 16)
+            before = void 0;
+        }
+        if ((off < pos || pos == end && (side < -1 ? tile.length : tile.covers(1))) && (!before || !tile.isWidget() && before.isWidget())) {
+          before = tile;
+          beforeOff = pos - off;
+        }
+        if ((end > pos || pos == off && (side > 1 ? tile.length : tile.covers(-1))) && (!after || !tile.isWidget() && after.isWidget())) {
+          after = tile;
+          afterOff = pos - off;
+        }
+      }
+    });
+    if (!before && !after)
+      throw new Error("No tile at position " + pos);
+    return before && side < 0 || !after ? { tile: before, offset: beforeOff } : { tile: after, offset: afterOff };
+  }
+};
+var BlockWrapperTile = class _BlockWrapperTile extends CompositeTile {
+  constructor(dom, wrapper) {
+    super(dom);
+    this.wrapper = wrapper;
+  }
+  isBlock() {
+    return true;
+  }
+  covers(side) {
+    if (!this.children.length)
+      return false;
+    return side < 0 ? this.children[0].covers(-1) : this.lastChild.covers(1);
+  }
+  get domAttrs() {
+    return this.wrapper.attributes;
+  }
+  static of(wrapper, dom) {
+    let tile = new _BlockWrapperTile(dom || document.createElement(wrapper.tagName), wrapper);
+    if (!dom)
+      tile.flags |= 4;
+    return tile;
+  }
+};
+var LineTile = class _LineTile extends CompositeTile {
+  constructor(dom, attrs) {
+    super(dom);
+    this.attrs = attrs;
+  }
+  isLine() {
+    return true;
+  }
+  static start(attrs, dom, keepAttrs) {
+    let line = new _LineTile(dom || document.createElement("div"), attrs);
+    if (!dom || !keepAttrs)
+      line.flags |= 4;
+    return line;
+  }
+  get domAttrs() {
+    return this.attrs;
+  }
+  // Find the tile associated with a given position in this line.
+  resolveInline(pos, side, forCoords) {
+    let before = null, beforeOff = -1, after = null, afterOff = -1;
+    function scan(tile, pos2) {
+      for (let i2 = 0, off = 0; i2 < tile.children.length && off <= pos2; i2++) {
+        let child = tile.children[i2], end = off + child.length;
+        if (end >= pos2) {
+          if (child.isComposite()) {
+            scan(child, pos2 - off);
+          } else if ((!after || after.isHidden && (side > 0 || forCoords && onSameLine(after, child))) && (end > pos2 || child.flags & 32)) {
+            after = child;
+            afterOff = pos2 - off;
+          } else if (off < pos2 || child.flags & 16 && !child.isHidden) {
+            before = child;
+            beforeOff = pos2 - off;
+          }
+        }
+        off = end;
+      }
+    }
+    scan(this, pos);
+    let target = (side < 0 ? before : after) || before || after;
+    return target ? { tile: target, offset: target == before ? beforeOff : afterOff } : null;
+  }
+  coordsIn(pos, side) {
+    let found = this.resolveInline(pos, side, true);
+    if (!found)
+      return fallbackRect(this);
+    return found.tile.coordsIn(Math.max(0, found.offset), side);
+  }
+  domIn(pos, side) {
+    let found = this.resolveInline(pos, side);
+    if (found) {
+      let { tile, offset } = found;
+      if (this.dom.contains(tile.dom)) {
+        if (tile.isText())
+          return new DOMPos(tile.dom, Math.min(tile.dom.nodeValue.length, offset));
+        return tile.domPosFor(offset, tile.flags & 16 ? 1 : tile.flags & 32 ? -1 : side);
+      }
+      let parent = found.tile.parent, saw = false;
+      for (let ch of parent.children) {
+        if (saw)
+          return new DOMPos(ch.dom, 0);
+        if (ch == found.tile) {
+          saw = true;
+        }
+      }
+    }
+    return new DOMPos(this.dom, 0);
+  }
+};
+function fallbackRect(tile) {
+  let last = tile.dom.lastChild;
+  if (!last)
+    return tile.dom.getBoundingClientRect();
+  let rects = clientRectsFor(last);
+  return rects[rects.length - 1] || null;
+}
+function onSameLine(a, b) {
+  let posA = a.coordsIn(0, 1), posB = b.coordsIn(0, 1);
+  return posA && posB && posB.top < posA.bottom;
+}
+var MarkTile = class _MarkTile extends CompositeTile {
+  constructor(dom, mark) {
+    super(dom);
+    this.mark = mark;
+  }
+  get domAttrs() {
+    return this.mark.attrs;
+  }
+  static of(mark, dom) {
+    let tile = new _MarkTile(dom || document.createElement(mark.tagName), mark);
+    if (!dom)
+      tile.flags |= 4;
+    return tile;
+  }
+};
+var TextTile = class _TextTile extends Tile {
+  constructor(dom, text) {
+    super(dom, text.length);
+    this.text = text;
+  }
+  sync(track) {
+    if (this.flags & 2)
+      return;
+    super.sync(track);
+    if (this.dom.nodeValue != this.text) {
+      if (track && track.node == this.dom)
+        track.written = true;
+      this.dom.nodeValue = this.text;
+    }
+  }
+  isText() {
+    return true;
+  }
+  toString() {
+    return JSON.stringify(this.text);
+  }
+  coordsIn(pos, side) {
+    let length = this.dom.nodeValue.length;
+    if (pos > length)
+      pos = length;
+    let from = pos, to = pos, flatten2 = 0;
+    if (pos == 0 && side < 0 || pos == length && side >= 0) {
+      if (!(browser.chrome || browser.gecko)) {
+        if (pos) {
+          from--;
+          flatten2 = 1;
+        } else if (to < length) {
+          to++;
+          flatten2 = -1;
+        }
+      }
+    } else {
+      if (side < 0)
+        from--;
+      else if (to < length)
+        to++;
+    }
+    let rects = textRange(this.dom, from, to).getClientRects();
+    if (!rects.length)
+      return null;
+    let rect = rects[(flatten2 ? flatten2 < 0 : side >= 0) ? 0 : rects.length - 1];
+    if (browser.safari && !flatten2 && rect.width == 0)
+      rect = Array.prototype.find.call(rects, (r2) => r2.width) || rect;
+    return flatten2 ? flattenRect(rect, flatten2 < 0) : rect || null;
+  }
+  static of(text, dom) {
+    let tile = new _TextTile(dom || document.createTextNode(text), text);
+    if (!dom)
+      tile.flags |= 2;
+    return tile;
+  }
+};
+var WidgetTile = class _WidgetTile extends Tile {
+  constructor(dom, length, widget, flags) {
+    super(dom, length, flags);
+    this.widget = widget;
+  }
+  isWidget() {
+    return true;
+  }
+  get isHidden() {
+    return this.widget.isHidden;
+  }
+  covers(side) {
+    if (this.flags & 48)
+      return false;
+    return (this.flags & (side < 0 ? 64 : 128)) > 0;
+  }
+  coordsIn(pos, side) {
+    return this.coordsInWidget(pos, side, false);
+  }
+  coordsInWidget(pos, side, block) {
+    let custom = this.widget.coordsAt(this.dom, pos, side);
+    if (custom)
+      return custom;
+    if (block) {
+      return flattenRect(this.dom.getBoundingClientRect(), this.length ? pos == 0 : side <= 0);
+    } else {
+      let rects = this.dom.getClientRects(), rect = null;
+      if (!rects.length)
+        return null;
+      let fromBack = this.flags & 16 ? true : this.flags & 32 ? false : pos > 0;
+      for (let i2 = fromBack ? rects.length - 1 : 0; ; i2 += fromBack ? -1 : 1) {
+        rect = rects[i2];
+        if (pos > 0 ? i2 == 0 : i2 == rects.length - 1 || rect.top < rect.bottom)
+          break;
+      }
+      return flattenRect(rect, !fromBack);
+    }
+  }
+  get overrideDOMText() {
+    if (!this.length)
+      return Text.empty;
+    let { root } = this;
+    if (!root)
+      return Text.empty;
+    let start = this.posAtStart;
+    return root.view.state.doc.slice(start, start + this.length);
+  }
+  destroy() {
+    super.destroy();
+    this.widget.destroy(this.dom);
+  }
+  static of(widget, view, length, flags, dom) {
+    if (!dom) {
+      dom = widget.toDOM(view);
+      if (!widget.editable)
+        dom.contentEditable = "false";
+    }
+    return new _WidgetTile(dom, length, widget, flags);
+  }
+};
+var WidgetBufferTile = class extends Tile {
+  constructor(flags) {
+    let img = document.createElement("img");
+    img.className = "cm-widgetBuffer";
+    img.setAttribute("aria-hidden", "true");
+    super(img, 0, flags);
+  }
+  get isHidden() {
+    return true;
+  }
+  get overrideDOMText() {
+    return Text.empty;
+  }
+  coordsIn(pos) {
+    return this.dom.getBoundingClientRect();
+  }
+};
+var TilePointer = class {
+  constructor(top2) {
+    this.index = 0;
+    this.beforeBreak = false;
+    this.parents = [];
+    this.tile = top2;
+  }
+  // Advance by the given distance. If side is -1, stop leaving or
+  // entering tiles, or skipping zero-length tiles, once the distance
+  // has been traversed. When side is 1, leave, enter, or skip
+  // everything at the end position.
+  advance(dist2, side, walker) {
+    let { tile, index, beforeBreak, parents } = this;
+    while (dist2 || side > 0) {
+      if (!tile.isComposite()) {
+        if (index == tile.length) {
+          beforeBreak = !!tile.breakAfter;
+          ({ tile, index } = parents.pop());
+          index++;
+        } else if (!dist2) {
+          break;
+        } else {
+          let take = Math.min(dist2, tile.length - index);
+          if (walker)
+            walker.skip(tile, index, index + take);
+          dist2 -= take;
+          index += take;
+        }
+      } else if (beforeBreak) {
+        if (!dist2)
+          break;
+        if (walker)
+          walker.break();
+        dist2--;
+        beforeBreak = false;
+      } else if (index == tile.children.length) {
+        if (!dist2 && !parents.length)
+          break;
+        if (walker)
+          walker.leave(tile);
+        beforeBreak = !!tile.breakAfter;
+        ({ tile, index } = parents.pop());
+        index++;
+      } else {
+        let next = tile.children[index], brk = next.breakAfter;
+        if ((side > 0 ? next.length <= dist2 : next.length < dist2) && (!walker || walker.skip(next, 0, next.length) !== false || !next.isComposite)) {
+          beforeBreak = !!brk;
+          index++;
+          dist2 -= next.length;
+        } else {
+          parents.push({ tile, index });
+          tile = next;
+          index = 0;
+          if (walker && next.isComposite())
+            walker.enter(next);
+        }
+      }
+    }
+    this.tile = tile;
+    this.index = index;
+    this.beforeBreak = beforeBreak;
+    return this;
+  }
+  get root() {
+    return this.parents.length ? this.parents[0].tile : this.tile;
+  }
+};
+var OpenWrapper = class {
+  constructor(from, to, wrapper, rank) {
+    this.from = from;
+    this.to = to;
+    this.wrapper = wrapper;
+    this.rank = rank;
+  }
+};
+var TileBuilder = class {
+  constructor(cache2, root, blockWrappers2) {
+    this.cache = cache2;
+    this.root = root;
+    this.blockWrappers = blockWrappers2;
+    this.curLine = null;
+    this.lastBlock = null;
+    this.afterWidget = null;
+    this.pos = 0;
+    this.wrappers = [];
+    this.wrapperPos = 0;
+  }
+  addText(text, marks2, openStart, tile) {
+    var _a2;
+    this.flushBuffer();
+    let parent = this.ensureMarks(marks2, openStart);
+    let prev = parent.lastChild;
+    if (prev && prev.isText() && !(prev.flags & 8) && prev.length + text.length < 512) {
+      this.cache.reused.set(
+        prev,
+        2
+        /* Reused.DOM */
+      );
+      let tile2 = parent.children[parent.children.length - 1] = new TextTile(prev.dom, prev.text + text);
+      tile2.parent = parent;
+    } else {
+      parent.append(tile || TextTile.of(text, (_a2 = this.cache.find(TextTile)) === null || _a2 === void 0 ? void 0 : _a2.dom));
+    }
+    this.pos += text.length;
+    this.afterWidget = null;
+  }
+  addComposition(composition, context) {
+    let line = this.curLine;
+    if (line.dom != context.line.dom) {
+      line.setDOM(this.cache.reused.has(context.line) ? freeNode(context.line.dom) : context.line.dom);
+      this.cache.reused.set(
+        context.line,
+        2
+        /* Reused.DOM */
+      );
+    }
+    let head = line;
+    for (let i2 = context.marks.length - 1; i2 >= 0; i2--) {
+      let mark = context.marks[i2];
+      let last = head.lastChild;
+      if (last instanceof MarkTile && last.mark.eq(mark.mark)) {
+        if (last.dom != mark.dom)
+          last.setDOM(freeNode(mark.dom));
+        head = last;
+      } else {
+        if (this.cache.reused.get(mark)) {
+          let tile = Tile.get(mark.dom);
+          if (tile)
+            tile.setDOM(freeNode(mark.dom));
+        }
+        let nw = MarkTile.of(mark.mark, mark.dom);
+        head.append(nw);
+        head = nw;
+      }
+      this.cache.reused.set(
+        mark,
+        2
+        /* Reused.DOM */
+      );
+    }
+    let oldTile = Tile.get(composition.text);
+    if (oldTile)
+      this.cache.reused.set(
+        oldTile,
+        2
+        /* Reused.DOM */
+      );
+    let text = new TextTile(composition.text, composition.text.nodeValue);
+    text.flags |= 8;
+    this.pos = composition.range.toB;
+    head.append(text);
+  }
+  addInlineWidget(widget, marks2, openStart) {
+    let noSpace = this.afterWidget && widget.flags & 48 && (this.afterWidget.flags & 48) == (widget.flags & 48);
+    if (!noSpace)
+      this.flushBuffer();
+    let parent = this.ensureMarks(marks2, openStart);
+    if (!noSpace && !(widget.flags & 16))
+      parent.append(this.getBuffer(1));
+    parent.append(widget);
+    this.pos += widget.length;
+    this.afterWidget = widget;
+  }
+  addMark(tile, marks2, openStart) {
+    this.flushBuffer();
+    let parent = this.ensureMarks(marks2, openStart);
+    parent.append(tile);
+    this.pos += tile.length;
+    this.afterWidget = null;
+  }
+  addBlockWidget(widget) {
+    this.getBlockPos().append(widget);
+    this.pos += widget.length;
+    this.lastBlock = widget;
+    this.endLine();
+  }
+  continueWidget(length) {
+    let widget = this.afterWidget || this.lastBlock;
+    widget.length += length;
+    this.pos += length;
+  }
+  addLineStart(attrs, dom) {
+    var _a2;
+    if (!attrs)
+      attrs = lineBaseAttrs;
+    let tile = LineTile.start(attrs, dom || ((_a2 = this.cache.find(LineTile)) === null || _a2 === void 0 ? void 0 : _a2.dom), !!dom);
+    this.getBlockPos().append(this.lastBlock = this.curLine = tile);
+  }
+  addLine(tile) {
+    this.getBlockPos().append(tile);
+    this.pos += tile.length;
+    this.lastBlock = tile;
+    this.endLine();
+  }
+  addBreak() {
+    this.lastBlock.flags |= 1;
+    this.endLine();
+    this.pos++;
+  }
+  addLineStartIfNotCovered(attrs) {
+    if (!this.blockPosCovered())
+      this.addLineStart(attrs);
+  }
+  ensureLine(attrs) {
+    if (!this.curLine)
+      this.addLineStart(attrs);
+  }
+  ensureMarks(marks2, openStart) {
+    var _a2;
+    let parent = this.curLine;
+    for (let i2 = marks2.length - 1; i2 >= 0; i2--) {
+      let mark = marks2[i2], last;
+      if (openStart > 0 && (last = parent.lastChild) && last instanceof MarkTile && last.mark.eq(mark)) {
+        parent = last;
+        openStart--;
+      } else {
+        let tile = MarkTile.of(mark, (_a2 = this.cache.find(MarkTile, (m) => m.mark.eq(mark))) === null || _a2 === void 0 ? void 0 : _a2.dom);
+        parent.append(tile);
+        parent = tile;
+        openStart = 0;
+      }
+    }
+    return parent;
+  }
+  endLine() {
+    if (this.curLine) {
+      this.flushBuffer();
+      let last = this.curLine.lastChild;
+      if (!last || !hasContent(this.curLine, false) || last.dom.nodeName != "BR" && last.isWidget() && !(browser.ios && hasContent(this.curLine, true)))
+        this.curLine.append(this.cache.findWidget(
+          BreakWidget,
+          0,
+          32
+          /* TileFlag.After */
+        ) || new WidgetTile(
+          BreakWidget.toDOM(),
+          0,
+          BreakWidget,
+          32
+          /* TileFlag.After */
+        ));
+      this.curLine = this.afterWidget = null;
+    }
+  }
+  updateBlockWrappers() {
+    if (this.wrapperPos > this.pos + 1e4) {
+      this.blockWrappers.goto(this.pos);
+      this.wrappers.length = 0;
+    }
+    for (let i2 = this.wrappers.length - 1; i2 >= 0; i2--)
+      if (this.wrappers[i2].to < this.pos)
+        this.wrappers.splice(i2, 1);
+    for (let cur = this.blockWrappers; cur.value && cur.from <= this.pos; cur.next())
+      if (cur.to >= this.pos) {
+        let rank = cur.rank * 102 + cur.value.rank;
+        let wrap = new OpenWrapper(cur.from, cur.to, cur.value, rank), i2 = this.wrappers.length;
+        while (i2 > 0 && (this.wrappers[i2 - 1].rank - wrap.rank || this.wrappers[i2 - 1].to - wrap.to) < 0)
+          i2--;
+        this.wrappers.splice(i2, 0, wrap);
+      }
+    this.wrapperPos = this.pos;
+  }
+  getBlockPos() {
+    var _a2;
+    this.updateBlockWrappers();
+    let parent = this.root;
+    for (let wrap of this.wrappers) {
+      let last = parent.lastChild;
+      if (wrap.from < this.pos && last instanceof BlockWrapperTile && last.wrapper.eq(wrap.wrapper)) {
+        parent = last;
+      } else {
+        let tile = BlockWrapperTile.of(wrap.wrapper, (_a2 = this.cache.find(BlockWrapperTile, (t2) => t2.wrapper.eq(wrap.wrapper))) === null || _a2 === void 0 ? void 0 : _a2.dom);
+        parent.append(tile);
+        parent = tile;
+      }
+    }
+    return parent;
+  }
+  blockPosCovered() {
+    let last = this.lastBlock;
+    return last != null && !last.breakAfter && (!last.isWidget() || (last.flags & (32 | 128)) > 0);
+  }
+  getBuffer(side) {
+    let flags = 2 | (side < 0 ? 16 : 32);
+    let found = this.cache.find(
+      WidgetBufferTile,
+      void 0,
+      1
+      /* Reused.Full */
+    );
+    if (found)
+      found.flags = flags;
+    return found || new WidgetBufferTile(flags);
+  }
+  flushBuffer() {
+    if (this.afterWidget && !(this.afterWidget.flags & 32)) {
+      this.afterWidget.parent.append(this.getBuffer(-1));
+      this.afterWidget = null;
+    }
+  }
+};
+var TextStream = class {
+  constructor(doc2) {
+    this.skipCount = 0;
+    this.text = "";
+    this.textOff = 0;
+    this.cursor = doc2.iter();
+  }
+  skip(len) {
+    if (this.textOff + len <= this.text.length) {
+      this.textOff += len;
+    } else {
+      this.skipCount += len - (this.text.length - this.textOff);
+      this.text = "";
+      this.textOff = 0;
+    }
+  }
+  next(maxLen) {
+    if (this.textOff == this.text.length) {
+      let { value, lineBreak, done } = this.cursor.next(this.skipCount);
+      this.skipCount = 0;
+      if (done)
+        throw new Error("Ran out of text content when drawing inline views");
+      this.text = value;
+      let len = this.textOff = Math.min(maxLen, value.length);
+      return lineBreak ? null : value.slice(0, len);
+    }
+    let end = Math.min(this.text.length, this.textOff + maxLen);
+    let chars = this.text.slice(this.textOff, end);
+    this.textOff = end;
+    return chars;
+  }
+};
+var buckets = [WidgetTile, LineTile, TextTile, MarkTile, WidgetBufferTile, BlockWrapperTile, DocTile];
+for (let i2 = 0; i2 < buckets.length; i2++)
+  buckets[i2].bucket = i2;
+var TileCache = class {
+  constructor(view) {
+    this.view = view;
+    this.buckets = buckets.map(() => []);
+    this.index = buckets.map(() => 0);
+    this.reused = /* @__PURE__ */ new Map();
+  }
+  // Put a tile in the cache.
+  add(tile) {
+    let i2 = tile.constructor.bucket, bucket = this.buckets[i2];
+    if (bucket.length < 6)
+      bucket.push(tile);
+    else
+      bucket[
+        this.index[i2] = (this.index[i2] + 1) % 6
+        /* C.Bucket */
+      ] = tile;
+  }
+  find(cls, test, type = 2) {
+    let i2 = cls.bucket;
+    let bucket = this.buckets[i2], off = this.index[i2];
+    for (let j = bucket.length - 1; j >= 0; j--) {
+      let index = (j + off) % bucket.length, tile = bucket[index];
+      if ((!test || test(tile)) && !this.reused.has(tile)) {
+        bucket.splice(index, 1);
+        if (index < off)
+          this.index[i2]--;
+        this.reused.set(tile, type);
+        return tile;
+      }
+    }
+    return null;
+  }
+  findWidget(widget, length, flags) {
+    let widgets = this.buckets[0];
+    if (widgets.length)
+      for (let i2 = 0, pass = 0; ; i2++) {
+        if (i2 == widgets.length) {
+          if (pass)
+            return null;
+          pass = 1;
+          i2 = 0;
+        }
+        let tile = widgets[i2];
+        if (!this.reused.has(tile) && (pass == 0 ? tile.widget.compare(widget) : tile.widget.constructor == widget.constructor && widget.updateDOM(tile.dom, this.view, tile.widget))) {
+          widgets.splice(i2, 1);
+          if (i2 < this.index[0])
+            this.index[0]--;
+          if (tile.widget == widget && tile.length == length && (tile.flags & (496 | 1)) == flags) {
+            this.reused.set(
+              tile,
+              1
+              /* Reused.Full */
+            );
+            return tile;
+          } else {
+            this.reused.set(
+              tile,
+              2
+              /* Reused.DOM */
+            );
+            return new WidgetTile(tile.dom, length, widget, tile.flags & ~(496 | 1) | flags);
+          }
+        }
+      }
+  }
+  reuse(tile) {
+    this.reused.set(
+      tile,
+      1
+      /* Reused.Full */
+    );
+    return tile;
+  }
+  maybeReuse(tile, type = 2) {
+    if (this.reused.has(tile))
+      return void 0;
+    this.reused.set(tile, type);
+    return tile.dom;
+  }
+  clear() {
+    for (let i2 = 0; i2 < this.buckets.length; i2++)
+      this.buckets[i2].length = this.index[i2] = 0;
+  }
+};
+var TileUpdate = class {
+  constructor(view, old, blockWrappers2, decorations2, disallowBlockEffectsFor) {
+    this.view = view;
+    this.decorations = decorations2;
+    this.disallowBlockEffectsFor = disallowBlockEffectsFor;
+    this.openWidget = false;
+    this.openMarks = 0;
+    this.cache = new TileCache(view);
+    this.text = new TextStream(view.state.doc);
+    this.builder = new TileBuilder(this.cache, new DocTile(view, view.contentDOM), RangeSet.iter(blockWrappers2));
+    this.cache.reused.set(
+      old,
+      2
+      /* Reused.DOM */
+    );
+    this.old = new TilePointer(old);
+    this.reuseWalker = {
+      skip: (tile, from, to) => {
+        this.cache.add(tile);
+        if (tile.isComposite())
+          return false;
+      },
+      enter: (tile) => this.cache.add(tile),
+      leave: () => {
+      },
+      break: () => {
+      }
+    };
+  }
+  run(changes, composition) {
+    let compositionContext = composition && this.getCompositionContext(composition.text);
+    for (let posA = 0, posB = 0, i2 = 0; ; ) {
+      let next = i2 < changes.length ? changes[i2++] : null;
+      let skipA = next ? next.fromA : this.old.root.length;
+      if (skipA > posA) {
+        let len = skipA - posA;
+        this.preserve(len, !i2, !next);
+        posA = skipA;
+        posB += len;
+      }
+      if (!next)
+        break;
+      if (composition && next.fromA <= composition.range.fromA && next.toA >= composition.range.toA) {
+        this.forward(next.fromA, composition.range.fromA, composition.range.fromA < composition.range.toA ? 1 : -1);
+        this.emit(posB, composition.range.fromB);
+        this.builder.flushBuffer();
+        this.cache.clear();
+        this.builder.addComposition(composition, compositionContext);
+        this.text.skip(composition.range.toB - composition.range.fromB);
+        this.forward(composition.range.fromA, next.toA);
+        this.emit(composition.range.toB, next.toB);
+      } else {
+        this.forward(next.fromA, next.toA);
+        this.emit(posB, next.toB);
+      }
+      posB = next.toB;
+      posA = next.toA;
+    }
+    if (this.builder.curLine)
+      this.builder.endLine();
+    return this.builder.root;
+  }
+  preserve(length, incStart, incEnd) {
+    let activeMarks = getMarks(this.old), openMarks = this.openMarks;
+    this.old.advance(length, incEnd ? 1 : -1, {
+      skip: (tile, from, to) => {
+        if (tile.isWidget()) {
+          if (this.openWidget) {
+            this.builder.continueWidget(to - from);
+          } else {
+            let widget = to > 0 || from < tile.length ? WidgetTile.of(tile.widget, this.view, to - from, tile.flags & 496, this.cache.maybeReuse(tile)) : this.cache.reuse(tile);
+            if (widget.flags & 256) {
+              widget.flags &= ~1;
+              this.builder.addBlockWidget(widget);
+            } else {
+              this.builder.ensureLine(null);
+              this.builder.addInlineWidget(widget, activeMarks, openMarks);
+              openMarks = activeMarks.length;
+            }
+          }
+        } else if (tile.isText()) {
+          this.builder.ensureLine(null);
+          if (!from && to == tile.length && !this.cache.reused.has(tile)) {
+            this.builder.addText(tile.text, activeMarks, openMarks, this.cache.reuse(tile));
+          } else {
+            this.cache.add(tile);
+            this.builder.addText(tile.text.slice(from, to), activeMarks, openMarks);
+          }
+          openMarks = activeMarks.length;
+        } else if (tile.isLine()) {
+          tile.flags &= ~1;
+          this.cache.reused.set(
+            tile,
+            1
+            /* Reused.Full */
+          );
+          this.builder.addLine(tile);
+        } else if (tile instanceof WidgetBufferTile) {
+          this.cache.add(tile);
+        } else if (tile instanceof MarkTile) {
+          this.builder.ensureLine(null);
+          this.builder.addMark(tile, activeMarks, openMarks);
+          this.cache.reused.set(
+            tile,
+            1
+            /* Reused.Full */
+          );
+          openMarks = activeMarks.length;
+        } else {
+          return false;
+        }
+        this.openWidget = false;
+      },
+      enter: (tile) => {
+        if (tile.isLine()) {
+          this.builder.addLineStart(tile.attrs, this.cache.maybeReuse(tile));
+        } else {
+          this.cache.add(tile);
+          if (tile instanceof MarkTile)
+            activeMarks.unshift(tile.mark);
+        }
+        this.openWidget = false;
+      },
+      leave: (tile) => {
+        if (tile.isLine()) {
+          if (activeMarks.length)
+            activeMarks.length = openMarks = 0;
+        } else if (tile instanceof MarkTile) {
+          activeMarks.shift();
+          openMarks = Math.min(openMarks, activeMarks.length);
+        }
+      },
+      break: () => {
+        this.builder.addBreak();
+        this.openWidget = false;
+      }
+    });
+    this.text.skip(length);
+  }
+  emit(from, to) {
+    let pendingLineAttrs = null;
+    let b = this.builder, markCount = 0;
+    let openEnd = RangeSet.spans(this.decorations, from, to, {
+      point: (from2, to2, deco, active, openStart, index) => {
+        if (deco instanceof PointDecoration) {
+          if (this.disallowBlockEffectsFor[index]) {
+            if (deco.block)
+              throw new RangeError("Block decorations may not be specified via plugins");
+            if (to2 > this.view.state.doc.lineAt(from2).to)
+              throw new RangeError("Decorations that replace line breaks may not be specified via plugins");
+          }
+          markCount = active.length;
+          if (openStart > active.length) {
+            b.continueWidget(to2 - from2);
+          } else {
+            let widget = deco.widget || (deco.block ? NullWidget.block : NullWidget.inline);
+            let flags = widgetFlags(deco);
+            let tile = this.cache.findWidget(widget, to2 - from2, flags) || WidgetTile.of(widget, this.view, to2 - from2, flags);
+            if (deco.block) {
+              if (deco.startSide > 0)
+                b.addLineStartIfNotCovered(pendingLineAttrs);
+              b.addBlockWidget(tile);
+            } else {
+              b.ensureLine(pendingLineAttrs);
+              b.addInlineWidget(tile, active, openStart);
+            }
+          }
+          pendingLineAttrs = null;
+        } else {
+          pendingLineAttrs = addLineDeco(pendingLineAttrs, deco);
+        }
+        if (to2 > from2)
+          this.text.skip(to2 - from2);
+      },
+      span: (from2, to2, active, openStart) => {
+        for (let pos = from2; pos < to2; ) {
+          let chars = this.text.next(Math.min(512, to2 - pos));
+          if (chars == null) {
+            b.addLineStartIfNotCovered(pendingLineAttrs);
+            b.addBreak();
+            pos++;
+          } else {
+            b.ensureLine(pendingLineAttrs);
+            b.addText(chars, active, pos == from2 ? openStart : active.length);
+            pos += chars.length;
+          }
+          pendingLineAttrs = null;
+        }
+      }
+    });
+    this.openWidget = openEnd > markCount;
+    if (!this.openWidget)
+      b.addLineStartIfNotCovered(pendingLineAttrs);
+    this.openMarks = openEnd;
+  }
+  forward(from, to, side = 1) {
+    if (to - from <= 10) {
+      this.old.advance(to - from, side, this.reuseWalker);
+    } else {
+      this.old.advance(5, -1, this.reuseWalker);
+      this.old.advance(to - from - 10, -1);
+      this.old.advance(5, side, this.reuseWalker);
+    }
+  }
+  getCompositionContext(text) {
+    let marks2 = [], line = null;
+    for (let parent = text.parentNode; ; parent = parent.parentNode) {
+      let tile = Tile.get(parent);
+      if (parent == this.view.contentDOM)
+        break;
+      if (tile instanceof MarkTile)
+        marks2.push(tile);
+      else if (tile === null || tile === void 0 ? void 0 : tile.isLine())
+        line = tile;
+      else if (tile instanceof BlockWrapperTile) ;
+      else if (parent.nodeName == "DIV" && !line && parent != this.view.contentDOM)
+        line = new LineTile(parent, lineBaseAttrs);
+      else if (!line)
+        marks2.push(MarkTile.of(new MarkDecoration({ tagName: parent.nodeName.toLowerCase(), attributes: getAttrs(parent) }), parent));
+    }
+    return { line, marks: marks2 };
+  }
+};
+function hasContent(tile, requireText) {
+  let scan = (tile2) => {
+    for (let ch of tile2.children)
+      if ((requireText ? ch.isText() : ch.length) || scan(ch))
+        return true;
+    return false;
+  };
+  return scan(tile);
+}
+function widgetFlags(deco) {
+  let flags = deco.isReplace ? (deco.startSide < 0 ? 64 : 0) | (deco.endSide > 0 ? 128 : 0) : deco.startSide > 0 ? 32 : 16;
+  if (deco.block)
+    flags |= 256;
+  return flags;
+}
+var lineBaseAttrs = { class: "cm-line" };
+function addLineDeco(value, deco) {
+  let attrs = deco.spec.attributes, cls = deco.spec.class;
+  if (!attrs && !cls)
+    return value;
+  if (!value)
+    value = { class: "cm-line" };
+  if (attrs)
+    combineAttrs(attrs, value);
+  if (cls)
+    value.class += " " + cls;
+  return value;
+}
+function getMarks(ptr) {
+  let found = [];
+  for (let i2 = ptr.parents.length; i2 > 1; i2--) {
+    let tile = i2 == ptr.parents.length ? ptr.tile : ptr.parents[i2].tile;
+    if (tile instanceof MarkTile)
+      found.push(tile.mark);
+  }
+  return found;
+}
+function freeNode(node) {
+  let tile = Tile.get(node);
+  if (tile)
+    tile.setDOM(node.cloneNode());
+  return node;
+}
+var NullWidget = class extends WidgetType {
+  constructor(tag) {
+    super();
+    this.tag = tag;
+  }
+  eq(other) {
+    return other.tag == this.tag;
+  }
+  toDOM() {
+    return document.createElement(this.tag);
+  }
+  updateDOM(elt) {
+    return elt.nodeName.toLowerCase() == this.tag;
+  }
+  get isHidden() {
+    return true;
+  }
+};
+NullWidget.inline = /* @__PURE__ */ new NullWidget("span");
+NullWidget.block = /* @__PURE__ */ new NullWidget("div");
+var BreakWidget = /* @__PURE__ */ new class extends WidgetType {
+  toDOM() {
+    return document.createElement("br");
+  }
+  get isHidden() {
+    return true;
+  }
+  get editable() {
+    return true;
+  }
+}();
+var DocView = class {
+  constructor(view) {
+    this.view = view;
+    this.decorations = [];
+    this.blockWrappers = [];
+    this.dynamicDecorationMap = [false];
+    this.domChanged = null;
+    this.hasComposition = null;
+    this.editContextFormatting = Decoration.none;
+    this.lastCompositionAfterCursor = false;
+    this.minWidth = 0;
+    this.minWidthFrom = 0;
+    this.minWidthTo = 0;
+    this.impreciseAnchor = null;
+    this.impreciseHead = null;
+    this.forceSelection = false;
+    this.lastUpdate = Date.now();
+    this.updateDeco();
+    this.tile = new DocTile(view, view.contentDOM);
+    this.updateInner([new ChangedRange(0, 0, 0, view.state.doc.length)], null);
+  }
+  // Update the document view to a given state.
+  update(update) {
+    var _a2;
+    let changedRanges = update.changedRanges;
+    if (this.minWidth > 0 && changedRanges.length) {
+      if (!changedRanges.every(({ fromA, toA }) => toA < this.minWidthFrom || fromA > this.minWidthTo)) {
+        this.minWidth = this.minWidthFrom = this.minWidthTo = 0;
+      } else {
+        this.minWidthFrom = update.changes.mapPos(this.minWidthFrom, 1);
+        this.minWidthTo = update.changes.mapPos(this.minWidthTo, 1);
+      }
+    }
+    this.updateEditContextFormatting(update);
+    let readCompositionAt = -1;
+    if (this.view.inputState.composing >= 0 && !this.view.observer.editContext) {
+      if ((_a2 = this.domChanged) === null || _a2 === void 0 ? void 0 : _a2.newSel)
+        readCompositionAt = this.domChanged.newSel.head;
+      else if (!touchesComposition(update.changes, this.hasComposition) && !update.selectionSet)
+        readCompositionAt = update.state.selection.main.head;
+    }
+    let composition = readCompositionAt > -1 ? findCompositionRange(this.view, update.changes, readCompositionAt) : null;
+    this.domChanged = null;
+    if (this.hasComposition) {
+      let { from, to } = this.hasComposition;
+      changedRanges = new ChangedRange(from, to, update.changes.mapPos(from, -1), update.changes.mapPos(to, 1)).addToSet(changedRanges.slice());
+    }
+    this.hasComposition = composition ? { from: composition.range.fromB, to: composition.range.toB } : null;
+    if ((browser.ie || browser.chrome) && !composition && update && update.state.doc.lines != update.startState.doc.lines)
+      this.forceSelection = true;
+    let prevDeco = this.decorations, prevWrappers = this.blockWrappers;
+    this.updateDeco();
+    let decoDiff = findChangedDeco(prevDeco, this.decorations, update.changes);
+    if (decoDiff.length)
+      changedRanges = ChangedRange.extendWithRanges(changedRanges, decoDiff);
+    let blockDiff = findChangedWrappers(prevWrappers, this.blockWrappers, update.changes);
+    if (blockDiff.length)
+      changedRanges = ChangedRange.extendWithRanges(changedRanges, blockDiff);
+    if (composition && !changedRanges.some((r2) => r2.fromA <= composition.range.fromA && r2.toA >= composition.range.toA))
+      changedRanges = composition.range.addToSet(changedRanges.slice());
+    if (this.tile.flags & 2 && changedRanges.length == 0) {
+      return false;
+    } else {
+      this.updateInner(changedRanges, composition);
+      if (update.transactions.length)
+        this.lastUpdate = Date.now();
+      return true;
+    }
+  }
+  // Used by update and the constructor do perform the actual DOM
+  // update
+  updateInner(changes, composition) {
+    this.view.viewState.mustMeasureContent = true;
+    let { observer } = this.view;
+    observer.ignore(() => {
+      if (composition || changes.length) {
+        let oldTile = this.tile;
+        let builder = new TileUpdate(this.view, oldTile, this.blockWrappers, this.decorations, this.dynamicDecorationMap);
+        if (composition && Tile.get(composition.text))
+          builder.cache.reused.set(
+            Tile.get(composition.text),
+            2
+            /* Reused.DOM */
+          );
+        this.tile = builder.run(changes, composition);
+        destroyDropped(oldTile, builder.cache.reused);
+      }
+      this.tile.dom.style.height = this.view.viewState.contentHeight / this.view.scaleY + "px";
+      this.tile.dom.style.flexBasis = this.minWidth ? this.minWidth + "px" : "";
+      let track = browser.chrome || browser.ios ? { node: observer.selectionRange.focusNode, written: false } : void 0;
+      this.tile.sync(track);
+      if (track && (track.written || observer.selectionRange.focusNode != track.node || !this.tile.dom.contains(track.node)))
+        this.forceSelection = true;
+      this.tile.dom.style.height = "";
+    });
+    let gaps = [];
+    if (this.view.viewport.from || this.view.viewport.to < this.view.state.doc.length) {
+      for (let child of this.tile.children)
+        if (child.isWidget() && child.widget instanceof BlockGapWidget)
+          gaps.push(child.dom);
+    }
+    observer.updateGaps(gaps);
+  }
+  updateEditContextFormatting(update) {
+    this.editContextFormatting = this.editContextFormatting.map(update.changes);
+    for (let tr of update.transactions)
+      for (let effect of tr.effects)
+        if (effect.is(setEditContextFormatting)) {
+          this.editContextFormatting = effect.value;
+        }
+  }
+  // Sync the DOM selection to this.state.selection
+  updateSelection(mustRead = false, fromPointer = false) {
+    if (mustRead || !this.view.observer.selectionRange.focusNode)
+      this.view.observer.readSelectionRange();
+    let { dom } = this.tile;
+    let activeElt = this.view.root.activeElement, focused = activeElt == dom;
+    let selectionNotFocus = !focused && !(this.view.state.facet(editable) || dom.tabIndex > -1) && hasSelection(dom, this.view.observer.selectionRange) && !(activeElt && dom.contains(activeElt));
+    if (!(focused || fromPointer || selectionNotFocus))
+      return;
+    let force = this.forceSelection;
+    this.forceSelection = false;
+    let main = this.view.state.selection.main, anchor, head;
+    if (main.empty) {
+      head = anchor = this.inlineDOMNearPos(main.anchor, main.assoc || 1);
+    } else {
+      head = this.inlineDOMNearPos(main.head, main.head == main.from ? 1 : -1);
+      anchor = this.inlineDOMNearPos(main.anchor, main.anchor == main.from ? 1 : -1);
+    }
+    if (browser.gecko && main.empty && !this.hasComposition && betweenUneditable(anchor)) {
+      let dummy = document.createTextNode("");
+      this.view.observer.ignore(() => anchor.node.insertBefore(dummy, anchor.node.childNodes[anchor.offset] || null));
+      anchor = head = new DOMPos(dummy, 0);
+      force = true;
+    }
+    let domSel = this.view.observer.selectionRange;
+    if (force || !domSel.focusNode || (!isEquivalentPosition(anchor.node, anchor.offset, domSel.anchorNode, domSel.anchorOffset) || !isEquivalentPosition(head.node, head.offset, domSel.focusNode, domSel.focusOffset)) && !this.suppressWidgetCursorChange(domSel, main)) {
+      this.view.observer.ignore(() => {
+        if (browser.android && browser.chrome && dom.contains(domSel.focusNode) && inUneditable(domSel.focusNode, dom)) {
+          dom.blur();
+          dom.focus({ preventScroll: true });
+        }
+        let rawSel = getSelection(this.view.root);
+        if (!rawSel) ;
+        else if (main.empty) {
+          if (browser.gecko) {
+            let nextTo = nextToUneditable(anchor.node, anchor.offset);
+            if (nextTo && nextTo != (1 | 2)) {
+              let text = (nextTo == 1 ? textNodeBefore : textNodeAfter)(anchor.node, anchor.offset);
+              if (text)
+                anchor = new DOMPos(text.node, text.offset);
+            }
+          }
+          rawSel.collapse(anchor.node, anchor.offset);
+          if (main.bidiLevel != null && rawSel.caretBidiLevel !== void 0)
+            rawSel.caretBidiLevel = main.bidiLevel;
+        } else if (rawSel.extend) {
+          rawSel.collapse(anchor.node, anchor.offset);
+          try {
+            rawSel.extend(head.node, head.offset);
+          } catch (_) {
+          }
+        } else {
+          let range = document.createRange();
+          if (main.anchor > main.head)
+            [anchor, head] = [head, anchor];
+          range.setEnd(head.node, head.offset);
+          range.setStart(anchor.node, anchor.offset);
+          rawSel.removeAllRanges();
+          rawSel.addRange(range);
+        }
+        if (selectionNotFocus && this.view.root.activeElement == dom) {
+          dom.blur();
+          if (activeElt)
+            activeElt.focus();
+        }
+      });
+      this.view.observer.setSelectionRange(anchor, head);
+    }
+    this.impreciseAnchor = anchor.precise ? null : new DOMPos(domSel.anchorNode, domSel.anchorOffset);
+    this.impreciseHead = head.precise ? null : new DOMPos(domSel.focusNode, domSel.focusOffset);
+  }
+  // If a zero-length widget is inserted next to the cursor during
+  // composition, avoid moving it across it and disrupting the
+  // composition.
+  suppressWidgetCursorChange(sel, cursor) {
+    return this.hasComposition && cursor.empty && isEquivalentPosition(sel.focusNode, sel.focusOffset, sel.anchorNode, sel.anchorOffset) && this.posFromDOM(sel.focusNode, sel.focusOffset) == cursor.head;
+  }
+  enforceCursorAssoc() {
+    if (this.hasComposition)
+      return;
+    let { view } = this, cursor = view.state.selection.main;
+    let sel = getSelection(view.root);
+    let { anchorNode, anchorOffset } = view.observer.selectionRange;
+    if (!sel || !cursor.empty || !cursor.assoc || !sel.modify)
+      return;
+    let line = this.lineAt(cursor.head, cursor.assoc);
+    if (!line)
+      return;
+    let lineStart = line.posAtStart;
+    if (cursor.head == lineStart || cursor.head == lineStart + line.length)
+      return;
+    let before = this.coordsAt(cursor.head, -1), after = this.coordsAt(cursor.head, 1);
+    if (!before || !after || before.bottom > after.top)
+      return;
+    let dom = this.domAtPos(cursor.head + cursor.assoc, cursor.assoc);
+    sel.collapse(dom.node, dom.offset);
+    sel.modify("move", cursor.assoc < 0 ? "forward" : "backward", "lineboundary");
+    view.observer.readSelectionRange();
+    let newRange = view.observer.selectionRange;
+    if (view.docView.posFromDOM(newRange.anchorNode, newRange.anchorOffset) != cursor.from)
+      sel.collapse(anchorNode, anchorOffset);
+  }
+  posFromDOM(node, offset) {
+    let tile = this.tile.nearest(node);
+    if (!tile)
+      return this.tile.dom.compareDocumentPosition(node) & 2 ? 0 : this.view.state.doc.length;
+    let start = tile.posAtStart;
+    if (tile.isComposite()) {
+      let after;
+      if (node == tile.dom) {
+        after = tile.dom.childNodes[offset];
+      } else {
+        let bias = maxOffset(node) == 0 ? 0 : offset == 0 ? -1 : 1;
+        for (; ; ) {
+          let parent = node.parentNode;
+          if (parent == tile.dom)
+            break;
+          if (bias == 0 && parent.firstChild != parent.lastChild) {
+            if (node == parent.firstChild)
+              bias = -1;
+            else
+              bias = 1;
+          }
+          node = parent;
+        }
+        if (bias < 0)
+          after = node;
+        else
+          after = node.nextSibling;
+      }
+      if (after == tile.dom.firstChild)
+        return start;
+      while (after && !Tile.get(after))
+        after = after.nextSibling;
+      if (!after)
+        return start + tile.length;
+      for (let i2 = 0, pos = start; ; i2++) {
+        let child = tile.children[i2];
+        if (child.dom == after)
+          return pos;
+        pos += child.length + child.breakAfter;
+      }
+    } else if (tile.isText()) {
+      return node == tile.dom ? start + offset : start + (offset ? tile.length : 0);
+    } else {
+      return start;
+    }
+  }
+  domAtPos(pos, side) {
+    let { tile, offset } = this.tile.resolveBlock(pos, side);
+    if (tile.isWidget())
+      return tile.domPosFor(pos, side);
+    return tile.domIn(offset, side);
+  }
+  inlineDOMNearPos(pos, side) {
+    let before, beforeOff = -1, beforeBad = false;
+    let after, afterOff = -1, afterBad = false;
+    this.tile.blockTiles((tile, off) => {
+      if (tile.isWidget()) {
+        if (tile.flags & 32 && off >= pos)
+          return true;
+        if (tile.flags & 16)
+          beforeBad = true;
+      } else {
+        let end = off + tile.length;
+        if (off <= pos) {
+          before = tile;
+          beforeOff = pos - off;
+          beforeBad = end < pos;
+        }
+        if (end >= pos && !after) {
+          after = tile;
+          afterOff = pos - off;
+          afterBad = off > pos;
+        }
+        if (off > pos && after)
+          return true;
+      }
+    });
+    if (!before && !after)
+      return this.domAtPos(pos, side);
+    if (beforeBad && after)
+      before = null;
+    else if (afterBad && before)
+      after = null;
+    return before && side < 0 || !after ? before.domIn(beforeOff, side) : after.domIn(afterOff, side);
+  }
+  coordsAt(pos, side) {
+    let { tile, offset } = this.tile.resolveBlock(pos, side);
+    if (tile.isWidget()) {
+      if (tile.widget instanceof BlockGapWidget)
+        return null;
+      return tile.coordsInWidget(offset, side, true);
+    }
+    return tile.coordsIn(offset, side);
+  }
+  lineAt(pos, side) {
+    let { tile } = this.tile.resolveBlock(pos, side);
+    return tile.isLine() ? tile : null;
+  }
+  coordsForChar(pos) {
+    let { tile, offset } = this.tile.resolveBlock(pos, 1);
+    if (!tile.isLine())
+      return null;
+    function scan(tile2, offset2) {
+      if (tile2.isComposite()) {
+        for (let ch of tile2.children) {
+          if (ch.length >= offset2) {
+            let found = scan(ch, offset2);
+            if (found)
+              return found;
+          }
+          offset2 -= ch.length;
+          if (offset2 < 0)
+            break;
+        }
+      } else if (tile2.isText() && offset2 < tile2.length) {
+        let end = findClusterBreak2(tile2.text, offset2);
+        if (end == offset2)
+          return null;
+        let rects = textRange(tile2.dom, offset2, end).getClientRects();
+        for (let i2 = 0; i2 < rects.length; i2++) {
+          let rect = rects[i2];
+          if (i2 == rects.length - 1 || rect.top < rect.bottom && rect.left < rect.right)
+            return rect;
+        }
+      }
+      return null;
+    }
+    return scan(tile, offset);
+  }
+  measureVisibleLineHeights(viewport) {
+    let result = [], { from, to } = viewport;
+    let contentWidth = this.view.contentDOM.clientWidth;
+    let isWider = contentWidth > Math.max(this.view.scrollDOM.clientWidth, this.minWidth) + 1;
+    let widest = -1, ltr = this.view.textDirection == Direction.LTR;
+    let spaceAbove = 0;
+    let scan = (tile, pos, measureBounds) => {
+      for (let i2 = 0; i2 < tile.children.length; i2++) {
+        if (pos > to)
+          break;
+        let child = tile.children[i2], end = pos + child.length;
+        let childRect = child.dom.getBoundingClientRect(), { height } = childRect;
+        if (measureBounds && !i2)
+          spaceAbove += childRect.top - measureBounds.top;
+        if (child instanceof BlockWrapperTile) {
+          if (end > from)
+            scan(child, pos, childRect);
+        } else if (pos >= from) {
+          if (spaceAbove > 0)
+            result.push(-spaceAbove);
+          result.push(height + spaceAbove);
+          spaceAbove = 0;
+          if (isWider) {
+            let last = child.dom.lastChild;
+            let rects = last ? clientRectsFor(last) : [];
+            if (rects.length) {
+              let rect = rects[rects.length - 1];
+              let width = ltr ? rect.right - childRect.left : childRect.right - rect.left;
+              if (width > widest) {
+                widest = width;
+                this.minWidth = contentWidth;
+                this.minWidthFrom = pos;
+                this.minWidthTo = end;
+              }
+            }
+          }
+        }
+        if (measureBounds && i2 == tile.children.length - 1)
+          spaceAbove += measureBounds.bottom - childRect.bottom;
+        pos = end + child.breakAfter;
+      }
+    };
+    scan(this.tile, 0, null);
+    return result;
+  }
+  textDirectionAt(pos) {
+    let { tile } = this.tile.resolveBlock(pos, 1);
+    return getComputedStyle(tile.dom).direction == "rtl" ? Direction.RTL : Direction.LTR;
+  }
+  measureTextSize() {
+    let lineMeasure = this.tile.blockTiles((tile) => {
+      if (tile.isLine() && tile.children.length && tile.length <= 20) {
+        let totalWidth = 0, textHeight2;
+        for (let child of tile.children) {
+          if (!child.isText() || /[^ -~]/.test(child.text))
+            return void 0;
+          let rects = clientRectsFor(child.dom);
+          if (rects.length != 1)
+            return void 0;
+          totalWidth += rects[0].width;
+          textHeight2 = rects[0].height;
+        }
+        if (totalWidth)
+          return {
+            lineHeight: tile.dom.getBoundingClientRect().height,
+            charWidth: totalWidth / tile.length,
+            textHeight: textHeight2
+          };
+      }
+    });
+    if (lineMeasure)
+      return lineMeasure;
+    let dummy = document.createElement("div"), lineHeight, charWidth, textHeight;
+    dummy.className = "cm-line";
+    dummy.style.width = "99999px";
+    dummy.style.position = "absolute";
+    dummy.textContent = "abc def ghi jkl mno pqr stu";
+    this.view.observer.ignore(() => {
+      this.tile.dom.appendChild(dummy);
+      let rect = clientRectsFor(dummy.firstChild)[0];
+      lineHeight = dummy.getBoundingClientRect().height;
+      charWidth = rect && rect.width ? rect.width / 27 : 7;
+      textHeight = rect && rect.height ? rect.height : lineHeight;
+      dummy.remove();
+    });
+    return { lineHeight, charWidth, textHeight };
+  }
+  computeBlockGapDeco() {
+    let deco = [], vs = this.view.viewState;
+    for (let pos = 0, i2 = 0; ; i2++) {
+      let next = i2 == vs.viewports.length ? null : vs.viewports[i2];
+      let end = next ? next.from - 1 : this.view.state.doc.length;
+      if (end > pos) {
+        let height = (vs.lineBlockAt(end).bottom - vs.lineBlockAt(pos).top) / this.view.scaleY;
+        deco.push(Decoration.replace({
+          widget: new BlockGapWidget(height),
+          block: true,
+          inclusive: true,
+          isBlockGap: true
+        }).range(pos, end));
+      }
+      if (!next)
+        break;
+      pos = next.to + 1;
+    }
+    return Decoration.set(deco);
+  }
+  updateDeco() {
+    let i2 = 1;
+    let allDeco = this.view.state.facet(decorations).map((d) => {
+      let dynamic = this.dynamicDecorationMap[i2++] = typeof d == "function";
+      return dynamic ? d(this.view) : d;
+    });
+    let dynamicOuter = false, outerDeco = this.view.state.facet(outerDecorations).map((d, i3) => {
+      let dynamic = typeof d == "function";
+      if (dynamic)
+        dynamicOuter = true;
+      return dynamic ? d(this.view) : d;
+    });
+    if (outerDeco.length) {
+      this.dynamicDecorationMap[i2++] = dynamicOuter;
+      allDeco.push(RangeSet.join(outerDeco));
+    }
+    this.decorations = [
+      this.editContextFormatting,
+      ...allDeco,
+      this.computeBlockGapDeco(),
+      this.view.viewState.lineGapDeco
+    ];
+    while (i2 < this.decorations.length)
+      this.dynamicDecorationMap[i2++] = false;
+    this.blockWrappers = this.view.state.facet(blockWrappers).map((v) => typeof v == "function" ? v(this.view) : v);
+  }
+  scrollIntoView(target) {
+    var _a2;
+    if (target.isSnapshot) {
+      let ref = this.view.viewState.lineBlockAt(target.range.head);
+      this.view.scrollDOM.scrollTop = ref.top - target.yMargin;
+      this.view.scrollDOM.scrollLeft = target.xMargin;
+      return;
+    }
+    for (let handler of this.view.state.facet(scrollHandler)) {
+      try {
+        if (handler(this.view, target.range, target))
+          return true;
+      } catch (e) {
+        logException(this.view.state, e, "scroll handler");
+      }
+    }
+    let { range } = target;
+    let rect = this.coordsAt(range.head, (_a2 = range.assoc) !== null && _a2 !== void 0 ? _a2 : range.empty ? 0 : range.head > range.anchor ? -1 : 1), other;
+    if (!rect)
+      return;
+    if (!range.empty && (other = this.coordsAt(range.anchor, range.anchor > range.head ? -1 : 1)))
+      rect = {
+        left: Math.min(rect.left, other.left),
+        top: Math.min(rect.top, other.top),
+        right: Math.max(rect.right, other.right),
+        bottom: Math.max(rect.bottom, other.bottom)
+      };
+    let margins = getScrollMargins(this.view);
+    let targetRect = {
+      left: rect.left - margins.left,
+      top: rect.top - margins.top,
+      right: rect.right + margins.right,
+      bottom: rect.bottom + margins.bottom
+    };
+    let { offsetWidth, offsetHeight } = this.view.scrollDOM;
+    scrollRectIntoView(this.view.scrollDOM, targetRect, range.head < range.anchor ? -1 : 1, target.x, target.y, Math.max(Math.min(target.xMargin, offsetWidth), -offsetWidth), Math.max(Math.min(target.yMargin, offsetHeight), -offsetHeight), this.view.textDirection == Direction.LTR);
+    if (window.visualViewport && window.innerHeight - window.visualViewport.height > 1 && (rect.top > window.pageYOffset + window.visualViewport.offsetTop + window.visualViewport.height || rect.bottom < window.pageYOffset + window.visualViewport.offsetTop)) {
+      let line = this.view.docView.lineAt(range.head, 1);
+      if (line)
+        line.dom.scrollIntoView({ block: "nearest" });
+    }
+  }
+  lineHasWidget(pos) {
+    let scan = (child) => child.isWidget() || child.children.some(scan);
+    return scan(this.tile.resolveBlock(pos, 1).tile);
+  }
+  destroy() {
+    destroyDropped(this.tile);
+  }
+};
+function destroyDropped(tile, reused) {
+  let r2 = reused === null || reused === void 0 ? void 0 : reused.get(tile);
+  if (r2 != 1) {
+    if (r2 == null)
+      tile.destroy();
+    for (let ch of tile.children)
+      destroyDropped(ch, reused);
+  }
+}
+function betweenUneditable(pos) {
+  return pos.node.nodeType == 1 && pos.node.firstChild && (pos.offset == 0 || pos.node.childNodes[pos.offset - 1].contentEditable == "false") && (pos.offset == pos.node.childNodes.length || pos.node.childNodes[pos.offset].contentEditable == "false");
+}
+function findCompositionNode(view, headPos) {
+  let sel = view.observer.selectionRange;
+  if (!sel.focusNode)
+    return null;
+  let textBefore = textNodeBefore(sel.focusNode, sel.focusOffset);
+  let textAfter = textNodeAfter(sel.focusNode, sel.focusOffset);
+  let textNode = textBefore || textAfter;
+  if (textAfter && textBefore && textAfter.node != textBefore.node) {
+    let tileAfter = Tile.get(textAfter.node);
+    if (!tileAfter || tileAfter.isText() && tileAfter.text != textAfter.node.nodeValue) {
+      textNode = textAfter;
+    } else if (view.docView.lastCompositionAfterCursor) {
+      let tileBefore = Tile.get(textBefore.node);
+      if (!(!tileBefore || tileBefore.isText() && tileBefore.text != textBefore.node.nodeValue))
+        textNode = textAfter;
+    }
+  }
+  view.docView.lastCompositionAfterCursor = textNode != textBefore;
+  if (!textNode)
+    return null;
+  let from = headPos - textNode.offset;
+  return { from, to: from + textNode.node.nodeValue.length, node: textNode.node };
+}
+function findCompositionRange(view, changes, headPos) {
+  let found = findCompositionNode(view, headPos);
+  if (!found)
+    return null;
+  let { node: textNode, from, to } = found, text = textNode.nodeValue;
+  if (/[\n\r]/.test(text))
+    return null;
+  if (view.state.doc.sliceString(found.from, found.to) != text)
+    return null;
+  let inv = changes.invertedDesc;
+  return { range: new ChangedRange(inv.mapPos(from), inv.mapPos(to), from, to), text: textNode };
+}
+function nextToUneditable(node, offset) {
+  if (node.nodeType != 1)
+    return 0;
+  return (offset && node.childNodes[offset - 1].contentEditable == "false" ? 1 : 0) | (offset < node.childNodes.length && node.childNodes[offset].contentEditable == "false" ? 2 : 0);
+}
+var DecorationComparator$1 = class DecorationComparator {
+  constructor() {
+    this.changes = [];
+  }
+  compareRange(from, to) {
+    addRange(from, to, this.changes);
+  }
+  comparePoint(from, to) {
+    addRange(from, to, this.changes);
+  }
+  boundChange(pos) {
+    addRange(pos, pos, this.changes);
+  }
+};
+function findChangedDeco(a, b, diff) {
+  let comp = new DecorationComparator$1();
+  RangeSet.compare(a, b, diff, comp);
+  return comp.changes;
+}
+var WrapperComparator = class {
+  constructor() {
+    this.changes = [];
+  }
+  compareRange(from, to) {
+    addRange(from, to, this.changes);
+  }
+  comparePoint() {
+  }
+  boundChange(pos) {
+    addRange(pos, pos, this.changes);
+  }
+};
+function findChangedWrappers(a, b, diff) {
+  let comp = new WrapperComparator();
+  RangeSet.compare(a, b, diff, comp);
+  return comp.changes;
+}
+function inUneditable(node, inside) {
+  for (let cur = node; cur && cur != inside; cur = cur.assignedSlot || cur.parentNode) {
+    if (cur.nodeType == 1 && cur.contentEditable == "false") {
+      return true;
+    }
+  }
+  return false;
+}
+function touchesComposition(changes, composition) {
+  let touched = false;
+  if (composition)
+    changes.iterChangedRanges((from, to) => {
+      if (from < composition.to && to > composition.from)
+        touched = true;
+    });
+  return touched;
+}
+var BlockGapWidget = class extends WidgetType {
+  constructor(height) {
+    super();
+    this.height = height;
+  }
+  toDOM() {
+    let elt = document.createElement("div");
+    elt.className = "cm-gap";
+    this.updateDOM(elt);
+    return elt;
+  }
+  eq(other) {
+    return other.height == this.height;
+  }
+  updateDOM(elt) {
+    elt.style.height = this.height + "px";
+    return true;
+  }
+  get editable() {
+    return true;
+  }
+  get estimatedHeight() {
+    return this.height;
+  }
+  ignoreEvent() {
+    return false;
+  }
+};
+function groupAt(state, pos, bias = 1) {
+  let categorize = state.charCategorizer(pos);
+  let line = state.doc.lineAt(pos), linePos = pos - line.from;
+  if (line.length == 0)
+    return EditorSelection.cursor(pos);
+  if (linePos == 0)
+    bias = 1;
+  else if (linePos == line.length)
+    bias = -1;
+  let from = linePos, to = linePos;
+  if (bias < 0)
+    from = findClusterBreak2(line.text, linePos, false);
+  else
+    to = findClusterBreak2(line.text, linePos);
+  let cat = categorize(line.text.slice(from, to));
+  while (from > 0) {
+    let prev = findClusterBreak2(line.text, from, false);
+    if (categorize(line.text.slice(prev, from)) != cat)
+      break;
+    from = prev;
+  }
+  while (to < line.length) {
+    let next = findClusterBreak2(line.text, to);
+    if (categorize(line.text.slice(to, next)) != cat)
+      break;
+    to = next;
+  }
+  return EditorSelection.undirectionalRange(from + line.from, to + line.from);
+}
+function posAtCoordsImprecise(view, contentRect, block, x, y) {
+  let into = Math.round((x - contentRect.left) * view.defaultCharacterWidth);
+  if (view.lineWrapping && block.height > view.defaultLineHeight * 1.5) {
+    let textHeight = view.viewState.heightOracle.textHeight;
+    let line = Math.floor((y - block.top - (view.defaultLineHeight - textHeight) * 0.5) / textHeight);
+    into += line * view.viewState.heightOracle.lineLength;
+  }
+  let content2 = view.state.sliceDoc(block.from, block.to);
+  return block.from + findColumn(content2, into, view.state.tabSize);
+}
+function blockAt(view, pos, side) {
+  let line = view.lineBlockAt(pos);
+  if (Array.isArray(line.type)) {
+    let best;
+    for (let l of line.type) {
+      if (l.from > pos)
+        break;
+      if (l.to < pos)
+        continue;
+      if (l.from < pos && l.to > pos)
+        return l;
+      if (!best || l.type == BlockType.Text && (best.type != l.type || (side < 0 ? l.from < pos : l.to > pos)))
+        best = l;
+    }
+    return best || line;
+  }
+  return line;
+}
+function moveToLineBoundary(view, start, forward, includeWrap) {
+  let line = blockAt(view, start.head, start.assoc || -1);
+  let coords = !includeWrap || line.type != BlockType.Text || !(view.lineWrapping || line.widgetLineBreaks) ? null : view.coordsAtPos(start.assoc < 0 && start.head > line.from ? start.head - 1 : start.head);
+  if (coords) {
+    let editorRect = view.dom.getBoundingClientRect();
+    let direction = view.textDirectionAt(line.from);
+    let pos = view.posAtCoords({
+      x: forward == (direction == Direction.LTR) ? editorRect.right - 1 : editorRect.left + 1,
+      y: (coords.top + coords.bottom) / 2
+    });
+    if (pos != null)
+      return EditorSelection.cursor(pos, forward ? -1 : 1);
+  }
+  return EditorSelection.cursor(forward ? line.to : line.from, forward ? -1 : 1);
+}
+function moveByChar(view, start, forward, by) {
+  let line = view.state.doc.lineAt(start.head), spans = view.bidiSpans(line);
+  let direction = view.textDirectionAt(line.from);
+  for (let cur = start, check = null; ; ) {
+    let next = moveVisually(line, spans, direction, cur, forward), char = movedOver;
+    if (!next) {
+      if (line.number == (forward ? view.state.doc.lines : 1))
+        return cur;
+      char = "\n";
+      line = view.state.doc.line(line.number + (forward ? 1 : -1));
+      spans = view.bidiSpans(line);
+      next = view.visualLineSide(line, !forward);
+    }
+    if (!check) {
+      if (!by)
+        return next;
+      check = by(char);
+    } else if (!check(char)) {
+      return cur;
+    }
+    cur = next;
+  }
+}
+function byGroup(view, pos, start) {
+  let categorize = view.state.charCategorizer(pos);
+  let cat = categorize(start);
+  return (next) => {
+    let nextCat = categorize(next);
+    if (cat == CharCategory.Space)
+      cat = nextCat;
+    return cat == nextCat;
+  };
+}
+function moveVertically(view, start, forward, distance) {
+  let startPos = start.head, dir = forward ? 1 : -1;
+  if (startPos == (forward ? view.state.doc.length : 0))
+    return EditorSelection.cursor(startPos, start.assoc);
+  let goal = start.goalColumn, startY;
+  let rect = view.contentDOM.getBoundingClientRect();
+  let startCoords = view.coordsAtPos(startPos, start.assoc || ((start.empty ? forward : start.head == start.from) ? 1 : -1));
+  let docTop = view.documentTop;
+  if (startCoords) {
+    if (goal == null)
+      goal = startCoords.left - rect.left;
+    startY = dir < 0 ? startCoords.top : startCoords.bottom;
+  } else {
+    let line = view.viewState.lineBlockAt(startPos);
+    if (goal == null)
+      goal = Math.min(rect.right - rect.left, view.defaultCharacterWidth * (startPos - line.from));
+    startY = (dir < 0 ? line.top : line.bottom) + docTop;
+  }
+  let resolvedGoal = rect.left + goal;
+  let halfText = view.viewState.heightOracle.textHeight >> 1, dist2 = distance !== null && distance !== void 0 ? distance : halfText;
+  for (let scan = 0; ; scan += halfText) {
+    let y = startY + (dist2 + scan) * dir;
+    let pos = posAtCoords(view, { x: resolvedGoal, y }, false, dir);
+    if (forward ? y > rect.bottom : y < rect.top)
+      return EditorSelection.cursor(pos.pos, pos.assoc);
+    let posCoords = view.coordsAtPos(pos.pos, pos.assoc), mid = posCoords ? (posCoords.top + posCoords.bottom) / 2 : 0;
+    if (!posCoords || (forward ? mid > startY : mid < startY))
+      return EditorSelection.cursor(pos.pos, pos.assoc, void 0, goal);
+  }
+}
+function skipAtomicRanges(atoms, pos, bias) {
+  for (; ; ) {
+    let moved = 0;
+    for (let set of atoms) {
+      set.between(pos - 1, pos + 1, (from, to, value) => {
+        if (pos > from && pos < to) {
+          let side = moved || bias || (pos - from < to - pos ? -1 : 1);
+          pos = side < 0 ? from : to;
+          moved = side;
+        }
+      });
+    }
+    if (!moved)
+      return pos;
+  }
+}
+function skipAtomsForSelection(atoms, sel) {
+  let ranges = null;
+  for (let i2 = 0; i2 < sel.ranges.length; i2++) {
+    let range = sel.ranges[i2], updated = null;
+    if (range.empty) {
+      let pos = skipAtomicRanges(atoms, range.from, 0);
+      if (pos != range.from)
+        updated = EditorSelection.cursor(pos, -1);
+    } else {
+      let from = skipAtomicRanges(atoms, range.from, -1);
+      let to = skipAtomicRanges(atoms, range.to, 1);
+      if (from != range.from || to != range.to) {
+        if (range.undirectional)
+          updated = EditorSelection.undirectionalRange(range.from, range.to);
+        else
+          updated = EditorSelection.range(range.from == range.anchor ? from : to, range.from == range.head ? from : to);
+      }
+    }
+    if (updated) {
+      if (!ranges)
+        ranges = sel.ranges.slice();
+      ranges[i2] = updated;
+    }
+  }
+  return ranges ? EditorSelection.create(ranges, sel.mainIndex) : sel;
+}
+function skipAtoms(view, oldPos, pos) {
+  let newPos = skipAtomicRanges(view.state.facet(atomicRanges).map((f) => f(view)), pos.from, oldPos.head > pos.from ? -1 : 1);
+  return newPos == pos.from ? pos : EditorSelection.cursor(newPos, newPos < pos.from ? 1 : -1);
+}
+var PosAssoc = class {
+  constructor(pos, assoc) {
+    this.pos = pos;
+    this.assoc = assoc;
+  }
+};
+function posAtCoords(view, coords, precise, scanY) {
+  let content2 = view.contentDOM.getBoundingClientRect(), docTop = content2.top + view.viewState.paddingTop;
+  let { x, y } = coords, yOffset = y - docTop, block;
+  for (; ; ) {
+    if (yOffset < 0)
+      return new PosAssoc(0, 1);
+    if (yOffset > view.viewState.docHeight)
+      return new PosAssoc(view.state.doc.length, -1);
+    block = view.elementAtHeight(yOffset);
+    if (scanY == null)
+      break;
+    if (block.type == BlockType.Text) {
+      if (scanY < 0 ? block.to < view.viewport.from : block.from > view.viewport.to)
+        break;
+      let rect = view.docView.coordsAt(scanY < 0 ? block.from : block.to, scanY > 0 ? -1 : 1);
+      if (rect && (scanY < 0 ? rect.top <= yOffset + docTop : rect.bottom >= yOffset + docTop))
+        break;
+    }
+    let halfLine = view.viewState.heightOracle.textHeight / 2;
+    yOffset = scanY > 0 ? block.bottom + halfLine : block.top - halfLine;
+  }
+  if (view.viewport.from >= block.to || view.viewport.to <= block.from) {
+    if (precise)
+      return null;
+    if (block.type == BlockType.Text) {
+      let pos = posAtCoordsImprecise(view, content2, block, x, y);
+      return new PosAssoc(pos, pos == block.from ? 1 : -1);
+    }
+  }
+  if (block.type != BlockType.Text)
+    return yOffset < (block.top + block.bottom) / 2 ? new PosAssoc(block.from, 1) : new PosAssoc(block.to, -1);
+  let line = view.docView.lineAt(block.from, 2);
+  if (!line || line.length != block.length)
+    line = view.docView.lineAt(block.from, -2);
+  return new InlineCoordsScan(view, x, y, view.textDirectionAt(block.from)).scanTile(line, block.from);
+}
+var InlineCoordsScan = class {
+  constructor(view, x, y, baseDir) {
+    this.view = view;
+    this.x = x;
+    this.y = y;
+    this.baseDir = baseDir;
+    this.line = null;
+    this.spans = null;
+  }
+  bidiSpansAt(pos) {
+    if (!this.line || this.line.from > pos || this.line.to < pos) {
+      this.line = this.view.state.doc.lineAt(pos);
+      this.spans = this.view.bidiSpans(this.line);
+    }
+    return this;
+  }
+  baseDirAt(pos, side) {
+    let { line, spans } = this.bidiSpansAt(pos);
+    let level = spans[BidiSpan.find(spans, pos - line.from, -1, side)].level;
+    return level == this.baseDir;
+  }
+  dirAt(pos, side) {
+    let { line, spans } = this.bidiSpansAt(pos);
+    return spans[BidiSpan.find(spans, pos - line.from, -1, side)].dir;
+  }
+  // Used to short-circuit bidi tests for content with a uniform direction
+  bidiIn(from, to) {
+    let { spans, line } = this.bidiSpansAt(from);
+    return spans.length > 1 || spans.length && (spans[0].level != this.baseDir || spans[0].to + line.from < to);
+  }
+  // Scan through the rectangles for the content of a tile with inline
+  // content, looking for one that overlaps the queried position
+  // vertically and is closest horizontally. The caller is responsible
+  // for dividing its content into N pieces, and pass an array with
+  // N+1 positions (including the position after the last piece). For
+  // a text tile, these will be character clusters, for a composite
+  // tile, these will be child tiles.
+  scan(positions, getRects, recursed = false) {
+    let lo = 0, hi = positions.length - 1, seen = /* @__PURE__ */ new Set();
+    let bidi = this.bidiIn(positions[0], positions[hi]);
+    let above, below;
+    let closestI = -1, closestDx = 1e9, closestRect;
+    search: while (lo < hi) {
+      let dist2 = hi - lo, mid = lo + hi >> 1;
+      adjust: if (seen.has(mid)) {
+        let scan = lo + Math.floor(Math.random() * dist2);
+        for (let i2 = 0; i2 < dist2; i2++) {
+          if (!seen.has(scan)) {
+            mid = scan;
+            break adjust;
+          }
+          scan++;
+          if (scan == hi)
+            scan = lo;
+        }
+        break search;
+      }
+      seen.add(mid);
+      let rects = getRects(mid);
+      if (rects)
+        for (let i2 = 0; i2 < rects.length; i2++) {
+          let rect = rects[i2], side = 0;
+          if (rect.width == 0 && rects.length > 1)
+            continue;
+          if (rect.bottom < this.y) {
+            if (!above || above.bottom < rect.bottom)
+              above = rect;
+            side = 1;
+          } else if (rect.top > this.y) {
+            if (!below || below.top > rect.top)
+              below = rect;
+            side = -1;
+          } else {
+            let off = rect.left > this.x ? this.x - rect.left : rect.right < this.x ? this.x - rect.right : 0;
+            let dx = Math.abs(off);
+            if (dx < closestDx) {
+              closestI = mid;
+              closestDx = dx;
+              closestRect = rect;
+            }
+            if (off)
+              side = off < 0 == (this.baseDir == Direction.LTR) ? -1 : 1;
+          }
+          if (side == -1 && (!bidi || this.baseDirAt(positions[mid], 1)))
+            hi = mid;
+          else if (side == 1 && (!bidi || this.baseDirAt(positions[mid + 1], -1)))
+            lo = mid + 1;
+        }
+    }
+    if (!closestRect) {
+      if (!below && !above)
+        return { i: positions[0], after: false };
+      let side = above && (!below || this.y - above.bottom < below.top - this.y) ? above : below;
+      this.y = (side.top + side.bottom) / 2;
+      return this.scan(positions, getRects, true);
+    }
+    if (closestDx && !recursed) {
+      let { top: top2, bottom } = closestRect;
+      if (above && above.bottom > (top2 + top2 + bottom) / 3) {
+        this.y = above.bottom - 1;
+        return this.scan(positions, getRects, true);
+      }
+      if (below && below.top < (top2 + bottom + bottom) / 3) {
+        this.y = below.top + 1;
+        return this.scan(positions, getRects, true);
+      }
+    }
+    let ltr = (bidi ? this.dirAt(positions[closestI], 1) : this.baseDir) == Direction.LTR;
+    return {
+      i: closestI,
+      // Test whether x is closes to the start or end of this element
+      after: this.x > (closestRect.left + closestRect.right) / 2 == ltr
+    };
+  }
+  scanText(tile, offset) {
+    let positions = [];
+    for (let i2 = 0; i2 < tile.length; i2 = findClusterBreak2(tile.text, i2))
+      positions.push(offset + i2);
+    positions.push(offset + tile.length);
+    let scan = this.scan(positions, (i2) => {
+      let off = positions[i2] - offset, end = positions[i2 + 1] - offset;
+      return textRange(tile.dom, off, end).getClientRects();
+    });
+    return scan.after ? new PosAssoc(positions[scan.i + 1], -1) : new PosAssoc(positions[scan.i], 1);
+  }
+  scanTile(tile, offset) {
+    if (!tile.length)
+      return new PosAssoc(offset, 1);
+    if (tile.children.length == 1) {
+      let child2 = tile.children[0];
+      if (child2.isText())
+        return this.scanText(child2, offset);
+      else if (child2.isComposite())
+        return this.scanTile(child2, offset);
+    }
+    let positions = [offset];
+    for (let i2 = 0, pos2 = offset; i2 < tile.children.length; i2++)
+      positions.push(pos2 += tile.children[i2].length);
+    let scan = this.scan(positions, (i2) => {
+      let child2 = tile.children[i2];
+      if (child2.flags & 48)
+        return null;
+      return (child2.dom.nodeType == 1 ? child2.dom : textRange(child2.dom, 0, child2.length)).getClientRects();
+    });
+    let child = tile.children[scan.i], pos = positions[scan.i];
+    if (child.isText())
+      return this.scanText(child, pos);
+    if (child.isComposite())
+      return this.scanTile(child, pos);
+    return scan.after ? new PosAssoc(positions[scan.i + 1], -1) : new PosAssoc(pos, 1);
+  }
+};
+var LineBreakPlaceholder = "\uFFFF";
+var DOMReader = class {
+  constructor(points, view) {
+    this.points = points;
+    this.view = view;
+    this.text = "";
+    this.lineSeparator = view.state.facet(EditorState.lineSeparator);
+  }
+  append(text) {
+    this.text += text;
+  }
+  lineBreak() {
+    this.text += LineBreakPlaceholder;
+  }
+  readRange(start, end) {
+    if (!start)
+      return this;
+    let parent = start.parentNode;
+    for (let cur = start; ; ) {
+      this.findPointBefore(parent, cur);
+      let oldLen = this.text.length;
+      this.readNode(cur);
+      let tile = Tile.get(cur), next = cur.nextSibling;
+      if (next == end) {
+        if ((tile === null || tile === void 0 ? void 0 : tile.breakAfter) && !next && parent != this.view.contentDOM)
+          this.lineBreak();
+        break;
+      }
+      let nextTile = Tile.get(next);
+      if ((tile && nextTile ? tile.breakAfter : (tile ? tile.breakAfter : isBlockElement(cur)) || isBlockElement(next) && (cur.nodeName != "BR" || (tile === null || tile === void 0 ? void 0 : tile.isWidget())) && this.text.length > oldLen) && !isEmptyToEnd(next, end))
+        this.lineBreak();
+      cur = next;
+    }
+    this.findPointBefore(parent, end);
+    return this;
+  }
+  readTextNode(node) {
+    let text = node.nodeValue;
+    for (let point of this.points)
+      if (point.node == node)
+        point.pos = this.text.length + Math.min(point.offset, text.length);
+    for (let off = 0, re = this.lineSeparator ? null : /\r\n?|\n/g; ; ) {
+      let nextBreak = -1, breakSize = 1, m;
+      if (this.lineSeparator) {
+        nextBreak = text.indexOf(this.lineSeparator, off);
+        breakSize = this.lineSeparator.length;
+      } else if (m = re.exec(text)) {
+        nextBreak = m.index;
+        breakSize = m[0].length;
+      }
+      this.append(text.slice(off, nextBreak < 0 ? text.length : nextBreak));
+      if (nextBreak < 0)
+        break;
+      this.lineBreak();
+      if (breakSize > 1) {
+        for (let point of this.points)
+          if (point.node == node && point.pos > this.text.length)
+            point.pos -= breakSize - 1;
+      }
+      off = nextBreak + breakSize;
+    }
+  }
+  readNode(node) {
+    let tile = Tile.get(node);
+    let fromView = tile && tile.overrideDOMText;
+    if (fromView != null) {
+      this.findPointInside(node, fromView.length);
+      for (let i2 = fromView.iter(); !i2.next().done; ) {
+        if (i2.lineBreak)
+          this.lineBreak();
+        else
+          this.append(i2.value);
+      }
+    } else if (node.nodeType == 3) {
+      this.readTextNode(node);
+    } else if (node.nodeName == "BR") {
+      if (node.nextSibling)
+        this.lineBreak();
+    } else if (node.nodeType == 1) {
+      this.readRange(node.firstChild, null);
+    }
+  }
+  findPointBefore(node, next) {
+    for (let point of this.points)
+      if (point.node == node && node.childNodes[point.offset] == next)
+        point.pos = this.text.length;
+  }
+  findPointInside(node, length) {
+    for (let point of this.points)
+      if (node.nodeType == 3 ? point.node == node : node.contains(point.node))
+        point.pos = this.text.length + (isAtEnd(node, point.node, point.offset) ? length : 0);
+  }
+};
+function isAtEnd(parent, node, offset) {
+  for (; ; ) {
+    if (!node || offset < maxOffset(node))
+      return false;
+    if (node == parent)
+      return true;
+    offset = domIndex(node) + 1;
+    node = node.parentNode;
+  }
+}
+function isEmptyToEnd(node, end) {
+  let widgets;
+  for (; ; node = node.nextSibling) {
+    if (node == end || !node)
+      break;
+    let view = Tile.get(node);
+    if (!(view === null || view === void 0 ? void 0 : view.isWidget()))
+      return false;
+    if (view)
+      (widgets || (widgets = [])).push(view);
+  }
+  if (widgets)
+    for (let w of widgets) {
+      let override = w.overrideDOMText;
+      if (override === null || override === void 0 ? void 0 : override.length)
+        return false;
+    }
+  return true;
+}
+var DOMPoint = class {
+  constructor(node, offset) {
+    this.node = node;
+    this.offset = offset;
+    this.pos = -1;
+  }
+};
+var DOMChange = class {
+  constructor(view, start, end, typeOver) {
+    this.typeOver = typeOver;
+    this.bounds = null;
+    this.text = "";
+    this.domChanged = start > -1;
+    let { impreciseHead: iHead, impreciseAnchor: iAnchor } = view.docView, curSel = view.state.selection;
+    if (view.state.readOnly && start > -1) {
+      this.newSel = null;
+    } else if (start > -1 && (this.bounds = domBoundsAround(view.docView.tile, start, end, 0))) {
+      let selPoints = iHead || iAnchor ? [] : selectionPoints(view);
+      let reader = new DOMReader(selPoints, view);
+      reader.readRange(this.bounds.startDOM, this.bounds.endDOM);
+      this.text = reader.text;
+      this.newSel = selectionFromPoints(selPoints, this.bounds.from);
+    } else {
+      let domSel = view.observer.selectionRange;
+      let head = iHead && iHead.node == domSel.focusNode && iHead.offset == domSel.focusOffset || !contains(view.contentDOM, domSel.focusNode) ? curSel.main.head : view.docView.posFromDOM(domSel.focusNode, domSel.focusOffset);
+      let anchor = iAnchor && iAnchor.node == domSel.anchorNode && iAnchor.offset == domSel.anchorOffset || !contains(view.contentDOM, domSel.anchorNode) ? curSel.main.anchor : view.docView.posFromDOM(domSel.anchorNode, domSel.anchorOffset);
+      let vp = view.viewport;
+      if ((browser.ios || browser.chrome) && head != anchor && Math.min(head, anchor) <= curSel.main.from && Math.max(head, anchor) >= curSel.main.to && (vp.from > 0 || vp.to < view.state.doc.length)) {
+        let from = Math.min(head, anchor), to = Math.max(head, anchor);
+        let offFrom = vp.from - from, offTo = vp.to - to;
+        if ((offFrom == 0 || offFrom == 1 || from == 0) && (offTo == 0 || offTo == -1 || to == view.state.doc.length)) {
+          head = 0;
+          anchor = view.state.doc.length;
+        }
+      }
+      if (view.inputState.composing > -1 && curSel.ranges.length > 1) {
+        this.newSel = curSel.replaceRange(EditorSelection.range(anchor, head));
+      } else if (view.lineWrapping && anchor == head && !(curSel.main.empty && curSel.main.head == head) && view.inputState.lastTouchTime > Date.now() - 100) {
+        let before = view.coordsAtPos(head, -1), assoc = 0;
+        if (before)
+          assoc = view.inputState.lastTouchY <= before.bottom ? -1 : 1;
+        this.newSel = EditorSelection.create([EditorSelection.cursor(head, assoc)]);
+      } else {
+        this.newSel = EditorSelection.single(anchor, head);
+      }
+    }
+  }
+};
+function domBoundsAround(tile, from, to, offset) {
+  if (tile.isComposite()) {
+    let fromI = -1, fromStart = -1, toI = -1, toEnd = -1;
+    for (let i2 = 0, pos = offset, prevEnd = offset; i2 < tile.children.length; i2++) {
+      let child = tile.children[i2], end = pos + child.length;
+      if (pos < from && end > to)
+        return domBoundsAround(child, from, to, pos);
+      if (end >= from && fromI == -1) {
+        fromI = i2;
+        fromStart = pos;
+      }
+      if (pos > to && child.dom.parentNode == tile.dom) {
+        toI = i2;
+        toEnd = prevEnd;
+        break;
+      }
+      prevEnd = end;
+      pos = end + child.breakAfter;
+    }
+    return {
+      from: fromStart,
+      to: toEnd < 0 ? offset + tile.length : toEnd,
+      startDOM: (fromI ? tile.children[fromI - 1].dom.nextSibling : null) || tile.dom.firstChild,
+      endDOM: toI < tile.children.length && toI >= 0 ? tile.children[toI].dom : null
+    };
+  } else if (tile.isText()) {
+    return { from: offset, to: offset + tile.length, startDOM: tile.dom, endDOM: tile.dom.nextSibling };
+  } else {
+    return null;
+  }
+}
+function applyDOMChange(view, domChange) {
+  let change;
+  let { newSel } = domChange, { state } = view, sel = state.selection.main;
+  let lastKey = view.inputState.lastKeyTime > Date.now() - 100 ? view.inputState.lastKeyCode : -1;
+  if (domChange.bounds) {
+    let { from, to } = domChange.bounds;
+    let preferredPos = sel.from, preferredSide = null;
+    if (lastKey === 8 || browser.android && domChange.text.length < to - from) {
+      preferredPos = sel.to;
+      preferredSide = "end";
+    }
+    let cmp = state.doc.sliceString(from, to, LineBreakPlaceholder), selEnd, diff;
+    if (!sel.empty && sel.from >= from && sel.to <= to && (domChange.typeOver || cmp != domChange.text) && cmp.slice(0, sel.from - from) == domChange.text.slice(0, sel.from - from) && cmp.slice(sel.to - from) == domChange.text.slice(selEnd = domChange.text.length - (cmp.length - (sel.to - from)))) {
+      change = {
+        from: sel.from,
+        to: sel.to,
+        insert: Text.of(domChange.text.slice(sel.from - from, selEnd).split(LineBreakPlaceholder))
+      };
+    } else if (diff = findDiff(cmp, domChange.text, preferredPos - from, preferredSide)) {
+      if (browser.chrome && lastKey == 13 && diff.toB == diff.from + 2 && domChange.text.slice(diff.from, diff.toB) == LineBreakPlaceholder + LineBreakPlaceholder)
+        diff.toB--;
+      change = {
+        from: from + diff.from,
+        to: from + diff.toA,
+        insert: Text.of(domChange.text.slice(diff.from, diff.toB).split(LineBreakPlaceholder))
+      };
+    }
+  } else if (newSel && (!view.hasFocus && state.facet(editable) || sameSelPos(newSel, sel))) {
+    newSel = null;
+  }
+  if (!change && !newSel)
+    return false;
+  if ((browser.mac || browser.android) && change && change.from == change.to && change.from == sel.head - 1 && /^\. ?$/.test(change.insert.toString()) && view.contentDOM.getAttribute("autocorrect") == "off") {
+    if (newSel && change.insert.length == 2)
+      newSel = EditorSelection.single(newSel.main.anchor - 1, newSel.main.head - 1);
+    change = { from: change.from, to: change.to, insert: Text.of([change.insert.toString().replace(".", " ")]) };
+  } else if (state.doc.lineAt(sel.from).to < sel.to && view.docView.lineHasWidget(sel.to) && view.inputState.insertingTextAt > Date.now() - 50) {
+    change = {
+      from: sel.from,
+      to: sel.to,
+      insert: state.toText(view.inputState.insertingText)
+    };
+  } else if (browser.chrome && change && change.from == change.to && change.from == sel.head && change.insert.toString() == "\n " && view.lineWrapping) {
+    if (newSel)
+      newSel = EditorSelection.single(newSel.main.anchor - 1, newSel.main.head - 1);
+    change = { from: sel.from, to: sel.to, insert: Text.of([" "]) };
+  }
+  if (change) {
+    return applyDOMChangeInner(view, change, newSel, lastKey);
+  } else if (newSel && !sameSelPos(newSel, sel)) {
+    let scrollIntoView2 = false, userEvent = "select";
+    if (view.inputState.lastSelectionTime > Date.now() - 50) {
+      if (view.inputState.lastSelectionOrigin == "select")
+        scrollIntoView2 = true;
+      userEvent = view.inputState.lastSelectionOrigin;
+      if (userEvent == "select.pointer")
+        newSel = skipAtomsForSelection(state.facet(atomicRanges).map((f) => f(view)), newSel);
+    }
+    view.dispatch({ selection: newSel, scrollIntoView: scrollIntoView2, userEvent });
+    return true;
+  } else {
+    return false;
+  }
+}
+function applyDOMChangeInner(view, change, newSel, lastKey = -1) {
+  if (browser.ios && view.inputState.flushIOSKey(change))
+    return true;
+  let sel = view.state.selection.main;
+  if (browser.android && (change.to == sel.to && // GBoard will sometimes remove a space it just inserted
+  // after a completion when you press enter
+  (change.from == sel.from || change.from == sel.from - 1 && view.state.sliceDoc(change.from, sel.from) == " ") && change.insert.length == 1 && change.insert.lines == 2 && dispatchKey(view.contentDOM, "Enter", 13) || (change.from == sel.from - 1 && change.to == sel.to && change.insert.length == 0 || lastKey == 8 && change.insert.length < change.to - change.from && change.to > sel.head) && dispatchKey(view.contentDOM, "Backspace", 8) || change.from == sel.from && change.to == sel.to + 1 && change.insert.length == 0 && dispatchKey(view.contentDOM, "Delete", 46)))
+    return true;
+  let text = change.insert.toString();
+  if (view.inputState.composing >= 0)
+    view.inputState.composing++;
+  let defaultTr;
+  let defaultInsert = () => defaultTr || (defaultTr = applyDefaultInsert(view, change, newSel));
+  if (!view.state.facet(inputHandler).some((h) => h(view, change.from, change.to, text, defaultInsert)))
+    view.dispatch(defaultInsert());
+  return true;
+}
+function applyDefaultInsert(view, change, newSel) {
+  let tr, startState = view.state, sel = startState.selection.main, inAtomic = -1;
+  if (change.from == change.to && change.from < sel.from || change.from > sel.to) {
+    let side = change.from < sel.from ? -1 : 1, pos = side < 0 ? sel.from : sel.to;
+    let moved = skipAtomicRanges(startState.facet(atomicRanges).map((f) => f(view)), pos, side);
+    if (change.from == moved)
+      inAtomic = moved;
+  }
+  if (inAtomic > -1) {
+    tr = {
+      changes: change,
+      selection: EditorSelection.cursor(change.from + change.insert.length, -1)
+    };
+  } else if (change.from >= sel.from && change.to <= sel.to && change.to - change.from >= (sel.to - sel.from) / 3 && (!newSel || newSel.main.empty && newSel.main.from == change.from + change.insert.length) && view.inputState.composing < 0) {
+    let before = sel.from < change.from ? startState.sliceDoc(sel.from, change.from) : "";
+    let after = sel.to > change.to ? startState.sliceDoc(change.to, sel.to) : "";
+    tr = startState.replaceSelection(view.state.toText(before + change.insert.sliceString(0, void 0, view.state.lineBreak) + after));
+  } else {
+    let changes = startState.changes(change);
+    let mainSel = newSel && newSel.main.to <= changes.newLength ? newSel.main : void 0;
+    if (startState.selection.ranges.length > 1 && (view.inputState.composing >= 0 || view.inputState.compositionPendingChange) && change.to <= sel.to + 10 && change.to >= sel.to - 10) {
+      let replaced = view.state.sliceDoc(change.from, change.to);
+      let compositionRange, composition = newSel && findCompositionNode(view, newSel.main.head);
+      if (composition) {
+        let dLen = change.insert.length - (change.to - change.from);
+        compositionRange = { from: composition.from, to: composition.to - dLen };
+      } else {
+        compositionRange = view.state.doc.lineAt(sel.head);
+      }
+      let offset = sel.to - change.to;
+      tr = startState.changeByRange((range) => {
+        if (range.from == sel.from && range.to == sel.to)
+          return { changes, range: mainSel || range.map(changes) };
+        let to = range.to - offset, from = to - replaced.length;
+        if (view.state.sliceDoc(from, to) != replaced || // Unfortunately, there's no way to make multiple
+        // changes in the same node work without aborting
+        // composition, so cursors in the composition range are
+        // ignored.
+        to >= compositionRange.from && from <= compositionRange.to)
+          return { range };
+        let rangeChanges = startState.changes({ from, to, insert: change.insert }), selOff = range.to - sel.to;
+        return {
+          changes: rangeChanges,
+          range: !mainSel ? range.map(rangeChanges) : EditorSelection.range(Math.max(0, mainSel.anchor + selOff), Math.max(0, mainSel.head + selOff))
+        };
+      });
+    } else {
+      tr = {
+        changes,
+        selection: mainSel && startState.selection.replaceRange(mainSel)
+      };
+    }
+  }
+  let userEvent = "input.type";
+  if (view.composing || view.inputState.compositionPendingChange && view.inputState.compositionEndedAt > Date.now() - 50) {
+    view.inputState.compositionPendingChange = false;
+    userEvent += ".compose";
+    if (view.inputState.compositionFirstChange) {
+      userEvent += ".start";
+      view.inputState.compositionFirstChange = false;
+    }
+  }
+  return startState.update(tr, { userEvent, scrollIntoView: true });
+}
+function findDiff(a, b, preferredPos, preferredSide) {
+  let minLen = Math.min(a.length, b.length);
+  let from = 0;
+  while (from < minLen && a.charCodeAt(from) == b.charCodeAt(from))
+    from++;
+  if (from == minLen && a.length == b.length)
+    return null;
+  let toA = a.length, toB = b.length;
+  while (toA > 0 && toB > 0 && a.charCodeAt(toA - 1) == b.charCodeAt(toB - 1)) {
+    toA--;
+    toB--;
+  }
+  if (preferredSide == "end") {
+    let adjust = Math.max(0, from - Math.min(toA, toB));
+    preferredPos -= toA + adjust - from;
+  }
+  if (toA < from && a.length < b.length) {
+    let move = preferredPos <= from && preferredPos >= toA ? from - preferredPos : 0;
+    from -= move;
+    toB = from + (toB - toA);
+    toA = from;
+  } else if (toB < from) {
+    let move = preferredPos <= from && preferredPos >= toB ? from - preferredPos : 0;
+    from -= move;
+    toA = from + (toA - toB);
+    toB = from;
+  }
+  return { from, toA, toB };
+}
+function selectionPoints(view) {
+  let result = [];
+  if (view.root.activeElement != view.contentDOM)
+    return result;
+  let { anchorNode, anchorOffset, focusNode, focusOffset } = view.observer.selectionRange;
+  if (anchorNode) {
+    result.push(new DOMPoint(anchorNode, anchorOffset));
+    if (focusNode != anchorNode || focusOffset != anchorOffset)
+      result.push(new DOMPoint(focusNode, focusOffset));
+  }
+  return result;
+}
+function selectionFromPoints(points, base2) {
+  if (points.length == 0)
+    return null;
+  let anchor = points[0].pos, head = points.length == 2 ? points[1].pos : anchor;
+  return anchor > -1 && head > -1 ? EditorSelection.single(anchor + base2, head + base2) : null;
+}
+function sameSelPos(selection, range) {
+  return range.head == selection.main.head && range.anchor == selection.main.anchor;
+}
+var InputState = class {
+  setSelectionOrigin(origin) {
+    this.lastSelectionOrigin = origin;
+    this.lastSelectionTime = Date.now();
+  }
+  constructor(view) {
+    this.view = view;
+    this.lastKeyCode = 0;
+    this.lastKeyTime = 0;
+    this.lastTouchTime = 0;
+    this.lastTouchX = 0;
+    this.lastTouchY = 0;
+    this.lastFocusTime = 0;
+    this.lastScrollTop = 0;
+    this.lastScrollLeft = 0;
+    this.lastWheelEvent = 0;
+    this.pendingIOSKey = void 0;
+    this.tabFocusMode = -1;
+    this.lastSelectionOrigin = null;
+    this.lastSelectionTime = 0;
+    this.lastContextMenu = 0;
+    this.scrollHandlers = [];
+    this.handlers = /* @__PURE__ */ Object.create(null);
+    this.composing = -1;
+    this.compositionFirstChange = null;
+    this.compositionEndedAt = 0;
+    this.compositionPendingKey = false;
+    this.compositionPendingChange = false;
+    this.insertingText = "";
+    this.insertingTextAt = 0;
+    this.mouseSelection = null;
+    this.draggedContent = null;
+    this.handleEvent = this.handleEvent.bind(this);
+    this.notifiedFocused = view.hasFocus;
+    if (browser.safari)
+      view.contentDOM.addEventListener("input", () => null);
+    if (browser.gecko)
+      firefoxCopyCutHack(view.contentDOM.ownerDocument);
+  }
+  handleEvent(event) {
+    if (!eventBelongsToEditor(this.view, event) || this.ignoreDuringComposition(event))
+      return;
+    if (event.type == "keydown" && this.keydown(event))
+      return;
+    if (this.view.updateState != 0)
+      Promise.resolve().then(() => this.runHandlers(event.type, event));
+    else
+      this.runHandlers(event.type, event);
+  }
+  runHandlers(type, event) {
+    let handlers2 = this.handlers[type];
+    if (handlers2) {
+      for (let observer of handlers2.observers)
+        observer(this.view, event);
+      for (let handler of handlers2.handlers) {
+        if (event.defaultPrevented)
+          break;
+        if (handler(this.view, event)) {
+          event.preventDefault();
+          break;
+        }
+      }
+    }
+  }
+  ensureHandlers(plugins) {
+    let handlers2 = computeHandlers(plugins), prev = this.handlers, dom = this.view.contentDOM;
+    for (let type in handlers2)
+      if (type != "scroll") {
+        let passive = !handlers2[type].handlers.length;
+        let exists = prev[type];
+        if (exists && passive != !exists.handlers.length) {
+          dom.removeEventListener(type, this.handleEvent);
+          exists = null;
+        }
+        if (!exists)
+          dom.addEventListener(type, this.handleEvent, { passive });
+      }
+    for (let type in prev)
+      if (type != "scroll" && !handlers2[type])
+        dom.removeEventListener(type, this.handleEvent);
+    this.handlers = handlers2;
+  }
+  keydown(event) {
+    this.lastKeyCode = event.keyCode;
+    this.lastKeyTime = Date.now();
+    if (event.keyCode == 9 && this.tabFocusMode > -1 && (!this.tabFocusMode || Date.now() <= this.tabFocusMode))
+      return true;
+    if (this.tabFocusMode > 0 && event.keyCode != 27 && modifierCodes.indexOf(event.keyCode) < 0)
+      this.tabFocusMode = -1;
+    if (browser.android && browser.chrome && !event.synthetic && (event.keyCode == 13 || event.keyCode == 8)) {
+      this.view.observer.delayAndroidKey(event.key, event.keyCode);
+      return true;
+    }
+    if (browser.ios && !event.synthetic && !event.altKey && !event.metaKey && (PendingKeys.some((key) => key.keyCode == event.keyCode) && !event.ctrlKey || EmacsyPendingKeys.indexOf(event.key) > -1 && event.ctrlKey)) {
+      let mods = { ctrlKey: event.ctrlKey, altKey: event.altKey, metaKey: event.metaKey, shiftKey: event.shiftKey };
+      if (mods.shiftKey && browser.ios && !/^(off|none)$/.test(this.view.contentDOM.autocapitalize) && iosVirtualKeyboardOpen(this.view.win))
+        mods.shiftKey = false;
+      this.pendingIOSKey = { key: event.key, keyCode: event.keyCode, mods };
+      setTimeout(() => this.flushIOSKey(), 250);
+      return true;
+    }
+    if (event.keyCode != 229)
+      this.view.observer.forceFlush();
+    return false;
+  }
+  flushIOSKey(change) {
+    let key = this.pendingIOSKey;
+    if (!key)
+      return false;
+    if (key.key == "Enter" && change && change.from < change.to && /^\S+$/.test(change.insert.toString()))
+      return false;
+    this.pendingIOSKey = void 0;
+    return dispatchKey(this.view.contentDOM, key.key, key.keyCode, key.mods);
+  }
+  ignoreDuringComposition(event) {
+    if (!/^key/.test(event.type) || event.synthetic)
+      return false;
+    if (this.composing > 0)
+      return true;
+    if (browser.safari && !browser.ios && this.compositionPendingKey && Date.now() - this.compositionEndedAt < 100) {
+      this.compositionPendingKey = false;
+      return true;
+    }
+    return false;
+  }
+  startMouseSelection(mouseSelection) {
+    if (this.mouseSelection)
+      this.mouseSelection.destroy();
+    this.mouseSelection = mouseSelection;
+  }
+  update(update) {
+    this.view.observer.update(update);
+    if (this.mouseSelection)
+      this.mouseSelection.update(update);
+    if (this.draggedContent && update.docChanged)
+      this.draggedContent = this.draggedContent.map(update.changes);
+    if (update.transactions.length)
+      this.lastKeyCode = this.lastSelectionTime = 0;
+  }
+  destroy() {
+    if (this.mouseSelection)
+      this.mouseSelection.destroy();
+  }
+};
+function iosVirtualKeyboardOpen(win) {
+  if (!win.visualViewport)
+    return false;
+  return win.visualViewport.height * win.visualViewport.scale / win.document.documentElement.clientHeight < 0.85;
+}
+function bindHandler(plugin, handler) {
+  return (view, event) => {
+    try {
+      return handler.call(plugin, event, view);
+    } catch (e) {
+      logException(view.state, e);
+    }
+  };
+}
+function computeHandlers(plugins) {
+  let result = /* @__PURE__ */ Object.create(null);
+  function record(type) {
+    return result[type] || (result[type] = { observers: [], handlers: [] });
+  }
+  for (let plugin of plugins) {
+    let spec = plugin.spec, handlers2 = spec && spec.plugin.domEventHandlers, observers2 = spec && spec.plugin.domEventObservers;
+    if (handlers2)
+      for (let type in handlers2) {
+        let f = handlers2[type];
+        if (f)
+          record(type).handlers.push(bindHandler(plugin.value, f));
+      }
+    if (observers2)
+      for (let type in observers2) {
+        let f = observers2[type];
+        if (f)
+          record(type).observers.push(bindHandler(plugin.value, f));
+      }
+  }
+  for (let type in handlers)
+    record(type).handlers.push(handlers[type]);
+  for (let type in observers)
+    record(type).observers.push(observers[type]);
+  return result;
+}
+var PendingKeys = [
+  { key: "Backspace", keyCode: 8, inputType: "deleteContentBackward" },
+  { key: "Enter", keyCode: 13, inputType: "insertParagraph" },
+  { key: "Enter", keyCode: 13, inputType: "insertLineBreak" },
+  { key: "Delete", keyCode: 46, inputType: "deleteContentForward" }
+];
+var EmacsyPendingKeys = "dthko";
+var modifierCodes = [16, 17, 18, 20, 91, 92, 224, 225];
+var dragScrollMargin = 6;
+function dragScrollSpeed(dist2) {
+  return Math.max(0, dist2) * 0.7 + 8;
+}
+function dist(a, b) {
+  return Math.max(Math.abs(a.clientX - b.clientX), Math.abs(a.clientY - b.clientY));
+}
+var MouseSelection = class {
+  constructor(view, startEvent, style, mustSelect) {
+    this.view = view;
+    this.startEvent = startEvent;
+    this.style = style;
+    this.mustSelect = mustSelect;
+    this.scrollSpeed = { x: 0, y: 0 };
+    this.scrolling = -1;
+    this.lastEvent = startEvent;
+    this.scrollParents = scrollableParents(view.contentDOM);
+    this.atoms = view.state.facet(atomicRanges).map((f) => f(view));
+    let doc2 = view.contentDOM.ownerDocument;
+    doc2.addEventListener("mousemove", this.move = this.move.bind(this));
+    doc2.addEventListener("mouseup", this.up = this.up.bind(this));
+    this.extend = startEvent.shiftKey;
+    this.multiple = view.state.facet(EditorState.allowMultipleSelections) && addsSelectionRange(view, startEvent);
+    this.dragging = isInPrimarySelection(view, startEvent) && getClickType(startEvent) == 1 ? null : false;
+  }
+  start(event) {
+    if (this.dragging === false)
+      this.select(event);
+  }
+  move(event) {
+    if (event.buttons == 0)
+      return this.destroy();
+    if (this.dragging || this.dragging == null && dist(this.startEvent, event) < 10)
+      return;
+    this.select(this.lastEvent = event);
+    let sx = 0, sy = 0;
+    let left = 0, top2 = 0, right = this.view.win.innerWidth, bottom = this.view.win.innerHeight;
+    if (this.scrollParents.x)
+      ({ left, right } = this.scrollParents.x.getBoundingClientRect());
+    if (this.scrollParents.y)
+      ({ top: top2, bottom } = this.scrollParents.y.getBoundingClientRect());
+    let margins = getScrollMargins(this.view);
+    if (event.clientX - margins.left <= left + dragScrollMargin)
+      sx = -dragScrollSpeed(left - event.clientX);
+    else if (event.clientX + margins.right >= right - dragScrollMargin)
+      sx = dragScrollSpeed(event.clientX - right);
+    if (event.clientY - margins.top <= top2 + dragScrollMargin)
+      sy = -dragScrollSpeed(top2 - event.clientY);
+    else if (event.clientY + margins.bottom >= bottom - dragScrollMargin)
+      sy = dragScrollSpeed(event.clientY - bottom);
+    this.setScrollSpeed(sx, sy);
+  }
+  up(event) {
+    if (this.dragging == null)
+      this.select(this.lastEvent);
+    if (!this.dragging)
+      event.preventDefault();
+    this.destroy();
+  }
+  destroy() {
+    this.setScrollSpeed(0, 0);
+    let doc2 = this.view.contentDOM.ownerDocument;
+    doc2.removeEventListener("mousemove", this.move);
+    doc2.removeEventListener("mouseup", this.up);
+    this.view.inputState.mouseSelection = this.view.inputState.draggedContent = null;
+  }
+  setScrollSpeed(sx, sy) {
+    this.scrollSpeed = { x: sx, y: sy };
+    if (sx || sy) {
+      if (this.scrolling < 0)
+        this.scrolling = setInterval(() => this.scroll(), 50);
+    } else if (this.scrolling > -1) {
+      clearInterval(this.scrolling);
+      this.scrolling = -1;
+    }
+  }
+  scroll() {
+    let { x, y } = this.scrollSpeed;
+    if (x && this.scrollParents.x) {
+      this.scrollParents.x.scrollLeft += x;
+      x = 0;
+    }
+    if (y && this.scrollParents.y) {
+      this.scrollParents.y.scrollTop += y;
+      y = 0;
+    }
+    if (x || y)
+      this.view.win.scrollBy(x, y);
+    if (this.dragging === false)
+      this.select(this.lastEvent);
+  }
+  select(event) {
+    let { view } = this, selection = skipAtomsForSelection(this.atoms, this.style.get(event, this.extend, this.multiple));
+    if (this.mustSelect || !selection.eq(view.state.selection, this.dragging === false))
+      this.view.dispatch({
+        selection,
+        userEvent: "select.pointer"
+      });
+    this.mustSelect = false;
+  }
+  update(update) {
+    if (update.transactions.some((tr) => tr.isUserEvent("input.type")))
+      this.destroy();
+    else if (this.style.update(update))
+      setTimeout(() => this.select(this.lastEvent), 20);
+  }
+};
+function addsSelectionRange(view, event) {
+  let facet = view.state.facet(clickAddsSelectionRange);
+  return facet.length ? facet[0](event) : browser.mac ? event.metaKey : event.ctrlKey;
+}
+function dragMovesSelection(view, event) {
+  let facet = view.state.facet(dragMovesSelection$1);
+  return facet.length ? facet[0](event) : browser.mac ? !event.altKey : !event.ctrlKey;
+}
+function isInPrimarySelection(view, event) {
+  let { main } = view.state.selection;
+  if (main.empty)
+    return false;
+  let sel = getSelection(view.root);
+  if (!sel || sel.rangeCount == 0)
+    return true;
+  let rects = sel.getRangeAt(0).getClientRects();
+  for (let i2 = 0; i2 < rects.length; i2++) {
+    let rect = rects[i2];
+    if (rect.left <= event.clientX && rect.right >= event.clientX && rect.top <= event.clientY && rect.bottom >= event.clientY)
+      return true;
+  }
+  return false;
+}
+function eventBelongsToEditor(view, event) {
+  if (!event.bubbles)
+    return true;
+  if (event.defaultPrevented)
+    return false;
+  for (let node = event.target, tile; node != view.contentDOM; node = node.parentNode)
+    if (!node || node.nodeType == 11 || (tile = Tile.get(node)) && tile.isWidget() && !tile.isHidden && tile.widget.ignoreEvent(event))
+      return false;
+  return true;
+}
+var handlers = /* @__PURE__ */ Object.create(null);
+var observers = /* @__PURE__ */ Object.create(null);
+var brokenClipboardAPI = browser.ie && browser.ie_version < 15 || browser.ios && browser.webkit_version < 604;
+function capturePaste(view) {
+  let parent = view.dom.parentNode;
+  if (!parent)
+    return;
+  let target = parent.appendChild(document.createElement("textarea"));
+  target.style.cssText = "position: fixed; left: -10000px; top: 10px";
+  target.focus();
+  setTimeout(() => {
+    view.focus();
+    target.remove();
+    doPaste(view, target.value);
+  }, 50);
+}
+function textFilter(state, facet, text) {
+  for (let filter of state.facet(facet))
+    text = filter(text, state);
+  return text;
+}
+function doPaste(view, input) {
+  input = textFilter(view.state, clipboardInputFilter, input);
+  let { state } = view, changes, i2 = 1, text = state.toText(input);
+  let byLine = text.lines == state.selection.ranges.length;
+  let linewise = lastLinewiseCopy != null && state.selection.ranges.every((r2) => r2.empty) && lastLinewiseCopy == text.toString();
+  if (linewise) {
+    let lastLine = -1;
+    changes = state.changeByRange((range) => {
+      let line = state.doc.lineAt(range.from);
+      if (line.from == lastLine)
+        return { range };
+      lastLine = line.from;
+      let insert2 = state.toText((byLine ? text.line(i2++).text : input) + state.lineBreak);
+      return {
+        changes: { from: line.from, insert: insert2 },
+        range: EditorSelection.cursor(range.from + insert2.length)
+      };
+    });
+  } else if (byLine) {
+    changes = state.changeByRange((range) => {
+      let line = text.line(i2++);
+      return {
+        changes: { from: range.from, to: range.to, insert: line.text },
+        range: EditorSelection.cursor(range.from + line.length)
+      };
+    });
+  } else {
+    changes = state.replaceSelection(text);
+  }
+  view.dispatch(changes, {
+    userEvent: "input.paste",
+    scrollIntoView: true
+  });
+}
+observers.scroll = (view) => {
+  view.inputState.lastScrollTop = view.scrollDOM.scrollTop;
+  view.inputState.lastScrollLeft = view.scrollDOM.scrollLeft;
+};
+observers.wheel = observers.mousewheel = (view) => {
+  view.inputState.lastWheelEvent = Date.now();
+};
+handlers.keydown = (view, event) => {
+  view.inputState.setSelectionOrigin("select");
+  if (event.keyCode == 27 && view.inputState.tabFocusMode != 0)
+    view.inputState.tabFocusMode = Date.now() + 2e3;
+  return false;
+};
+observers.touchstart = (view, e) => {
+  let iState = view.inputState, touch = e.targetTouches[0];
+  iState.lastTouchTime = Date.now();
+  if (touch) {
+    iState.lastTouchX = touch.clientX;
+    iState.lastTouchY = touch.clientY;
+  }
+  iState.setSelectionOrigin("select.pointer");
+};
+observers.touchmove = (view) => {
+  view.inputState.setSelectionOrigin("select.pointer");
+};
+handlers.mousedown = (view, event) => {
+  view.observer.flush();
+  if (view.inputState.lastTouchTime > Date.now() - 2e3)
+    return false;
+  let style = null;
+  for (let makeStyle of view.state.facet(mouseSelectionStyle)) {
+    style = makeStyle(view, event);
+    if (style)
+      break;
+  }
+  if (!style && event.button == 0)
+    style = basicMouseSelection(view, event);
+  if (style) {
+    let mustFocus = !view.hasFocus;
+    view.inputState.startMouseSelection(new MouseSelection(view, event, style, mustFocus));
+    if (mustFocus)
+      view.observer.ignore(() => {
+        focusPreventScroll(view.contentDOM);
+        let active = view.root.activeElement;
+        if (active && !active.contains(view.contentDOM))
+          active.blur();
+      });
+    let mouseSel = view.inputState.mouseSelection;
+    if (mouseSel) {
+      mouseSel.start(event);
+      return mouseSel.dragging === false;
+    }
+  } else {
+    view.inputState.setSelectionOrigin("select.pointer");
+  }
+  return false;
+};
+function rangeForClick(view, pos, bias, type) {
+  if (type == 1) {
+    return EditorSelection.cursor(pos, bias);
+  } else if (type == 2) {
+    return groupAt(view.state, pos, bias);
+  } else {
+    let visual = view.docView.lineAt(pos, bias), line = view.state.doc.lineAt(visual ? visual.posAtEnd : pos);
+    let from = visual ? visual.posAtStart : line.from, to = visual ? visual.posAtEnd : line.to;
+    if (to < view.state.doc.length && to == line.to)
+      to++;
+    return EditorSelection.undirectionalRange(from, to);
+  }
+}
+var BadMouseDetail = browser.ie && browser.ie_version <= 11;
+var lastMouseDown = null;
+var lastMouseDownCount = 0;
+var lastMouseDownTime = 0;
+function getClickType(event) {
+  if (!BadMouseDetail)
+    return event.detail;
+  let last = lastMouseDown, lastTime = lastMouseDownTime;
+  lastMouseDown = event;
+  lastMouseDownTime = Date.now();
+  return lastMouseDownCount = !last || lastTime > Date.now() - 400 && Math.abs(last.clientX - event.clientX) < 2 && Math.abs(last.clientY - event.clientY) < 2 ? (lastMouseDownCount + 1) % 3 : 1;
+}
+function basicMouseSelection(view, event) {
+  let start = view.posAndSideAtCoords({ x: event.clientX, y: event.clientY }, false), type = getClickType(event);
+  let startSel = view.state.selection;
+  return {
+    update(update) {
+      if (update.docChanged) {
+        start.pos = update.changes.mapPos(start.pos);
+        startSel = startSel.map(update.changes);
+      }
+    },
+    get(event2, extend, multiple) {
+      let cur = view.posAndSideAtCoords({ x: event2.clientX, y: event2.clientY }, false), removed;
+      let range = rangeForClick(view, cur.pos, cur.assoc, type);
+      if (start.pos != cur.pos && !extend) {
+        let startRange = rangeForClick(view, start.pos, start.assoc, type);
+        let from = Math.min(startRange.from, range.from), to = Math.max(startRange.to, range.to);
+        range = from < range.from ? EditorSelection.range(from, to, range.assoc) : EditorSelection.range(to, from, range.assoc);
+      }
+      if (extend)
+        return startSel.replaceRange(startSel.main.extend(range.from, range.to, range.assoc));
+      else if (multiple && type == 1 && startSel.ranges.length > 1 && (removed = removeRangeAround(startSel, cur.pos)))
+        return removed;
+      else if (multiple)
+        return startSel.addRange(range);
+      else
+        return EditorSelection.create([range]);
+    }
+  };
+}
+function removeRangeAround(sel, pos) {
+  for (let i2 = 0; i2 < sel.ranges.length; i2++) {
+    let { from, to } = sel.ranges[i2];
+    if (from <= pos && to >= pos)
+      return EditorSelection.create(sel.ranges.slice(0, i2).concat(sel.ranges.slice(i2 + 1)), sel.mainIndex == i2 ? 0 : sel.mainIndex - (sel.mainIndex > i2 ? 1 : 0));
+  }
+  return null;
+}
+handlers.dragstart = (view, event) => {
+  let { selection: { main: range } } = view.state;
+  if (event.target.draggable) {
+    let tile = view.docView.tile.nearest(event.target);
+    if (tile && tile.isWidget()) {
+      let from = tile.posAtStart, to = from + tile.length;
+      if (from >= range.to || to <= range.from)
+        range = EditorSelection.undirectionalRange(from, to);
+    }
+  }
+  let { inputState } = view;
+  if (inputState.mouseSelection)
+    inputState.mouseSelection.dragging = true;
+  inputState.draggedContent = range;
+  if (event.dataTransfer) {
+    event.dataTransfer.setData("Text", textFilter(view.state, clipboardOutputFilter, view.state.sliceDoc(range.from, range.to)));
+    event.dataTransfer.effectAllowed = "copyMove";
+  }
+  return false;
+};
+handlers.dragend = (view) => {
+  view.inputState.draggedContent = null;
+  return false;
+};
+function dropText(view, event, text, direct) {
+  text = textFilter(view.state, clipboardInputFilter, text);
+  if (!text)
+    return;
+  let dropPos = view.posAtCoords({ x: event.clientX, y: event.clientY }, false);
+  let { draggedContent } = view.inputState;
+  let del = direct && draggedContent && dragMovesSelection(view, event) ? { from: draggedContent.from, to: draggedContent.to } : null;
+  let ins = { from: dropPos, insert: text };
+  let changes = view.state.changes(del ? [del, ins] : ins);
+  view.focus();
+  view.dispatch({
+    changes,
+    selection: { anchor: changes.mapPos(dropPos, -1), head: changes.mapPos(dropPos, 1) },
+    userEvent: del ? "move.drop" : "input.drop"
+  });
+  view.inputState.draggedContent = null;
+}
+handlers.drop = (view, event) => {
+  if (!event.dataTransfer)
+    return false;
+  if (view.state.readOnly)
+    return true;
+  let files = event.dataTransfer.files;
+  if (files && files.length) {
+    let text = Array(files.length), read = 0;
+    let finishFile = () => {
+      if (++read == files.length)
+        dropText(view, event, text.filter((s) => s != null).join(view.state.lineBreak), false);
+    };
+    for (let i2 = 0; i2 < files.length; i2++) {
+      let reader = new FileReader();
+      reader.onerror = finishFile;
+      reader.onload = () => {
+        if (!/[\x00-\x08\x0e-\x1f]{2}/.test(reader.result))
+          text[i2] = reader.result;
+        finishFile();
+      };
+      reader.readAsText(files[i2]);
+    }
+    return true;
+  } else {
+    let text = event.dataTransfer.getData("Text");
+    if (text) {
+      dropText(view, event, text, true);
+      return true;
+    }
+  }
+  return false;
+};
+handlers.paste = (view, event) => {
+  if (view.state.readOnly)
+    return true;
+  view.observer.flush();
+  let data = brokenClipboardAPI ? null : event.clipboardData;
+  if (data) {
+    doPaste(view, data.getData("text/plain") || data.getData("text/uri-list"));
+    return true;
+  } else {
+    capturePaste(view);
+    return false;
+  }
+};
+function captureCopy(view, text) {
+  let parent = view.dom.parentNode;
+  if (!parent)
+    return;
+  let target = parent.appendChild(document.createElement("textarea"));
+  target.style.cssText = "position: fixed; left: -10000px; top: 10px";
+  target.value = text;
+  target.focus();
+  target.selectionEnd = text.length;
+  target.selectionStart = 0;
+  setTimeout(() => {
+    target.remove();
+    view.focus();
+  }, 50);
+}
+function copiedRange(state) {
+  let content2 = [], ranges = [], linewise = false;
+  for (let range of state.selection.ranges)
+    if (!range.empty) {
+      content2.push(state.sliceDoc(range.from, range.to));
+      ranges.push(range);
+    }
+  if (!content2.length) {
+    let upto = -1;
+    for (let { from } of state.selection.ranges) {
+      let line = state.doc.lineAt(from);
+      if (line.number > upto) {
+        content2.push(line.text);
+        ranges.push({ from: line.from, to: Math.min(state.doc.length, line.to + 1) });
+      }
+      upto = line.number;
+    }
+    linewise = true;
+  }
+  return { text: textFilter(state, clipboardOutputFilter, content2.join(state.lineBreak)), ranges, linewise };
+}
+var lastLinewiseCopy = null;
+handlers.copy = handlers.cut = (view, event) => {
+  if (!hasSelection(view.contentDOM, view.observer.selectionRange))
+    return false;
+  let { text, ranges, linewise } = copiedRange(view.state);
+  if (!text && !linewise)
+    return false;
+  lastLinewiseCopy = linewise ? text : null;
+  if (event.type == "cut" && !view.state.readOnly)
+    view.dispatch({
+      changes: ranges,
+      scrollIntoView: true,
+      userEvent: "delete.cut"
+    });
+  let data = brokenClipboardAPI ? null : event.clipboardData;
+  if (data) {
+    data.clearData();
+    data.setData("text/plain", text);
+    return true;
+  } else {
+    captureCopy(view, text);
+    return false;
+  }
+};
+var isFocusChange = /* @__PURE__ */ Annotation.define();
+function focusChangeTransaction(state, focus) {
+  let effects = [];
+  for (let getEffect of state.facet(focusChangeEffect)) {
+    let effect = getEffect(state, focus);
+    if (effect)
+      effects.push(effect);
+  }
+  return effects.length ? state.update({ effects, annotations: isFocusChange.of(true) }) : null;
+}
+function updateForFocusChange(view) {
+  setTimeout(() => {
+    let focus = view.hasFocus;
+    if (focus != view.inputState.notifiedFocused) {
+      let tr = focusChangeTransaction(view.state, focus);
+      if (tr)
+        view.dispatch(tr);
+      else
+        view.update([]);
+    }
+  }, 10);
+}
+observers.focus = (view) => {
+  view.inputState.lastFocusTime = Date.now();
+  if (!view.scrollDOM.scrollTop && (view.inputState.lastScrollTop || view.inputState.lastScrollLeft)) {
+    view.scrollDOM.scrollTop = view.inputState.lastScrollTop;
+    view.scrollDOM.scrollLeft = view.inputState.lastScrollLeft;
+  }
+  updateForFocusChange(view);
+};
+observers.blur = (view) => {
+  view.observer.clearSelectionRange();
+  updateForFocusChange(view);
+};
+observers.compositionstart = observers.compositionupdate = (view) => {
+  if (view.observer.editContext)
+    return;
+  if (view.inputState.compositionFirstChange == null)
+    view.inputState.compositionFirstChange = true;
+  if (view.inputState.composing < 0) {
+    view.inputState.composing = 0;
+  }
+};
+observers.compositionend = (view) => {
+  if (view.observer.editContext)
+    return;
+  view.inputState.composing = -1;
+  view.inputState.compositionEndedAt = Date.now();
+  view.inputState.compositionPendingKey = true;
+  view.inputState.compositionPendingChange = view.observer.pendingRecords().length > 0;
+  view.inputState.compositionFirstChange = null;
+  if (browser.chrome && browser.android) {
+    view.observer.flushSoon();
+  } else if (view.inputState.compositionPendingChange) {
+    Promise.resolve().then(() => view.observer.flush());
+  } else {
+    setTimeout(() => {
+      if (view.inputState.composing < 0 && view.docView.hasComposition)
+        view.update([]);
+    }, 50);
+  }
+};
+observers.contextmenu = (view) => {
+  view.inputState.lastContextMenu = Date.now();
+};
+handlers.beforeinput = (view, event) => {
+  var _a2, _b;
+  if (event.inputType == "insertText" || event.inputType == "insertCompositionText") {
+    view.inputState.insertingText = event.data;
+    view.inputState.insertingTextAt = Date.now();
+  }
+  if (event.inputType == "insertReplacementText" && view.observer.editContext) {
+    let text = (_a2 = event.dataTransfer) === null || _a2 === void 0 ? void 0 : _a2.getData("text/plain"), ranges = event.getTargetRanges();
+    if (text && ranges.length) {
+      let r2 = ranges[0];
+      let from = view.posAtDOM(r2.startContainer, r2.startOffset), to = view.posAtDOM(r2.endContainer, r2.endOffset);
+      applyDOMChangeInner(view, { from, to, insert: view.state.toText(text) }, null);
+      return true;
+    }
+  }
+  let pending;
+  if (browser.chrome && browser.android && (pending = PendingKeys.find((key) => key.inputType == event.inputType))) {
+    view.observer.delayAndroidKey(pending.key, pending.keyCode);
+    if (pending.key == "Backspace" || pending.key == "Delete") {
+      let startViewHeight = ((_b = window.visualViewport) === null || _b === void 0 ? void 0 : _b.height) || 0;
+      setTimeout(() => {
+        var _a3;
+        if ((((_a3 = window.visualViewport) === null || _a3 === void 0 ? void 0 : _a3.height) || 0) > startViewHeight + 10 && view.hasFocus) {
+          view.contentDOM.blur();
+          view.focus();
+        }
+      }, 100);
+    }
+  }
+  if (browser.ios && event.inputType == "deleteContentForward") {
+    view.observer.flushSoon();
+  }
+  if (browser.safari && event.inputType == "insertText" && view.inputState.composing >= 0) {
+    setTimeout(() => observers.compositionend(view, event), 20);
+  }
+  return false;
+};
+var appliedFirefoxHack = /* @__PURE__ */ new Set();
+function firefoxCopyCutHack(doc2) {
+  if (!appliedFirefoxHack.has(doc2)) {
+    appliedFirefoxHack.add(doc2);
+    doc2.addEventListener("copy", () => {
+    });
+    doc2.addEventListener("cut", () => {
+    });
+  }
+}
+var wrappingWhiteSpace = ["pre-wrap", "normal", "pre-line", "break-spaces"];
+var heightChangeFlag = false;
+function clearHeightChangeFlag() {
+  heightChangeFlag = false;
+}
+var HeightOracle = class {
+  constructor(lineWrapping) {
+    this.lineWrapping = lineWrapping;
+    this.doc = Text.empty;
+    this.heightSamples = {};
+    this.lineHeight = 14;
+    this.charWidth = 7;
+    this.textHeight = 14;
+    this.lineLength = 30;
+  }
+  heightForGap(from, to) {
+    let lines = this.doc.lineAt(to).number - this.doc.lineAt(from).number + 1;
+    if (this.lineWrapping)
+      lines += Math.max(0, Math.ceil((to - from - lines * this.lineLength * 0.5) / this.lineLength));
+    return this.lineHeight * lines;
+  }
+  heightForLine(length) {
+    if (!this.lineWrapping)
+      return this.lineHeight;
+    let lines = 1 + Math.max(0, Math.ceil((length - this.lineLength) / Math.max(1, this.lineLength - 5)));
+    return lines * this.lineHeight;
+  }
+  setDoc(doc2) {
+    this.doc = doc2;
+    return this;
+  }
+  mustRefreshForWrapping(whiteSpace) {
+    return wrappingWhiteSpace.indexOf(whiteSpace) > -1 != this.lineWrapping;
+  }
+  mustRefreshForHeights(lineHeights) {
+    let newHeight = false;
+    for (let i2 = 0; i2 < lineHeights.length; i2++) {
+      let h = lineHeights[i2];
+      if (h < 0) {
+        i2++;
+      } else if (!this.heightSamples[Math.floor(h * 10)]) {
+        newHeight = true;
+        this.heightSamples[Math.floor(h * 10)] = true;
+      }
+    }
+    return newHeight;
+  }
+  refresh(whiteSpace, lineHeight, charWidth, textHeight, lineLength, knownHeights) {
+    let lineWrapping = wrappingWhiteSpace.indexOf(whiteSpace) > -1;
+    let changed = Math.abs(lineHeight - this.lineHeight) > 0.3 || this.lineWrapping != lineWrapping;
+    this.lineWrapping = lineWrapping;
+    this.lineHeight = lineHeight;
+    this.charWidth = charWidth;
+    this.textHeight = textHeight;
+    this.lineLength = lineLength;
+    if (changed) {
+      this.heightSamples = {};
+      for (let i2 = 0; i2 < knownHeights.length; i2++) {
+        let h = knownHeights[i2];
+        if (h < 0)
+          i2++;
+        else
+          this.heightSamples[Math.floor(h * 10)] = true;
+      }
+    }
+    return changed;
+  }
+};
+var MeasuredHeights = class {
+  constructor(from, heights) {
+    this.from = from;
+    this.heights = heights;
+    this.index = 0;
+  }
+  get more() {
+    return this.index < this.heights.length;
+  }
+};
+var BlockInfo = class _BlockInfo {
+  /**
+  @internal
+  */
+  constructor(from, length, top2, height, _content) {
+    this.from = from;
+    this.length = length;
+    this.top = top2;
+    this.height = height;
+    this._content = _content;
+  }
+  /**
+  The type of element this is. When querying lines, this may be
+  an array of all the blocks that make up the line.
+  */
+  get type() {
+    return typeof this._content == "number" ? BlockType.Text : Array.isArray(this._content) ? this._content : this._content.type;
+  }
+  /**
+  The end of the element as a document position.
+  */
+  get to() {
+    return this.from + this.length;
+  }
+  /**
+  The bottom position of the element.
+  */
+  get bottom() {
+    return this.top + this.height;
+  }
+  /**
+  If this is a widget block, this will return the widget
+  associated with it.
+  */
+  get widget() {
+    return this._content instanceof PointDecoration ? this._content.widget : null;
+  }
+  /**
+  If this is a textblock, this holds the number of line breaks
+  that appear in widgets inside the block.
+  */
+  get widgetLineBreaks() {
+    return typeof this._content == "number" ? this._content : 0;
+  }
+  /**
+  @internal
+  */
+  join(other) {
+    let content2 = (Array.isArray(this._content) ? this._content : [this]).concat(Array.isArray(other._content) ? other._content : [other]);
+    return new _BlockInfo(this.from, this.length + other.length, this.top, this.height + other.height, content2);
+  }
+};
+var QueryType = /* @__PURE__ */ (function(QueryType2) {
+  QueryType2[QueryType2["ByPos"] = 0] = "ByPos";
+  QueryType2[QueryType2["ByHeight"] = 1] = "ByHeight";
+  QueryType2[QueryType2["ByPosNoHeight"] = 2] = "ByPosNoHeight";
+  return QueryType2;
+})(QueryType || (QueryType = {}));
+var Epsilon = 1e-3;
+var HeightMap = class _HeightMap {
+  constructor(length, height, flags = 2) {
+    this.length = length;
+    this.height = height;
+    this.flags = flags;
+  }
+  get outdated() {
+    return (this.flags & 2) > 0;
+  }
+  set outdated(value) {
+    this.flags = (value ? 2 : 0) | this.flags & ~2;
+  }
+  setHeight(height) {
+    if (this.height != height) {
+      if (Math.abs(this.height - height) > Epsilon)
+        heightChangeFlag = true;
+      this.height = height;
+    }
+  }
+  // Base case is to replace a leaf node, which simply builds a tree
+  // from the new nodes and returns that (HeightMapBranch and
+  // HeightMapGap override this to actually use from/to)
+  replace(_from, _to, nodes) {
+    return _HeightMap.of(nodes);
+  }
+  // Again, these are base cases, and are overridden for branch and gap nodes.
+  decomposeLeft(_to, result) {
+    result.push(this);
+  }
+  decomposeRight(_from, result) {
+    result.push(this);
+  }
+  applyChanges(decorations2, oldDoc, oracle, changes) {
+    let me = this, doc2 = oracle.doc;
+    for (let i2 = changes.length - 1; i2 >= 0; i2--) {
+      let { fromA, toA, fromB, toB } = changes[i2];
+      let start = me.lineAt(fromA, QueryType.ByPosNoHeight, oracle.setDoc(oldDoc), 0, 0);
+      let end = start.to >= toA ? start : me.lineAt(toA, QueryType.ByPosNoHeight, oracle, 0, 0);
+      toB += end.to - toA;
+      toA = end.to;
+      while (i2 > 0 && start.from <= changes[i2 - 1].toA) {
+        fromA = changes[i2 - 1].fromA;
+        fromB = changes[i2 - 1].fromB;
+        i2--;
+        if (fromA < start.from)
+          start = me.lineAt(fromA, QueryType.ByPosNoHeight, oracle, 0, 0);
+      }
+      fromB += start.from - fromA;
+      fromA = start.from;
+      let nodes = NodeBuilder.build(oracle.setDoc(doc2), decorations2, fromB, toB);
+      me = replace(me, me.replace(fromA, toA, nodes));
+    }
+    return me.updateHeight(oracle, 0);
+  }
+  static empty() {
+    return new HeightMapText(0, 0, 0);
+  }
+  // nodes uses null values to indicate the position of line breaks.
+  // There are never line breaks at the start or end of the array, or
+  // two line breaks next to each other, and the array isn't allowed
+  // to be empty (same restrictions as return value from the builder).
+  static of(nodes) {
+    if (nodes.length == 1)
+      return nodes[0];
+    let i2 = 0, j = nodes.length, before = 0, after = 0;
+    for (; ; ) {
+      if (i2 == j) {
+        if (before > after * 2) {
+          let split = nodes[i2 - 1];
+          if (split.break)
+            nodes.splice(--i2, 1, split.left, null, split.right);
+          else
+            nodes.splice(--i2, 1, split.left, split.right);
+          j += 1 + split.break;
+          before -= split.size;
+        } else if (after > before * 2) {
+          let split = nodes[j];
+          if (split.break)
+            nodes.splice(j, 1, split.left, null, split.right);
+          else
+            nodes.splice(j, 1, split.left, split.right);
+          j += 2 + split.break;
+          after -= split.size;
+        } else {
+          break;
+        }
+      } else if (before < after) {
+        let next = nodes[i2++];
+        if (next)
+          before += next.size;
+      } else {
+        let next = nodes[--j];
+        if (next)
+          after += next.size;
+      }
+    }
+    let brk = 0;
+    if (nodes[i2 - 1] == null) {
+      brk = 1;
+      i2--;
+    } else if (nodes[i2] == null) {
+      brk = 1;
+      j++;
+    }
+    return new HeightMapBranch(_HeightMap.of(nodes.slice(0, i2)), brk, _HeightMap.of(nodes.slice(j)));
+  }
+};
+function replace(old, val) {
+  if (old == val)
+    return old;
+  if (old.constructor != val.constructor)
+    heightChangeFlag = true;
+  return val;
+}
+HeightMap.prototype.size = 1;
+var SpaceDeco = /* @__PURE__ */ Decoration.replace({});
+var HeightMapBlock = class extends HeightMap {
+  constructor(length, height, deco) {
+    super(length, height);
+    this.deco = deco;
+    this.spaceAbove = 0;
+  }
+  mainBlock(top2, offset) {
+    return new BlockInfo(offset, this.length, top2 + this.spaceAbove, this.height - this.spaceAbove, this.deco || 0);
+  }
+  blockAt(height, _oracle, top2, offset) {
+    return this.spaceAbove && height < top2 + this.spaceAbove ? new BlockInfo(offset, 0, top2, this.spaceAbove, SpaceDeco) : this.mainBlock(top2, offset);
+  }
+  lineAt(_value, _type, oracle, top2, offset) {
+    let main = this.mainBlock(top2, offset);
+    return this.spaceAbove ? this.blockAt(0, oracle, top2, offset).join(main) : main;
+  }
+  forEachLine(from, to, oracle, top2, offset, f) {
+    if (from <= offset + this.length && to >= offset)
+      f(this.lineAt(0, QueryType.ByPos, oracle, top2, offset));
+  }
+  setMeasuredHeight(measured) {
+    let next = measured.heights[measured.index++];
+    if (next < 0) {
+      this.spaceAbove = -next;
+      next = measured.heights[measured.index++];
+    } else {
+      this.spaceAbove = 0;
+    }
+    this.setHeight(next);
+  }
+  updateHeight(oracle, offset = 0, _force = false, measured) {
+    if (measured && measured.from <= offset && measured.more)
+      this.setMeasuredHeight(measured);
+    this.outdated = false;
+    return this;
+  }
+  toString() {
+    return `block(${this.length})`;
+  }
+};
+var HeightMapText = class _HeightMapText extends HeightMapBlock {
+  constructor(length, height, above) {
+    super(length, height, null);
+    this.collapsed = 0;
+    this.widgetHeight = 0;
+    this.breaks = 0;
+    this.spaceAbove = above;
+  }
+  mainBlock(top2, offset) {
+    return new BlockInfo(offset, this.length, top2 + this.spaceAbove, this.height - this.spaceAbove, this.breaks);
+  }
+  replace(_from, _to, nodes) {
+    let node = nodes[0];
+    if (nodes.length == 1 && (node instanceof _HeightMapText || node instanceof HeightMapGap && node.flags & 4) && Math.abs(this.length - node.length) < 10) {
+      if (node instanceof HeightMapGap)
+        node = new _HeightMapText(node.length, this.height, this.spaceAbove);
+      else
+        node.height = this.height;
+      if (!this.outdated)
+        node.outdated = false;
+      return node;
+    } else {
+      return HeightMap.of(nodes);
+    }
+  }
+  updateHeight(oracle, offset = 0, force = false, measured) {
+    if (measured && measured.from <= offset && measured.more) {
+      this.setMeasuredHeight(measured);
+    } else if (force || this.outdated) {
+      this.spaceAbove = 0;
+      this.setHeight(Math.max(this.widgetHeight, oracle.heightForLine(this.length - this.collapsed)) + this.breaks * oracle.lineHeight);
+    }
+    this.outdated = false;
+    return this;
+  }
+  toString() {
+    return `line(${this.length}${this.collapsed ? -this.collapsed : ""}${this.widgetHeight ? ":" + this.widgetHeight : ""})`;
+  }
+};
+var HeightMapGap = class _HeightMapGap extends HeightMap {
+  constructor(length) {
+    super(length, 0);
+  }
+  heightMetrics(oracle, offset) {
+    let firstLine = oracle.doc.lineAt(offset).number, lastLine = oracle.doc.lineAt(offset + this.length).number;
+    let lines = lastLine - firstLine + 1;
+    let perLine, perChar = 0;
+    if (oracle.lineWrapping) {
+      let totalPerLine = Math.min(this.height, oracle.lineHeight * lines);
+      perLine = totalPerLine / lines;
+      if (this.length > lines + 1)
+        perChar = (this.height - totalPerLine) / (this.length - lines - 1);
+    } else {
+      perLine = this.height / lines;
+    }
+    return { firstLine, lastLine, perLine, perChar };
+  }
+  blockAt(height, oracle, top2, offset) {
+    let { firstLine, lastLine, perLine, perChar } = this.heightMetrics(oracle, offset);
+    if (oracle.lineWrapping) {
+      let guess = offset + (height < oracle.lineHeight ? 0 : Math.round(Math.max(0, Math.min(1, (height - top2) / this.height)) * this.length));
+      let line = oracle.doc.lineAt(guess), lineHeight = perLine + line.length * perChar;
+      let lineTop = Math.max(top2, height - lineHeight / 2);
+      return new BlockInfo(line.from, line.length, lineTop, lineHeight, 0);
+    } else {
+      let line = Math.max(0, Math.min(lastLine - firstLine, Math.floor((height - top2) / perLine)));
+      let { from, length } = oracle.doc.line(firstLine + line);
+      return new BlockInfo(from, length, top2 + perLine * line, perLine, 0);
+    }
+  }
+  lineAt(value, type, oracle, top2, offset) {
+    if (type == QueryType.ByHeight)
+      return this.blockAt(value, oracle, top2, offset);
+    if (type == QueryType.ByPosNoHeight) {
+      let { from, to } = oracle.doc.lineAt(value);
+      return new BlockInfo(from, to - from, 0, 0, 0);
+    }
+    let { firstLine, perLine, perChar } = this.heightMetrics(oracle, offset);
+    let line = oracle.doc.lineAt(value), lineHeight = perLine + line.length * perChar;
+    let linesAbove = line.number - firstLine;
+    let lineTop = top2 + perLine * linesAbove + perChar * (line.from - offset - linesAbove);
+    return new BlockInfo(line.from, line.length, Math.max(top2, Math.min(lineTop, top2 + this.height - lineHeight)), lineHeight, 0);
+  }
+  forEachLine(from, to, oracle, top2, offset, f) {
+    from = Math.max(from, offset);
+    to = Math.min(to, offset + this.length);
+    let { firstLine, perLine, perChar } = this.heightMetrics(oracle, offset);
+    for (let pos = from, lineTop = top2; pos <= to; ) {
+      let line = oracle.doc.lineAt(pos);
+      if (pos == from) {
+        let linesAbove = line.number - firstLine;
+        lineTop += perLine * linesAbove + perChar * (from - offset - linesAbove);
+      }
+      let lineHeight = perLine + perChar * line.length;
+      f(new BlockInfo(line.from, line.length, lineTop, lineHeight, 0));
+      lineTop += lineHeight;
+      pos = line.to + 1;
+    }
+  }
+  replace(from, to, nodes) {
+    let after = this.length - to;
+    if (after > 0) {
+      let last = nodes[nodes.length - 1];
+      if (last instanceof _HeightMapGap)
+        nodes[nodes.length - 1] = new _HeightMapGap(last.length + after);
+      else
+        nodes.push(null, new _HeightMapGap(after - 1));
+    }
+    if (from > 0) {
+      let first = nodes[0];
+      if (first instanceof _HeightMapGap)
+        nodes[0] = new _HeightMapGap(from + first.length);
+      else
+        nodes.unshift(new _HeightMapGap(from - 1), null);
+    }
+    return HeightMap.of(nodes);
+  }
+  decomposeLeft(to, result) {
+    result.push(new _HeightMapGap(to - 1), null);
+  }
+  decomposeRight(from, result) {
+    result.push(null, new _HeightMapGap(this.length - from - 1));
+  }
+  updateHeight(oracle, offset = 0, force = false, measured) {
+    let end = offset + this.length;
+    if (measured && measured.from <= offset + this.length && measured.more) {
+      let nodes = [], pos = Math.max(offset, measured.from), singleHeight = -1;
+      if (measured.from > offset)
+        nodes.push(new _HeightMapGap(measured.from - offset - 1).updateHeight(oracle, offset));
+      while (pos <= end && measured.more) {
+        let len = oracle.doc.lineAt(pos).length;
+        if (nodes.length)
+          nodes.push(null);
+        let height = measured.heights[measured.index++], above = 0;
+        if (height < 0) {
+          above = -height;
+          height = measured.heights[measured.index++];
+        }
+        if (singleHeight == -1)
+          singleHeight = height;
+        else if (Math.abs(height - singleHeight) >= Epsilon)
+          singleHeight = -2;
+        let line = new HeightMapText(len, height, above);
+        line.outdated = false;
+        nodes.push(line);
+        pos += len + 1;
+      }
+      if (pos <= end)
+        nodes.push(null, new _HeightMapGap(end - pos).updateHeight(oracle, pos));
+      let result = HeightMap.of(nodes);
+      if (singleHeight < 0 || Math.abs(result.height - this.height) >= Epsilon || Math.abs(singleHeight - this.heightMetrics(oracle, offset).perLine) >= Epsilon)
+        heightChangeFlag = true;
+      return replace(this, result);
+    } else if (force || this.outdated) {
+      this.setHeight(oracle.heightForGap(offset, offset + this.length));
+      this.outdated = false;
+    }
+    return this;
+  }
+  toString() {
+    return `gap(${this.length})`;
+  }
+};
+var HeightMapBranch = class extends HeightMap {
+  constructor(left, brk, right) {
+    super(left.length + brk + right.length, left.height + right.height, brk | (left.outdated || right.outdated ? 2 : 0));
+    this.left = left;
+    this.right = right;
+    this.size = left.size + right.size;
+  }
+  get break() {
+    return this.flags & 1;
+  }
+  blockAt(height, oracle, top2, offset) {
+    let mid = top2 + this.left.height;
+    return height < mid ? this.left.blockAt(height, oracle, top2, offset) : this.right.blockAt(height, oracle, mid, offset + this.left.length + this.break);
+  }
+  lineAt(value, type, oracle, top2, offset) {
+    let rightTop = top2 + this.left.height, rightOffset = offset + this.left.length + this.break;
+    let left = type == QueryType.ByHeight ? value < rightTop : value < rightOffset;
+    let base2 = left ? this.left.lineAt(value, type, oracle, top2, offset) : this.right.lineAt(value, type, oracle, rightTop, rightOffset);
+    if (this.break || (left ? base2.to < rightOffset : base2.from > rightOffset))
+      return base2;
+    let subQuery = type == QueryType.ByPosNoHeight ? QueryType.ByPosNoHeight : QueryType.ByPos;
+    if (left)
+      return base2.join(this.right.lineAt(rightOffset, subQuery, oracle, rightTop, rightOffset));
+    else
+      return this.left.lineAt(rightOffset, subQuery, oracle, top2, offset).join(base2);
+  }
+  forEachLine(from, to, oracle, top2, offset, f) {
+    let rightTop = top2 + this.left.height, rightOffset = offset + this.left.length + this.break;
+    if (this.break) {
+      if (from < rightOffset)
+        this.left.forEachLine(from, to, oracle, top2, offset, f);
+      if (to >= rightOffset)
+        this.right.forEachLine(from, to, oracle, rightTop, rightOffset, f);
+    } else {
+      let mid = this.lineAt(rightOffset, QueryType.ByPos, oracle, top2, offset);
+      if (from < mid.from)
+        this.left.forEachLine(from, mid.from - 1, oracle, top2, offset, f);
+      if (mid.to >= from && mid.from <= to)
+        f(mid);
+      if (to > mid.to)
+        this.right.forEachLine(mid.to + 1, to, oracle, rightTop, rightOffset, f);
+    }
+  }
+  replace(from, to, nodes) {
+    let rightStart = this.left.length + this.break;
+    if (to < rightStart)
+      return this.balanced(this.left.replace(from, to, nodes), this.right);
+    if (from > this.left.length)
+      return this.balanced(this.left, this.right.replace(from - rightStart, to - rightStart, nodes));
+    let result = [];
+    if (from > 0)
+      this.decomposeLeft(from, result);
+    let left = result.length;
+    for (let node of nodes)
+      result.push(node);
+    if (from > 0)
+      mergeGaps(result, left - 1);
+    if (to < this.length) {
+      let right = result.length;
+      this.decomposeRight(to, result);
+      mergeGaps(result, right);
+    }
+    return HeightMap.of(result);
+  }
+  decomposeLeft(to, result) {
+    let left = this.left.length;
+    if (to <= left)
+      return this.left.decomposeLeft(to, result);
+    result.push(this.left);
+    if (this.break) {
+      left++;
+      if (to >= left)
+        result.push(null);
+    }
+    if (to > left)
+      this.right.decomposeLeft(to - left, result);
+  }
+  decomposeRight(from, result) {
+    let left = this.left.length, right = left + this.break;
+    if (from >= right)
+      return this.right.decomposeRight(from - right, result);
+    if (from < left)
+      this.left.decomposeRight(from, result);
+    if (this.break && from < right)
+      result.push(null);
+    result.push(this.right);
+  }
+  balanced(left, right) {
+    if (left.size > 2 * right.size || right.size > 2 * left.size)
+      return HeightMap.of(this.break ? [left, null, right] : [left, right]);
+    this.left = replace(this.left, left);
+    this.right = replace(this.right, right);
+    this.setHeight(left.height + right.height);
+    this.outdated = left.outdated || right.outdated;
+    this.size = left.size + right.size;
+    this.length = left.length + this.break + right.length;
+    return this;
+  }
+  updateHeight(oracle, offset = 0, force = false, measured) {
+    let { left, right } = this, rightStart = offset + left.length + this.break, rebalance = null;
+    if (measured && measured.from <= offset + left.length && measured.more)
+      rebalance = left = left.updateHeight(oracle, offset, force, measured);
+    else
+      left.updateHeight(oracle, offset, force);
+    if (measured && measured.from <= rightStart + right.length && measured.more)
+      rebalance = right = right.updateHeight(oracle, rightStart, force, measured);
+    else
+      right.updateHeight(oracle, rightStart, force);
+    if (rebalance)
+      return this.balanced(left, right);
+    this.height = this.left.height + this.right.height;
+    this.outdated = false;
+    return this;
+  }
+  toString() {
+    return this.left + (this.break ? " " : "-") + this.right;
+  }
+};
+function mergeGaps(nodes, around) {
+  let before, after;
+  if (nodes[around] == null && (before = nodes[around - 1]) instanceof HeightMapGap && (after = nodes[around + 1]) instanceof HeightMapGap)
+    nodes.splice(around - 1, 3, new HeightMapGap(before.length + 1 + after.length));
+}
+var relevantWidgetHeight = 5;
+var NodeBuilder = class _NodeBuilder {
+  constructor(pos, oracle) {
+    this.pos = pos;
+    this.oracle = oracle;
+    this.nodes = [];
+    this.lineStart = -1;
+    this.lineEnd = -1;
+    this.covering = null;
+    this.writtenTo = pos;
+  }
+  get isCovered() {
+    return this.covering && this.nodes[this.nodes.length - 1] == this.covering;
+  }
+  span(_from, to) {
+    if (this.lineStart > -1) {
+      let end = Math.min(to, this.lineEnd), last = this.nodes[this.nodes.length - 1];
+      if (last instanceof HeightMapText)
+        last.length += end - this.pos;
+      else if (end > this.pos || !this.isCovered)
+        this.nodes.push(new HeightMapText(end - this.pos, -1, 0));
+      this.writtenTo = end;
+      if (to > end) {
+        this.nodes.push(null);
+        this.writtenTo++;
+        this.lineStart = -1;
+      }
+    }
+    this.pos = to;
+  }
+  point(from, to, deco) {
+    if (from < to || deco.heightRelevant) {
+      let height = deco.widget ? deco.widget.estimatedHeight : 0;
+      let breaks = deco.widget ? deco.widget.lineBreaks : 0;
+      if (height < 0)
+        height = this.oracle.lineHeight;
+      let len = to - from;
+      if (deco.block) {
+        this.addBlock(new HeightMapBlock(len, height, deco));
+      } else if (len || breaks || height >= relevantWidgetHeight) {
+        this.addLineDeco(height, breaks, len);
+      }
+    } else if (to > from) {
+      this.span(from, to);
+    }
+    if (this.lineEnd > -1 && this.lineEnd < this.pos)
+      this.lineEnd = this.oracle.doc.lineAt(this.pos).to;
+  }
+  enterLine() {
+    if (this.lineStart > -1)
+      return;
+    let { from, to } = this.oracle.doc.lineAt(this.pos);
+    this.lineStart = from;
+    this.lineEnd = to;
+    if (this.writtenTo < from) {
+      if (this.writtenTo < from - 1 || this.nodes[this.nodes.length - 1] == null)
+        this.nodes.push(this.blankContent(this.writtenTo, from - 1));
+      this.nodes.push(null);
+    }
+    if (this.pos > from)
+      this.nodes.push(new HeightMapText(this.pos - from, -1, 0));
+    this.writtenTo = this.pos;
+  }
+  blankContent(from, to) {
+    let gap = new HeightMapGap(to - from);
+    if (this.oracle.doc.lineAt(from).to == to)
+      gap.flags |= 4;
+    return gap;
+  }
+  ensureLine() {
+    this.enterLine();
+    let last = this.nodes.length ? this.nodes[this.nodes.length - 1] : null;
+    if (last instanceof HeightMapText)
+      return last;
+    let line = new HeightMapText(0, -1, 0);
+    this.nodes.push(line);
+    return line;
+  }
+  addBlock(block) {
+    this.enterLine();
+    let deco = block.deco;
+    if (deco && deco.startSide > 0 && !this.isCovered)
+      this.ensureLine();
+    this.nodes.push(block);
+    this.writtenTo = this.pos = this.pos + block.length;
+    if (deco && deco.endSide > 0)
+      this.covering = block;
+  }
+  addLineDeco(height, breaks, length) {
+    let line = this.ensureLine();
+    line.length += length;
+    line.collapsed += length;
+    line.widgetHeight = Math.max(line.widgetHeight, height);
+    line.breaks += breaks;
+    this.writtenTo = this.pos = this.pos + length;
+  }
+  finish(from) {
+    let last = this.nodes.length == 0 ? null : this.nodes[this.nodes.length - 1];
+    if (this.lineStart > -1 && !(last instanceof HeightMapText) && !this.isCovered)
+      this.nodes.push(new HeightMapText(0, -1, 0));
+    else if (this.writtenTo < this.pos || last == null)
+      this.nodes.push(this.blankContent(this.writtenTo, this.pos));
+    let pos = from;
+    for (let node of this.nodes) {
+      if (node instanceof HeightMapText)
+        node.updateHeight(this.oracle, pos);
+      pos += node ? node.length : 1;
+    }
+    return this.nodes;
+  }
+  // Always called with a region that on both sides either stretches
+  // to a line break or the end of the document.
+  // The returned array uses null to indicate line breaks, but never
+  // starts or ends in a line break, or has multiple line breaks next
+  // to each other.
+  static build(oracle, decorations2, from, to) {
+    let builder = new _NodeBuilder(from, oracle);
+    RangeSet.spans(decorations2, from, to, builder, 0);
+    return builder.finish(from);
+  }
+};
+function heightRelevantDecoChanges(a, b, diff) {
+  let comp = new DecorationComparator2();
+  RangeSet.compare(a, b, diff, comp, 0);
+  return comp.changes;
+}
+var DecorationComparator2 = class {
+  constructor() {
+    this.changes = [];
+  }
+  compareRange() {
+  }
+  comparePoint(from, to, a, b) {
+    if (from < to || a && a.heightRelevant || b && b.heightRelevant)
+      addRange(from, to, this.changes, 5);
+  }
+};
+function visiblePixelRange(dom, paddingTop) {
+  let rect = dom.getBoundingClientRect();
+  let doc2 = dom.ownerDocument, win = doc2.defaultView || window;
+  let left = Math.max(0, rect.left), right = Math.min(win.innerWidth, rect.right);
+  let top2 = Math.max(0, rect.top), bottom = Math.min(win.innerHeight, rect.bottom);
+  for (let parent = dom.parentNode; parent && parent != doc2.body; ) {
+    if (parent.nodeType == 1) {
+      let elt = parent;
+      let style = window.getComputedStyle(elt);
+      if ((elt.scrollHeight > elt.clientHeight || elt.scrollWidth > elt.clientWidth) && style.overflow != "visible") {
+        let parentRect = elt.getBoundingClientRect();
+        left = Math.max(left, parentRect.left);
+        right = Math.min(right, parentRect.right);
+        top2 = Math.max(top2, parentRect.top);
+        bottom = Math.min(parent == dom.parentNode ? win.innerHeight : bottom, parentRect.bottom);
+      }
+      parent = style.position == "absolute" || style.position == "fixed" ? elt.offsetParent : elt.parentNode;
+    } else if (parent.nodeType == 11) {
+      parent = parent.host;
+    } else {
+      break;
+    }
+  }
+  return {
+    left: left - rect.left,
+    right: Math.max(left, right) - rect.left,
+    top: top2 - (rect.top + paddingTop),
+    bottom: Math.max(top2, bottom) - (rect.top + paddingTop)
+  };
+}
+function inWindow(elt) {
+  let rect = elt.getBoundingClientRect(), win = elt.ownerDocument.defaultView || window;
+  return rect.left < win.innerWidth && rect.right > 0 && rect.top < win.innerHeight && rect.bottom > 0;
+}
+function fullPixelRange(dom, paddingTop) {
+  let rect = dom.getBoundingClientRect();
+  return {
+    left: 0,
+    right: rect.right - rect.left,
+    top: paddingTop,
+    bottom: rect.bottom - (rect.top + paddingTop)
+  };
+}
+var LineGap = class {
+  constructor(from, to, size, displaySize) {
+    this.from = from;
+    this.to = to;
+    this.size = size;
+    this.displaySize = displaySize;
+  }
+  static same(a, b) {
+    if (a.length != b.length)
+      return false;
+    for (let i2 = 0; i2 < a.length; i2++) {
+      let gA = a[i2], gB = b[i2];
+      if (gA.from != gB.from || gA.to != gB.to || gA.size != gB.size)
+        return false;
+    }
+    return true;
+  }
+  draw(viewState, wrapping) {
+    return Decoration.replace({
+      widget: new LineGapWidget(this.displaySize * (wrapping ? viewState.scaleY : viewState.scaleX), wrapping)
+    }).range(this.from, this.to);
+  }
+};
+var LineGapWidget = class extends WidgetType {
+  constructor(size, vertical) {
+    super();
+    this.size = size;
+    this.vertical = vertical;
+  }
+  eq(other) {
+    return other.size == this.size && other.vertical == this.vertical;
+  }
+  toDOM() {
+    let elt = document.createElement("div");
+    if (this.vertical) {
+      elt.style.height = this.size + "px";
+    } else {
+      elt.style.width = this.size + "px";
+      elt.style.height = "2px";
+      elt.style.display = "inline-block";
+    }
+    return elt;
+  }
+  get estimatedHeight() {
+    return this.vertical ? this.size : -1;
+  }
+};
+var ViewState = class {
+  constructor(view, state) {
+    this.view = view;
+    this.state = state;
+    this.pixelViewport = { left: 0, right: window.innerWidth, top: 0, bottom: 0 };
+    this.inView = true;
+    this.paddingTop = 0;
+    this.paddingBottom = 0;
+    this.contentDOMWidth = 0;
+    this.contentDOMHeight = 0;
+    this.editorHeight = 0;
+    this.editorWidth = 0;
+    this.scaleX = 1;
+    this.scaleY = 1;
+    this.scrollOffset = 0;
+    this.scrolledToBottom = false;
+    this.scrollAnchorPos = 0;
+    this.scrollAnchorHeight = -1;
+    this.scaler = IdScaler;
+    this.scrollTarget = null;
+    this.printing = false;
+    this.mustMeasureContent = true;
+    this.defaultTextDirection = Direction.LTR;
+    this.visibleRanges = [];
+    this.mustEnforceCursorAssoc = false;
+    let guessWrapping = state.facet(contentAttributes).some((v) => typeof v != "function" && v.class == "cm-lineWrapping");
+    this.heightOracle = new HeightOracle(guessWrapping);
+    this.stateDeco = staticDeco(state);
+    this.heightMap = HeightMap.empty().applyChanges(this.stateDeco, Text.empty, this.heightOracle.setDoc(state.doc), [new ChangedRange(0, 0, 0, state.doc.length)]);
+    for (let i2 = 0; i2 < 2; i2++) {
+      this.viewport = this.getViewport(0, null);
+      if (!this.updateForViewport())
+        break;
+    }
+    this.updateViewportLines();
+    this.lineGaps = this.ensureLineGaps([]);
+    this.lineGapDeco = Decoration.set(this.lineGaps.map((gap) => gap.draw(this, false)));
+    this.scrollParent = view.scrollDOM;
+    this.computeVisibleRanges();
+  }
+  updateForViewport() {
+    let viewports = [this.viewport], { main } = this.state.selection;
+    for (let i2 = 0; i2 <= 1; i2++) {
+      let pos = i2 ? main.head : main.anchor;
+      if (!viewports.some(({ from, to }) => pos >= from && pos <= to)) {
+        let { from, to } = this.lineBlockAt(pos);
+        viewports.push(new Viewport(from, to));
+      }
+    }
+    this.viewports = viewports.sort((a, b) => a.from - b.from);
+    return this.updateScaler();
+  }
+  updateScaler() {
+    let scaler = this.scaler;
+    this.scaler = this.heightMap.height <= 7e6 ? IdScaler : new BigScaler(this.heightOracle, this.heightMap, this.viewports);
+    return scaler.eq(this.scaler) ? 0 : 2;
+  }
+  updateViewportLines() {
+    this.viewportLines = [];
+    this.heightMap.forEachLine(this.viewport.from, this.viewport.to, this.heightOracle.setDoc(this.state.doc), 0, 0, (block) => {
+      this.viewportLines.push(scaleBlock(block, this.scaler));
+    });
+  }
+  update(update, scrollTarget = null) {
+    this.state = update.state;
+    let prevDeco = this.stateDeco;
+    this.stateDeco = staticDeco(this.state);
+    let contentChanges = update.changedRanges;
+    let heightChanges = ChangedRange.extendWithRanges(contentChanges, heightRelevantDecoChanges(prevDeco, this.stateDeco, update ? update.changes : ChangeSet.empty(this.state.doc.length)));
+    let prevHeight = this.heightMap.height;
+    let scrollAnchor = this.scrolledToBottom ? null : this.scrollAnchorAt(this.scrollOffset);
+    clearHeightChangeFlag();
+    this.heightMap = this.heightMap.applyChanges(this.stateDeco, update.startState.doc, this.heightOracle.setDoc(this.state.doc), heightChanges);
+    if (this.heightMap.height != prevHeight || heightChangeFlag)
+      update.flags |= 2;
+    if (scrollAnchor) {
+      this.scrollAnchorPos = update.changes.mapPos(scrollAnchor.from, -1);
+      this.scrollAnchorHeight = scrollAnchor.top;
+    } else {
+      this.scrollAnchorPos = -1;
+      this.scrollAnchorHeight = prevHeight;
+    }
+    let viewport = heightChanges.length ? this.mapViewport(this.viewport, update.changes) : this.viewport;
+    if (scrollTarget && (scrollTarget.range.head < viewport.from || scrollTarget.range.head > viewport.to) || !this.viewportIsAppropriate(viewport))
+      viewport = this.getViewport(0, scrollTarget);
+    let viewportChange = viewport.from != this.viewport.from || viewport.to != this.viewport.to;
+    this.viewport = viewport;
+    update.flags |= this.updateForViewport();
+    if (viewportChange || !update.changes.empty || update.flags & 2)
+      this.updateViewportLines();
+    if (this.lineGaps.length || this.viewport.to - this.viewport.from > 2e3 << 1)
+      this.updateLineGaps(this.ensureLineGaps(this.mapLineGaps(this.lineGaps, update.changes)));
+    update.flags |= this.computeVisibleRanges(update.changes);
+    if (scrollTarget)
+      this.scrollTarget = scrollTarget;
+    if (!this.mustEnforceCursorAssoc && (update.selectionSet || update.focusChanged) && update.view.lineWrapping && update.state.selection.main.empty && update.state.selection.main.assoc && !update.state.facet(nativeSelectionHidden))
+      this.mustEnforceCursorAssoc = true;
+  }
+  measure() {
+    let { view } = this, dom = view.contentDOM, style = window.getComputedStyle(dom);
+    let oracle = this.heightOracle;
+    let whiteSpace = style.whiteSpace;
+    this.defaultTextDirection = style.direction == "rtl" ? Direction.RTL : Direction.LTR;
+    let refresh = this.heightOracle.mustRefreshForWrapping(whiteSpace) || this.mustMeasureContent === "refresh";
+    let domRect = dom.getBoundingClientRect();
+    let measureContent = refresh || this.mustMeasureContent || this.contentDOMHeight != domRect.height;
+    this.contentDOMHeight = domRect.height;
+    this.mustMeasureContent = false;
+    let result = 0, bias = 0;
+    if (domRect.width && domRect.height) {
+      let { scaleX, scaleY } = getScale(dom, domRect);
+      if (scaleX > 5e-3 && Math.abs(this.scaleX - scaleX) > 5e-3 || scaleY > 5e-3 && Math.abs(this.scaleY - scaleY) > 5e-3) {
+        this.scaleX = scaleX;
+        this.scaleY = scaleY;
+        result |= 16;
+        refresh = measureContent = true;
+      }
+    }
+    let paddingTop = (parseInt(style.paddingTop) || 0) * this.scaleY;
+    let paddingBottom = (parseInt(style.paddingBottom) || 0) * this.scaleY;
+    if (this.paddingTop != paddingTop || this.paddingBottom != paddingBottom) {
+      this.paddingTop = paddingTop;
+      this.paddingBottom = paddingBottom;
+      result |= 16 | 2;
+    }
+    if (this.editorWidth != view.scrollDOM.clientWidth) {
+      if (oracle.lineWrapping)
+        measureContent = true;
+      this.editorWidth = view.scrollDOM.clientWidth;
+      result |= 16;
+    }
+    let scrollParent = scrollableParents(this.view.contentDOM, false).y;
+    if (scrollParent != this.scrollParent) {
+      this.scrollParent = scrollParent;
+      this.scrollAnchorHeight = -1;
+      this.scrollOffset = 0;
+    }
+    let scrollOffset = this.getScrollOffset();
+    if (this.scrollOffset != scrollOffset) {
+      this.scrollAnchorHeight = -1;
+      this.scrollOffset = scrollOffset;
+    }
+    this.scrolledToBottom = isScrolledToBottom(this.scrollParent || view.win);
+    let pixelViewport = (this.printing ? fullPixelRange : visiblePixelRange)(dom, this.paddingTop);
+    let dTop = pixelViewport.top - this.pixelViewport.top, dBottom = pixelViewport.bottom - this.pixelViewport.bottom;
+    this.pixelViewport = pixelViewport;
+    let inView = this.pixelViewport.bottom > this.pixelViewport.top && this.pixelViewport.right > this.pixelViewport.left;
+    if (inView != this.inView) {
+      this.inView = inView;
+      if (inView)
+        measureContent = true;
+    }
+    if (!this.inView && !this.scrollTarget && !inWindow(view.dom))
+      return 0;
+    let contentWidth = domRect.width;
+    if (this.contentDOMWidth != contentWidth || this.editorHeight != view.scrollDOM.clientHeight) {
+      this.contentDOMWidth = domRect.width;
+      this.editorHeight = view.scrollDOM.clientHeight;
+      result |= 16;
+    }
+    if (measureContent) {
+      let lineHeights = view.docView.measureVisibleLineHeights(this.viewport);
+      if (oracle.mustRefreshForHeights(lineHeights))
+        refresh = true;
+      if (refresh || oracle.lineWrapping && Math.abs(contentWidth - this.contentDOMWidth) > oracle.charWidth) {
+        let { lineHeight, charWidth, textHeight } = view.docView.measureTextSize();
+        refresh = lineHeight > 0 && oracle.refresh(whiteSpace, lineHeight, charWidth, textHeight, Math.max(5, contentWidth / charWidth), lineHeights);
+        if (refresh) {
+          view.docView.minWidth = 0;
+          result |= 16;
+        }
+      }
+      if (dTop > 0 && dBottom > 0)
+        bias = Math.max(dTop, dBottom);
+      else if (dTop < 0 && dBottom < 0)
+        bias = Math.min(dTop, dBottom);
+      clearHeightChangeFlag();
+      for (let vp of this.viewports) {
+        let heights = vp.from == this.viewport.from ? lineHeights : view.docView.measureVisibleLineHeights(vp);
+        this.heightMap = (refresh ? HeightMap.empty().applyChanges(this.stateDeco, Text.empty, this.heightOracle, [new ChangedRange(0, 0, 0, view.state.doc.length)]) : this.heightMap).updateHeight(oracle, 0, refresh, new MeasuredHeights(vp.from, heights));
+      }
+      if (heightChangeFlag)
+        result |= 2;
+    }
+    let viewportChange = !this.viewportIsAppropriate(this.viewport, bias) || this.scrollTarget && (this.scrollTarget.range.head < this.viewport.from || this.scrollTarget.range.head > this.viewport.to);
+    if (viewportChange) {
+      if (result & 2)
+        result |= this.updateScaler();
+      this.viewport = this.getViewport(bias, this.scrollTarget);
+      result |= this.updateForViewport();
+    }
+    if (result & 2 || viewportChange)
+      this.updateViewportLines();
+    if (this.lineGaps.length || this.viewport.to - this.viewport.from > 2e3 << 1)
+      this.updateLineGaps(this.ensureLineGaps(refresh ? [] : this.lineGaps, view));
+    result |= this.computeVisibleRanges();
+    if (this.mustEnforceCursorAssoc) {
+      this.mustEnforceCursorAssoc = false;
+      view.docView.enforceCursorAssoc();
+    }
+    return result;
+  }
+  get visibleTop() {
+    return this.scaler.fromDOM(this.pixelViewport.top);
+  }
+  get visibleBottom() {
+    return this.scaler.fromDOM(this.pixelViewport.bottom);
+  }
+  getViewport(bias, scrollTarget) {
+    let marginTop = 0.5 - Math.max(-0.5, Math.min(0.5, bias / 1e3 / 2));
+    let map = this.heightMap, oracle = this.heightOracle;
+    let { visibleTop, visibleBottom } = this;
+    let viewport = new Viewport(map.lineAt(visibleTop - marginTop * 1e3, QueryType.ByHeight, oracle, 0, 0).from, map.lineAt(visibleBottom + (1 - marginTop) * 1e3, QueryType.ByHeight, oracle, 0, 0).to);
+    if (scrollTarget) {
+      let { head } = scrollTarget.range;
+      if (head < viewport.from || head > viewport.to) {
+        let viewHeight = Math.min(this.editorHeight, this.pixelViewport.bottom - this.pixelViewport.top);
+        let block = map.lineAt(head, QueryType.ByPos, oracle, 0, 0), topPos;
+        if (scrollTarget.y == "center")
+          topPos = (block.top + block.bottom) / 2 - viewHeight / 2;
+        else if (scrollTarget.y == "start" || scrollTarget.y == "nearest" && head < viewport.from)
+          topPos = block.top;
+        else
+          topPos = block.bottom - viewHeight;
+        viewport = new Viewport(map.lineAt(topPos - 1e3 / 2, QueryType.ByHeight, oracle, 0, 0).from, map.lineAt(topPos + viewHeight + 1e3 / 2, QueryType.ByHeight, oracle, 0, 0).to);
+      }
+    }
+    return viewport;
+  }
+  mapViewport(viewport, changes) {
+    let from = changes.mapPos(viewport.from, -1), to = changes.mapPos(viewport.to, 1);
+    return new Viewport(this.heightMap.lineAt(from, QueryType.ByPos, this.heightOracle, 0, 0).from, this.heightMap.lineAt(to, QueryType.ByPos, this.heightOracle, 0, 0).to);
+  }
+  // Checks if a given viewport covers the visible part of the
+  // document and not too much beyond that.
+  viewportIsAppropriate({ from, to }, bias = 0) {
+    if (!this.inView)
+      return true;
+    let { top: top2 } = this.heightMap.lineAt(from, QueryType.ByPos, this.heightOracle, 0, 0);
+    let { bottom } = this.heightMap.lineAt(to, QueryType.ByPos, this.heightOracle, 0, 0);
+    let { visibleTop, visibleBottom } = this;
+    return (from == 0 || top2 <= visibleTop - Math.max(10, Math.min(
+      -bias,
+      250
+      /* VP.MaxCoverMargin */
+    ))) && (to == this.state.doc.length || bottom >= visibleBottom + Math.max(10, Math.min(
+      bias,
+      250
+      /* VP.MaxCoverMargin */
+    ))) && (top2 > visibleTop - 2 * 1e3 && bottom < visibleBottom + 2 * 1e3);
+  }
+  mapLineGaps(gaps, changes) {
+    if (!gaps.length || changes.empty)
+      return gaps;
+    let mapped = [];
+    for (let gap of gaps)
+      if (!changes.touchesRange(gap.from, gap.to))
+        mapped.push(new LineGap(changes.mapPos(gap.from), changes.mapPos(gap.to), gap.size, gap.displaySize));
+    return mapped;
+  }
+  // Computes positions in the viewport where the start or end of a
+  // line should be hidden, trying to reuse existing line gaps when
+  // appropriate to avoid unneccesary redraws.
+  // Uses crude character-counting for the positioning and sizing,
+  // since actual DOM coordinates aren't always available and
+  // predictable. Relies on generous margins (see LG.Margin) to hide
+  // the artifacts this might produce from the user.
+  ensureLineGaps(current, mayMeasure) {
+    let wrapping = this.heightOracle.lineWrapping;
+    let margin = wrapping ? 1e4 : 2e3, halfMargin = margin >> 1, doubleMargin = margin << 1;
+    if (this.defaultTextDirection != Direction.LTR && !wrapping)
+      return [];
+    let gaps = [];
+    let addGap = (from, to, line, structure) => {
+      if (to - from < halfMargin)
+        return;
+      let sel = this.state.selection.main, avoid = [sel.from];
+      if (!sel.empty)
+        avoid.push(sel.to);
+      for (let pos of avoid) {
+        if (pos > from && pos < to) {
+          addGap(from, pos - 10, line, structure);
+          addGap(pos + 10, to, line, structure);
+          return;
+        }
+      }
+      let gap = find(current, (gap2) => gap2.from >= line.from && gap2.to <= line.to && Math.abs(gap2.from - from) < halfMargin && Math.abs(gap2.to - to) < halfMargin && !avoid.some((pos) => gap2.from < pos && gap2.to > pos));
+      if (!gap) {
+        if (to < line.to && mayMeasure && wrapping && mayMeasure.visibleRanges.some((r2) => r2.from <= to && r2.to >= to)) {
+          let lineStart = mayMeasure.moveToLineBoundary(EditorSelection.cursor(to), false, true).head;
+          if (lineStart > from)
+            to = lineStart;
+        }
+        let size = this.gapSize(line, from, to, structure);
+        let displaySize = wrapping || size < 2e6 ? size : 2e6;
+        gap = new LineGap(from, to, size, displaySize);
+      }
+      gaps.push(gap);
+    };
+    let checkLine = (line) => {
+      if (line.length < doubleMargin || line.type != BlockType.Text)
+        return;
+      let structure = lineStructure(line.from, line.to, this.stateDeco);
+      if (structure.total < doubleMargin)
+        return;
+      let target = this.scrollTarget ? this.scrollTarget.range.head : null;
+      let viewFrom, viewTo;
+      if (wrapping) {
+        let marginHeight = margin / this.heightOracle.lineLength * this.heightOracle.lineHeight;
+        let top2, bot;
+        if (target != null) {
+          let targetFrac = findFraction(structure, target);
+          let spaceFrac = ((this.visibleBottom - this.visibleTop) / 2 + marginHeight) / line.height;
+          top2 = targetFrac - spaceFrac;
+          bot = targetFrac + spaceFrac;
+        } else {
+          top2 = (this.visibleTop - line.top - marginHeight) / line.height;
+          bot = (this.visibleBottom - line.top + marginHeight) / line.height;
+        }
+        viewFrom = findPosition(structure, top2);
+        viewTo = findPosition(structure, bot);
+      } else {
+        let totalWidth = structure.total * this.heightOracle.charWidth;
+        let marginWidth = margin * this.heightOracle.charWidth;
+        let horizOffset = 0;
+        if (totalWidth > 2e6)
+          for (let old of current) {
+            if (old.from >= line.from && old.from < line.to && old.size != old.displaySize && old.from * this.heightOracle.charWidth + horizOffset < this.pixelViewport.left)
+              horizOffset = old.size - old.displaySize;
+          }
+        let pxLeft = this.pixelViewport.left + horizOffset, pxRight = this.pixelViewport.right + horizOffset;
+        let left, right;
+        if (target != null) {
+          let targetFrac = findFraction(structure, target);
+          let spaceFrac = ((pxRight - pxLeft) / 2 + marginWidth) / totalWidth;
+          left = targetFrac - spaceFrac;
+          right = targetFrac + spaceFrac;
+        } else {
+          left = (pxLeft - marginWidth) / totalWidth;
+          right = (pxRight + marginWidth) / totalWidth;
+        }
+        viewFrom = findPosition(structure, left);
+        viewTo = findPosition(structure, right);
+      }
+      if (viewFrom > line.from)
+        addGap(line.from, viewFrom, line, structure);
+      if (viewTo < line.to)
+        addGap(viewTo, line.to, line, structure);
+    };
+    for (let line of this.viewportLines) {
+      if (Array.isArray(line.type))
+        line.type.forEach(checkLine);
+      else
+        checkLine(line);
+    }
+    return gaps;
+  }
+  gapSize(line, from, to, structure) {
+    let fraction = findFraction(structure, to) - findFraction(structure, from);
+    if (this.heightOracle.lineWrapping) {
+      return line.height * fraction;
+    } else {
+      return structure.total * this.heightOracle.charWidth * fraction;
+    }
+  }
+  updateLineGaps(gaps) {
+    if (!LineGap.same(gaps, this.lineGaps)) {
+      this.lineGaps = gaps;
+      this.lineGapDeco = Decoration.set(gaps.map((gap) => gap.draw(this, this.heightOracle.lineWrapping)));
+    }
+  }
+  computeVisibleRanges(changes) {
+    let deco = this.stateDeco;
+    if (this.lineGaps.length)
+      deco = deco.concat(this.lineGapDeco);
+    let ranges = [];
+    RangeSet.spans(deco, this.viewport.from, this.viewport.to, {
+      span(from, to) {
+        ranges.push({ from, to });
+      },
+      point() {
+      }
+    }, 20);
+    let changed = 0;
+    if (ranges.length != this.visibleRanges.length) {
+      changed = 8 | 4;
+    } else {
+      for (let i2 = 0; i2 < ranges.length && !(changed & 8); i2++) {
+        let old = this.visibleRanges[i2], nw = ranges[i2];
+        if (old.from != nw.from || old.to != nw.to) {
+          changed |= 4;
+          if (!(changes && changes.mapPos(old.from, -1) == nw.from && changes.mapPos(old.to, 1) == nw.to))
+            changed |= 8;
+        }
+      }
+    }
+    this.visibleRanges = ranges;
+    return changed;
+  }
+  lineBlockAt(pos) {
+    return pos >= this.viewport.from && pos <= this.viewport.to && this.viewportLines.find((b) => b.from <= pos && b.to >= pos) || scaleBlock(this.heightMap.lineAt(pos, QueryType.ByPos, this.heightOracle, 0, 0), this.scaler);
+  }
+  lineBlockAtHeight(height) {
+    return height >= this.viewportLines[0].top && height <= this.viewportLines[this.viewportLines.length - 1].bottom && this.viewportLines.find((l) => l.top <= height && l.bottom >= height) || scaleBlock(this.heightMap.lineAt(this.scaler.fromDOM(height), QueryType.ByHeight, this.heightOracle, 0, 0), this.scaler);
+  }
+  getScrollOffset() {
+    let base2 = this.scrollParent == this.view.scrollDOM ? this.scrollParent.scrollTop : (this.scrollParent ? this.scrollParent.getBoundingClientRect().top : 0) - this.view.contentDOM.getBoundingClientRect().top;
+    return base2 * this.scaleY;
+  }
+  scrollAnchorAt(scrollOffset) {
+    let block = this.lineBlockAtHeight(scrollOffset + 8);
+    return block.from >= this.viewport.from || this.viewportLines[0].top - scrollOffset > 200 ? block : this.viewportLines[0];
+  }
+  elementAtHeight(height) {
+    return scaleBlock(this.heightMap.blockAt(this.scaler.fromDOM(height), this.heightOracle, 0, 0), this.scaler);
+  }
+  get docHeight() {
+    return this.scaler.toDOM(this.heightMap.height);
+  }
+  get contentHeight() {
+    return this.docHeight + this.paddingTop + this.paddingBottom;
+  }
+};
+var Viewport = class {
+  constructor(from, to) {
+    this.from = from;
+    this.to = to;
+  }
+};
+function lineStructure(from, to, stateDeco) {
+  let ranges = [], pos = from, total = 0;
+  RangeSet.spans(stateDeco, from, to, {
+    span() {
+    },
+    point(from2, to2) {
+      if (from2 > pos) {
+        ranges.push({ from: pos, to: from2 });
+        total += from2 - pos;
+      }
+      pos = to2;
+    }
+  }, 20);
+  if (pos < to) {
+    ranges.push({ from: pos, to });
+    total += to - pos;
+  }
+  return { total, ranges };
+}
+function findPosition({ total, ranges }, ratio) {
+  if (ratio <= 0)
+    return ranges[0].from;
+  if (ratio >= 1)
+    return ranges[ranges.length - 1].to;
+  let dist2 = Math.floor(total * ratio);
+  for (let i2 = 0; ; i2++) {
+    let { from, to } = ranges[i2], size = to - from;
+    if (dist2 <= size)
+      return from + dist2;
+    dist2 -= size;
+  }
+}
+function findFraction(structure, pos) {
+  let counted = 0;
+  for (let { from, to } of structure.ranges) {
+    if (pos <= to) {
+      counted += pos - from;
+      break;
+    }
+    counted += to - from;
+  }
+  return counted / structure.total;
+}
+function find(array, f) {
+  for (let val of array)
+    if (f(val))
+      return val;
+  return void 0;
+}
+var IdScaler = {
+  toDOM(n) {
+    return n;
+  },
+  fromDOM(n) {
+    return n;
+  },
+  scale: 1,
+  eq(other) {
+    return other == this;
+  }
+};
+function staticDeco(state) {
+  let deco = state.facet(decorations).filter((d) => typeof d != "function");
+  let outer = state.facet(outerDecorations).filter((d) => typeof d != "function");
+  if (outer.length)
+    deco.push(RangeSet.join(outer));
+  return deco;
+}
+var BigScaler = class _BigScaler {
+  constructor(oracle, heightMap, viewports) {
+    let vpHeight = 0, base2 = 0, domBase = 0;
+    this.viewports = viewports.map(({ from, to }) => {
+      let top2 = heightMap.lineAt(from, QueryType.ByPos, oracle, 0, 0).top;
+      let bottom = heightMap.lineAt(to, QueryType.ByPos, oracle, 0, 0).bottom;
+      vpHeight += bottom - top2;
+      return { from, to, top: top2, bottom, domTop: 0, domBottom: 0 };
+    });
+    this.scale = (7e6 - vpHeight) / (heightMap.height - vpHeight);
+    for (let obj of this.viewports) {
+      obj.domTop = domBase + (obj.top - base2) * this.scale;
+      domBase = obj.domBottom = obj.domTop + (obj.bottom - obj.top);
+      base2 = obj.bottom;
+    }
+  }
+  toDOM(n) {
+    for (let i2 = 0, base2 = 0, domBase = 0; ; i2++) {
+      let vp = i2 < this.viewports.length ? this.viewports[i2] : null;
+      if (!vp || n < vp.top)
+        return domBase + (n - base2) * this.scale;
+      if (n <= vp.bottom)
+        return vp.domTop + (n - vp.top);
+      base2 = vp.bottom;
+      domBase = vp.domBottom;
+    }
+  }
+  fromDOM(n) {
+    for (let i2 = 0, base2 = 0, domBase = 0; ; i2++) {
+      let vp = i2 < this.viewports.length ? this.viewports[i2] : null;
+      if (!vp || n < vp.domTop)
+        return base2 + (n - domBase) / this.scale;
+      if (n <= vp.domBottom)
+        return vp.top + (n - vp.domTop);
+      base2 = vp.bottom;
+      domBase = vp.domBottom;
+    }
+  }
+  eq(other) {
+    if (!(other instanceof _BigScaler))
+      return false;
+    return this.scale == other.scale && this.viewports.length == other.viewports.length && this.viewports.every((vp, i2) => vp.from == other.viewports[i2].from && vp.to == other.viewports[i2].to);
+  }
+};
+function scaleBlock(block, scaler) {
+  if (scaler.scale == 1)
+    return block;
+  let bTop = scaler.toDOM(block.top), bBottom = scaler.toDOM(block.bottom);
+  return new BlockInfo(block.from, block.length, bTop, bBottom - bTop, Array.isArray(block._content) ? block._content.map((b) => scaleBlock(b, scaler)) : block._content);
+}
+var theme = /* @__PURE__ */ Facet.define({ combine: (strs) => strs.join(" ") });
+var darkTheme = /* @__PURE__ */ Facet.define({ combine: (values) => values.indexOf(true) > -1 });
+var baseThemeID = /* @__PURE__ */ StyleModule.newName();
+var baseLightID = /* @__PURE__ */ StyleModule.newName();
+var baseDarkID = /* @__PURE__ */ StyleModule.newName();
+var lightDarkIDs = { "&light": "." + baseLightID, "&dark": "." + baseDarkID };
+function buildTheme(main, spec, scopes) {
+  return new StyleModule(spec, {
+    finish(sel) {
+      return /&/.test(sel) ? sel.replace(/&\w*/, (m) => {
+        if (m == "&")
+          return main;
+        if (!scopes || !scopes[m])
+          throw new RangeError(`Unsupported selector: ${m}`);
+        return scopes[m];
+      }) : main + " " + sel;
+    }
+  });
+}
+var baseTheme$1 = /* @__PURE__ */ buildTheme("." + baseThemeID, {
+  "&": {
+    position: "relative !important",
+    boxSizing: "border-box",
+    "&.cm-focused": {
+      // Provide a simple default outline to make sure a focused
+      // editor is visually distinct. Can't leave the default behavior
+      // because that will apply to the content element, which is
+      // inside the scrollable container and doesn't include the
+      // gutters. We also can't use an 'auto' outline, since those
+      // are, for some reason, drawn behind the element content, which
+      // will cause things like the active line background to cover
+      // the outline (#297).
+      outline: "1px dotted #212121"
+    },
+    display: "flex !important",
+    flexDirection: "column"
+  },
+  ".cm-scroller": {
+    display: "flex !important",
+    alignItems: "flex-start !important",
+    fontFamily: "monospace",
+    lineHeight: 1.4,
+    height: "100%",
+    overflowX: "auto",
+    position: "relative",
+    zIndex: 0,
+    overflowAnchor: "none"
+  },
+  ".cm-content": {
+    margin: 0,
+    flexGrow: 2,
+    flexShrink: 0,
+    display: "block",
+    whiteSpace: "pre",
+    wordWrap: "normal",
+    // Issue #456
+    boxSizing: "border-box",
+    minHeight: "100%",
+    padding: "4px 0",
+    outline: "none",
+    "&[contenteditable=true]": {
+      WebkitUserModify: "read-write-plaintext-only"
+    }
+  },
+  ".cm-lineWrapping": {
+    whiteSpace_fallback: "pre-wrap",
+    // For IE
+    whiteSpace: "break-spaces",
+    wordBreak: "break-word",
+    // For Safari, which doesn't support overflow-wrap: anywhere
+    overflowWrap: "anywhere",
+    flexShrink: 1
+  },
+  "&light .cm-content": { caretColor: "black" },
+  "&dark .cm-content": { caretColor: "white" },
+  ".cm-line": {
+    display: "block",
+    padding: "0 2px 0 6px"
+  },
+  ".cm-layer": {
+    userSelect: "none",
+    // #1708
+    position: "absolute",
+    left: 0,
+    top: 0,
+    contain: "size style",
+    "& > *": {
+      position: "absolute"
+    }
+  },
+  "&light .cm-selectionBackground": {
+    background: "#d9d9d9"
+  },
+  "&dark .cm-selectionBackground": {
+    background: "#222"
+  },
+  "&light.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground": {
+    background: "#d7d4f0"
+  },
+  "&dark.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground": {
+    background: "#233"
+  },
+  ".cm-cursorLayer": {
+    pointerEvents: "none"
+  },
+  "&.cm-focused > .cm-scroller > .cm-cursorLayer": {
+    animation: "steps(1) cm-blink 1.2s infinite"
+  },
+  // Two animations defined so that we can switch between them to
+  // restart the animation without forcing another style
+  // recomputation.
+  "@keyframes cm-blink": { "0%": {}, "50%": { opacity: 0 }, "100%": {} },
+  "@keyframes cm-blink2": { "0%": {}, "50%": { opacity: 0 }, "100%": {} },
+  ".cm-cursor, .cm-dropCursor": {
+    borderLeft: "1.2px solid black",
+    marginLeft: "-0.6px",
+    pointerEvents: "none"
+  },
+  ".cm-cursor": {
+    display: "none"
+  },
+  "&dark .cm-cursor": {
+    borderLeftColor: "#ddd"
+  },
+  ".cm-selectionHandle": {
+    backgroundColor: "currentColor",
+    width: "1.5px"
+  },
+  ".cm-selectionHandle-start::before, .cm-selectionHandle-end::before": {
+    content: '""',
+    backgroundColor: "inherit",
+    borderRadius: "50%",
+    width: "8px",
+    height: "8px",
+    position: "absolute",
+    left: "-3.25px"
+  },
+  ".cm-selectionHandle-start::before": { top: "-8px" },
+  ".cm-selectionHandle-end::before": { bottom: "-8px" },
+  ".cm-dropCursor": {
+    position: "absolute"
+  },
+  "&.cm-focused > .cm-scroller > .cm-cursorLayer .cm-cursor": {
+    display: "block"
+  },
+  ".cm-iso": {
+    unicodeBidi: "isolate"
+  },
+  ".cm-announced": {
+    position: "fixed",
+    top: "-10000px"
+  },
+  "@media print": {
+    ".cm-announced": { display: "none" }
+  },
+  "&light .cm-activeLine": { backgroundColor: "#cceeff44" },
+  "&dark .cm-activeLine": { backgroundColor: "#99eeff33" },
+  "&light .cm-specialChar": { color: "red" },
+  "&dark .cm-specialChar": { color: "#f78" },
+  ".cm-gutters": {
+    flexShrink: 0,
+    display: "flex",
+    height: "100%",
+    boxSizing: "border-box",
+    zIndex: 200
+  },
+  ".cm-gutters-before": { insetInlineStart: 0 },
+  ".cm-gutters-after": { insetInlineEnd: 0 },
+  "&light .cm-gutters": {
+    backgroundColor: "#f5f5f5",
+    color: "#6c6c6c",
+    border: "0px solid #ddd",
+    "&.cm-gutters-before": { borderRightWidth: "1px" },
+    "&.cm-gutters-after": { borderLeftWidth: "1px" }
+  },
+  "&dark .cm-gutters": {
+    backgroundColor: "#333338",
+    color: "#ccc"
+  },
+  ".cm-gutter": {
+    display: "flex !important",
+    // Necessary -- prevents margin collapsing
+    flexDirection: "column",
+    flexShrink: 0,
+    boxSizing: "border-box",
+    minHeight: "100%",
+    overflow: "hidden"
+  },
+  ".cm-gutterElement": {
+    boxSizing: "border-box"
+  },
+  ".cm-lineNumbers .cm-gutterElement": {
+    padding: "0 3px 0 5px",
+    minWidth: "20px",
+    textAlign: "right",
+    whiteSpace: "nowrap"
+  },
+  "&light .cm-activeLineGutter": {
+    backgroundColor: "#e2f2ff"
+  },
+  "&dark .cm-activeLineGutter": {
+    backgroundColor: "#222227"
+  },
+  ".cm-panels": {
+    boxSizing: "border-box",
+    position: "sticky",
+    left: 0,
+    right: 0,
+    zIndex: 300
+  },
+  "&light .cm-panels": {
+    backgroundColor: "#f5f5f5",
+    color: "black"
+  },
+  "&light .cm-panels-top": {
+    borderBottom: "1px solid #ddd"
+  },
+  "&light .cm-panels-bottom": {
+    borderTop: "1px solid #ddd"
+  },
+  "&dark .cm-panels": {
+    backgroundColor: "#333338",
+    color: "white"
+  },
+  ".cm-dialog": {
+    padding: "2px 19px 4px 6px",
+    position: "relative",
+    "& label": { fontSize: "80%" }
+  },
+  ".cm-dialog-close": {
+    position: "absolute",
+    top: "3px",
+    right: "4px",
+    backgroundColor: "inherit",
+    border: "none",
+    font: "inherit",
+    fontSize: "14px",
+    padding: "0"
+  },
+  ".cm-tab": {
+    display: "inline-block",
+    overflow: "hidden",
+    verticalAlign: "bottom"
+  },
+  ".cm-widgetBuffer": {
+    verticalAlign: "text-top",
+    height: "1em",
+    width: 0,
+    display: "inline"
+  },
+  ".cm-placeholder": {
+    color: "#888",
+    display: "inline-block",
+    verticalAlign: "top",
+    userSelect: "none"
+  },
+  ".cm-highlightSpace": {
+    backgroundImage: "radial-gradient(circle at 50% 55%, #aaa 20%, transparent 5%)",
+    backgroundPosition: "center"
+  },
+  ".cm-highlightTab": {
+    backgroundImage: `url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="200" height="20"><path stroke="%23888" stroke-width="1" fill="none" d="M1 10H196L190 5M190 15L196 10M197 4L197 16"/></svg>')`,
+    backgroundSize: "auto 100%",
+    backgroundPosition: "right 90%",
+    backgroundRepeat: "no-repeat"
+  },
+  ".cm-trailingSpace": {
+    backgroundColor: "#ff332255"
+  },
+  ".cm-button": {
+    verticalAlign: "middle",
+    color: "inherit",
+    fontSize: "70%",
+    padding: ".2em 1em",
+    borderRadius: "1px"
+  },
+  "&light .cm-button": {
+    backgroundImage: "linear-gradient(#eff1f5, #d9d9df)",
+    border: "1px solid #888",
+    "&:active": {
+      backgroundImage: "linear-gradient(#b4b4b4, #d0d3d6)"
+    }
+  },
+  "&dark .cm-button": {
+    backgroundImage: "linear-gradient(#393939, #111)",
+    border: "1px solid #888",
+    "&:active": {
+      backgroundImage: "linear-gradient(#111, #333)"
+    }
+  },
+  ".cm-textfield": {
+    verticalAlign: "middle",
+    color: "inherit",
+    fontSize: "70%",
+    border: "1px solid silver",
+    padding: ".2em .5em"
+  },
+  "&light .cm-textfield": {
+    backgroundColor: "white"
+  },
+  "&dark .cm-textfield": {
+    border: "1px solid #555",
+    backgroundColor: "inherit"
+  }
+}, lightDarkIDs);
+var observeOptions = {
+  childList: true,
+  characterData: true,
+  subtree: true,
+  attributes: true,
+  characterDataOldValue: true
+};
+var useCharData = browser.ie && browser.ie_version <= 11;
+var DOMObserver = class {
+  constructor(view) {
+    this.view = view;
+    this.active = false;
+    this.editContext = null;
+    this.selectionRange = new DOMSelectionState();
+    this.selectionChanged = false;
+    this.delayedFlush = -1;
+    this.resizeTimeout = -1;
+    this.queue = [];
+    this.delayedAndroidKey = null;
+    this.flushingAndroidKey = -1;
+    this.lastChange = 0;
+    this.scrollTargets = [];
+    this.intersection = null;
+    this.resizeScroll = null;
+    this.intersecting = false;
+    this.gapIntersection = null;
+    this.gaps = [];
+    this.printQuery = null;
+    this.parentCheck = -1;
+    this.dom = view.contentDOM;
+    this.observer = new MutationObserver((mutations) => {
+      for (let mut of mutations)
+        this.queue.push(mut);
+      if ((browser.ie && browser.ie_version <= 11 || browser.ios && view.composing) && mutations.some((m) => m.type == "childList" && m.removedNodes.length || m.type == "characterData" && m.oldValue.length > m.target.nodeValue.length))
+        this.flushSoon();
+      else
+        this.flush();
+    });
+    if (window.EditContext && browser.android && view.constructor.EDIT_CONTEXT !== false && // Chrome <126 doesn't support inverted selections in edit context (#1392)
+    !(browser.chrome && browser.chrome_version < 126)) {
+      this.editContext = new EditContextManager(view);
+      if (view.state.facet(editable))
+        view.contentDOM.editContext = this.editContext.editContext;
+    }
+    if (useCharData)
+      this.onCharData = (event) => {
+        this.queue.push({
+          target: event.target,
+          type: "characterData",
+          oldValue: event.prevValue
+        });
+        this.flushSoon();
+      };
+    this.onSelectionChange = this.onSelectionChange.bind(this);
+    this.onResize = this.onResize.bind(this);
+    this.onPrint = this.onPrint.bind(this);
+    this.onScroll = this.onScroll.bind(this);
+    if (window.matchMedia)
+      this.printQuery = window.matchMedia("print");
+    if (typeof ResizeObserver == "function") {
+      this.resizeScroll = new ResizeObserver(() => {
+        var _a2;
+        if (((_a2 = this.view.docView) === null || _a2 === void 0 ? void 0 : _a2.lastUpdate) < Date.now() - 75)
+          this.onResize();
+      });
+      this.resizeScroll.observe(view.scrollDOM);
+    }
+    this.addWindowListeners(this.win = view.win);
+    this.start();
+    if (typeof IntersectionObserver == "function") {
+      this.intersection = new IntersectionObserver((entries) => {
+        if (this.parentCheck < 0)
+          this.parentCheck = setTimeout(this.listenForScroll.bind(this), 1e3);
+        if (entries.length > 0 && entries[entries.length - 1].intersectionRatio > 0 != this.intersecting) {
+          this.intersecting = !this.intersecting;
+          if (this.intersecting != this.view.inView)
+            this.onScrollChanged(document.createEvent("Event"));
+        }
+      }, { threshold: [0, 1e-3] });
+      this.intersection.observe(this.dom);
+      this.gapIntersection = new IntersectionObserver((entries) => {
+        if (entries.length > 0 && entries[entries.length - 1].intersectionRatio > 0)
+          this.onScrollChanged(document.createEvent("Event"));
+      }, {});
+    }
+    this.listenForScroll();
+    this.readSelectionRange();
+  }
+  onScrollChanged(e) {
+    this.view.inputState.runHandlers("scroll", e);
+    if (this.intersecting)
+      this.view.measure();
+  }
+  onScroll(e) {
+    if (this.intersecting)
+      this.flush(false);
+    if (this.editContext)
+      this.view.requestMeasure(this.editContext.measureReq);
+    this.onScrollChanged(e);
+  }
+  onResize() {
+    if (this.resizeTimeout < 0)
+      this.resizeTimeout = setTimeout(() => {
+        this.resizeTimeout = -1;
+        this.view.requestMeasure();
+      }, 50);
+  }
+  onPrint(event) {
+    if ((event.type == "change" || !event.type) && !event.matches)
+      return;
+    this.view.viewState.printing = true;
+    this.view.measure();
+    setTimeout(() => {
+      this.view.viewState.printing = false;
+      this.view.requestMeasure();
+    }, 500);
+  }
+  updateGaps(gaps) {
+    if (this.gapIntersection && (gaps.length != this.gaps.length || this.gaps.some((g, i2) => g != gaps[i2]))) {
+      this.gapIntersection.disconnect();
+      for (let gap of gaps)
+        this.gapIntersection.observe(gap);
+      this.gaps = gaps;
+    }
+  }
+  onSelectionChange(event) {
+    let wasChanged = this.selectionChanged;
+    if (!this.readSelectionRange() || this.delayedAndroidKey)
+      return;
+    let { view } = this, sel = this.selectionRange;
+    if (view.state.facet(editable) ? view.root.activeElement != this.dom : !hasSelection(this.dom, sel))
+      return;
+    let context = sel.anchorNode && view.docView.tile.nearest(sel.anchorNode);
+    if (context && context.isWidget() && context.widget.ignoreEvent(event)) {
+      if (!wasChanged)
+        this.selectionChanged = false;
+      return;
+    }
+    if ((browser.ie && browser.ie_version <= 11 || browser.android && browser.chrome) && !view.state.selection.main.empty && // (Selection.isCollapsed isn't reliable on IE)
+    sel.focusNode && isEquivalentPosition(sel.focusNode, sel.focusOffset, sel.anchorNode, sel.anchorOffset))
+      this.flushSoon();
+    else
+      this.flush(false);
+  }
+  readSelectionRange() {
+    let { view } = this;
+    let selection = getSelection(view.root);
+    if (!selection)
+      return false;
+    let range = browser.safari && view.root.nodeType == 11 && view.root.activeElement == this.dom && safariSelectionRangeHack(this.view, selection) || selection;
+    if (!range || this.selectionRange.eq(range))
+      return false;
+    let local = hasSelection(this.dom, range);
+    if (local && !this.selectionChanged && view.inputState.lastFocusTime > Date.now() - 200 && view.inputState.lastTouchTime < Date.now() - 300 && atElementStart(this.dom, range)) {
+      this.view.inputState.lastFocusTime = 0;
+      view.docView.updateSelection();
+      return false;
+    }
+    this.selectionRange.setRange(range);
+    if (local)
+      this.selectionChanged = true;
+    return true;
+  }
+  setSelectionRange(anchor, head) {
+    this.selectionRange.set(anchor.node, anchor.offset, head.node, head.offset);
+    this.selectionChanged = false;
+  }
+  clearSelectionRange() {
+    this.selectionRange.set(null, 0, null, 0);
+  }
+  listenForScroll() {
+    this.parentCheck = -1;
+    let i2 = 0, changed = null;
+    for (let dom = this.dom; dom; ) {
+      if (dom.nodeType == 1) {
+        if (!changed && i2 < this.scrollTargets.length && this.scrollTargets[i2] == dom)
+          i2++;
+        else if (!changed)
+          changed = this.scrollTargets.slice(0, i2);
+        if (changed)
+          changed.push(dom);
+        dom = dom.assignedSlot || dom.parentNode;
+      } else if (dom.nodeType == 11) {
+        dom = dom.host;
+      } else {
+        break;
+      }
+    }
+    if (i2 < this.scrollTargets.length && !changed)
+      changed = this.scrollTargets.slice(0, i2);
+    if (changed) {
+      for (let dom of this.scrollTargets)
+        dom.removeEventListener("scroll", this.onScroll);
+      for (let dom of this.scrollTargets = changed)
+        dom.addEventListener("scroll", this.onScroll);
+    }
+  }
+  ignore(f) {
+    if (!this.active)
+      return f();
+    try {
+      this.stop();
+      return f();
+    } finally {
+      this.start();
+      this.clear();
+    }
+  }
+  start() {
+    if (this.active)
+      return;
+    this.observer.observe(this.dom, observeOptions);
+    if (useCharData)
+      this.dom.addEventListener("DOMCharacterDataModified", this.onCharData);
+    this.active = true;
+  }
+  stop() {
+    if (!this.active)
+      return;
+    this.active = false;
+    this.observer.disconnect();
+    if (useCharData)
+      this.dom.removeEventListener("DOMCharacterDataModified", this.onCharData);
+  }
+  // Throw away any pending changes
+  clear() {
+    this.processRecords();
+    this.queue.length = 0;
+    this.selectionChanged = false;
+  }
+  // Chrome Android, especially in combination with GBoard, not only
+  // doesn't reliably fire regular key events, but also often
+  // surrounds the effect of enter or backspace with a bunch of
+  // composition events that, when interrupted, cause text duplication
+  // or other kinds of corruption. This hack makes the editor back off
+  // from handling DOM changes for a moment when such a key is
+  // detected (via beforeinput or keydown), and then tries to flush
+  // them or, if that has no effect, dispatches the given key.
+  delayAndroidKey(key, keyCode) {
+    var _a2;
+    if (!this.delayedAndroidKey) {
+      let flush = () => {
+        let key2 = this.delayedAndroidKey;
+        if (key2) {
+          this.clearDelayedAndroidKey();
+          this.view.inputState.lastKeyCode = key2.keyCode;
+          this.view.inputState.lastKeyTime = Date.now();
+          let flushed = this.flush();
+          if (!flushed && key2.force)
+            dispatchKey(this.dom, key2.key, key2.keyCode);
+        }
+      };
+      this.flushingAndroidKey = this.view.win.requestAnimationFrame(flush);
+    }
+    if (!this.delayedAndroidKey || key == "Enter")
+      this.delayedAndroidKey = {
+        key,
+        keyCode,
+        // Only run the key handler when no changes are detected if
+        // this isn't coming right after another change, in which case
+        // it is probably part of a weird chain of updates, and should
+        // be ignored if it returns the DOM to its previous state.
+        force: this.lastChange < Date.now() - 50 || !!((_a2 = this.delayedAndroidKey) === null || _a2 === void 0 ? void 0 : _a2.force)
+      };
+  }
+  clearDelayedAndroidKey() {
+    this.win.cancelAnimationFrame(this.flushingAndroidKey);
+    this.delayedAndroidKey = null;
+    this.flushingAndroidKey = -1;
+  }
+  flushSoon() {
+    if (this.delayedFlush < 0)
+      this.delayedFlush = this.view.win.requestAnimationFrame(() => {
+        this.delayedFlush = -1;
+        this.flush();
+      });
+  }
+  forceFlush() {
+    if (this.delayedFlush >= 0) {
+      this.view.win.cancelAnimationFrame(this.delayedFlush);
+      this.delayedFlush = -1;
+    }
+    this.flush();
+  }
+  pendingRecords() {
+    for (let mut of this.observer.takeRecords())
+      this.queue.push(mut);
+    return this.queue;
+  }
+  processRecords() {
+    let records = this.pendingRecords();
+    if (records.length)
+      this.queue = [];
+    let from = -1, to = -1, typeOver = false;
+    for (let record of records) {
+      let range = this.readMutation(record);
+      if (!range)
+        continue;
+      if (range.typeOver)
+        typeOver = true;
+      if (from == -1) {
+        ({ from, to } = range);
+      } else {
+        from = Math.min(range.from, from);
+        to = Math.max(range.to, to);
+      }
+    }
+    return { from, to, typeOver };
+  }
+  readChange() {
+    let { from, to, typeOver } = this.processRecords();
+    let newSel = this.selectionChanged && hasSelection(this.dom, this.selectionRange);
+    if (from < 0 && !newSel)
+      return null;
+    if (from > -1)
+      this.lastChange = Date.now();
+    this.view.inputState.lastFocusTime = 0;
+    this.selectionChanged = false;
+    let change = new DOMChange(this.view, from, to, typeOver);
+    this.view.docView.domChanged = { newSel: change.newSel ? change.newSel.main : null };
+    return change;
+  }
+  // Apply pending changes, if any
+  flush(readSelection = true) {
+    if (this.delayedFlush >= 0 || this.delayedAndroidKey)
+      return false;
+    if (readSelection)
+      this.readSelectionRange();
+    let domChange = this.readChange();
+    if (!domChange) {
+      this.view.requestMeasure();
+      return false;
+    }
+    let startState = this.view.state;
+    let handled = applyDOMChange(this.view, domChange);
+    if (this.view.state == startState && (domChange.domChanged || domChange.newSel && !sameSelPos(this.view.state.selection, domChange.newSel.main)))
+      this.view.update([]);
+    return handled;
+  }
+  readMutation(rec) {
+    let tile = this.view.docView.tile.nearest(rec.target);
+    if (!tile || tile.isWidget())
+      return null;
+    tile.markDirty(rec.type == "attributes");
+    if (rec.type == "childList") {
+      let childBefore = findChild(tile, rec.previousSibling || rec.target.previousSibling, -1);
+      let childAfter = findChild(tile, rec.nextSibling || rec.target.nextSibling, 1);
+      return {
+        from: childBefore ? tile.posAfter(childBefore) : tile.posAtStart,
+        to: childAfter ? tile.posBefore(childAfter) : tile.posAtEnd,
+        typeOver: false
+      };
+    } else if (rec.type == "characterData") {
+      return { from: tile.posAtStart, to: tile.posAtEnd, typeOver: rec.target.nodeValue == rec.oldValue };
+    } else {
+      return null;
+    }
+  }
+  setWindow(win) {
+    if (win != this.win) {
+      this.removeWindowListeners(this.win);
+      this.win = win;
+      this.addWindowListeners(this.win);
+    }
+  }
+  addWindowListeners(win) {
+    win.addEventListener("resize", this.onResize);
+    if (this.printQuery) {
+      if (this.printQuery.addEventListener)
+        this.printQuery.addEventListener("change", this.onPrint);
+      else
+        this.printQuery.addListener(this.onPrint);
+    } else
+      win.addEventListener("beforeprint", this.onPrint);
+    win.addEventListener("scroll", this.onScroll);
+    win.document.addEventListener("selectionchange", this.onSelectionChange);
+  }
+  removeWindowListeners(win) {
+    win.removeEventListener("scroll", this.onScroll);
+    win.removeEventListener("resize", this.onResize);
+    if (this.printQuery) {
+      if (this.printQuery.removeEventListener)
+        this.printQuery.removeEventListener("change", this.onPrint);
+      else
+        this.printQuery.removeListener(this.onPrint);
+    } else
+      win.removeEventListener("beforeprint", this.onPrint);
+    win.document.removeEventListener("selectionchange", this.onSelectionChange);
+  }
+  update(update) {
+    if (this.editContext) {
+      this.editContext.update(update);
+      if (update.startState.facet(editable) != update.state.facet(editable))
+        update.view.contentDOM.editContext = update.state.facet(editable) ? this.editContext.editContext : null;
+    }
+  }
+  destroy() {
+    var _a2, _b, _c;
+    this.stop();
+    (_a2 = this.intersection) === null || _a2 === void 0 ? void 0 : _a2.disconnect();
+    (_b = this.gapIntersection) === null || _b === void 0 ? void 0 : _b.disconnect();
+    (_c = this.resizeScroll) === null || _c === void 0 ? void 0 : _c.disconnect();
+    for (let dom of this.scrollTargets)
+      dom.removeEventListener("scroll", this.onScroll);
+    this.removeWindowListeners(this.win);
+    clearTimeout(this.parentCheck);
+    clearTimeout(this.resizeTimeout);
+    this.win.cancelAnimationFrame(this.delayedFlush);
+    this.win.cancelAnimationFrame(this.flushingAndroidKey);
+    if (this.editContext) {
+      this.view.contentDOM.editContext = null;
+      this.editContext.destroy();
+    }
+  }
+};
+function findChild(tile, dom, dir) {
+  while (dom) {
+    let curTile = Tile.get(dom);
+    if (curTile && curTile.parent == tile)
+      return curTile;
+    let parent = dom.parentNode;
+    dom = parent != tile.dom ? parent : dir > 0 ? dom.nextSibling : dom.previousSibling;
+  }
+  return null;
+}
+function buildSelectionRangeFromRange(view, range) {
+  let anchorNode = range.startContainer, anchorOffset = range.startOffset;
+  let focusNode = range.endContainer, focusOffset = range.endOffset;
+  let curAnchor = view.docView.domAtPos(view.state.selection.main.anchor, 1);
+  if (isEquivalentPosition(curAnchor.node, curAnchor.offset, focusNode, focusOffset))
+    [anchorNode, anchorOffset, focusNode, focusOffset] = [focusNode, focusOffset, anchorNode, anchorOffset];
+  return { anchorNode, anchorOffset, focusNode, focusOffset };
+}
+function safariSelectionRangeHack(view, selection) {
+  if (selection.getComposedRanges) {
+    let range = selection.getComposedRanges(view.root)[0];
+    if (range)
+      return buildSelectionRangeFromRange(view, range);
+  }
+  let found = null;
+  function read(event) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    found = event.getTargetRanges()[0];
+  }
+  view.contentDOM.addEventListener("beforeinput", read, true);
+  view.dom.ownerDocument.execCommand("indent");
+  view.contentDOM.removeEventListener("beforeinput", read, true);
+  return found ? buildSelectionRangeFromRange(view, found) : null;
+}
+var EditContextManager = class {
+  constructor(view) {
+    this.from = 0;
+    this.to = 0;
+    this.pendingContextChange = null;
+    this.handlers = /* @__PURE__ */ Object.create(null);
+    this.composing = null;
+    this.resetRange(view.state);
+    let context = this.editContext = new window.EditContext({
+      text: view.state.doc.sliceString(this.from, this.to),
+      selectionStart: this.toContextPos(Math.max(this.from, Math.min(this.to, view.state.selection.main.anchor))),
+      selectionEnd: this.toContextPos(view.state.selection.main.head)
+    });
+    this.handlers.textupdate = (e) => {
+      let main = view.state.selection.main, { anchor, head } = main;
+      let from = this.toEditorPos(e.updateRangeStart), to = this.toEditorPos(e.updateRangeEnd);
+      if (view.inputState.composing >= 0 && !this.composing)
+        this.composing = { contextBase: e.updateRangeStart, editorBase: from, drifted: false };
+      let deletes = to - from > e.text.length;
+      if (from == this.from && anchor < this.from)
+        from = anchor;
+      else if (to == this.to && anchor > this.to)
+        to = anchor;
+      let diff = findDiff(view.state.sliceDoc(from, to), e.text, (deletes ? main.from : main.to) - from, deletes ? "end" : null);
+      if (!diff) {
+        let newSel = EditorSelection.single(this.toEditorPos(e.selectionStart), this.toEditorPos(e.selectionEnd));
+        if (!sameSelPos(newSel, main))
+          view.dispatch({ selection: newSel, userEvent: "select" });
+        return;
+      }
+      let change = {
+        from: diff.from + from,
+        to: diff.toA + from,
+        insert: Text.of(e.text.slice(diff.from, diff.toB).split("\n"))
+      };
+      if ((browser.mac || browser.android) && change.from == head - 1 && /^\. ?$/.test(e.text) && view.contentDOM.getAttribute("autocorrect") == "off")
+        change = { from, to, insert: Text.of([e.text.replace(".", " ")]) };
+      this.pendingContextChange = change;
+      if (!view.state.readOnly) {
+        let newLen = this.to - this.from + (change.to - change.from + change.insert.length);
+        applyDOMChangeInner(view, change, EditorSelection.single(this.toEditorPos(e.selectionStart, newLen), this.toEditorPos(e.selectionEnd, newLen)));
+      }
+      if (this.pendingContextChange) {
+        this.revertPending(view.state);
+        this.setSelection(view.state);
+      }
+      if (change.from < change.to && !change.insert.length && view.inputState.composing >= 0 && !/[\\p{Alphabetic}\\p{Number}_]/.test(context.text.slice(Math.max(0, e.updateRangeStart - 1), Math.min(context.text.length, e.updateRangeStart + 1))))
+        this.handlers.compositionend(e);
+    };
+    this.handlers.characterboundsupdate = (e) => {
+      let rects = [], prev = null;
+      for (let i2 = this.toEditorPos(e.rangeStart), end = this.toEditorPos(e.rangeEnd); i2 < end; i2++) {
+        let rect = view.coordsForChar(i2);
+        prev = rect && new DOMRect(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top) || prev || new DOMRect();
+        rects.push(prev);
+      }
+      context.updateCharacterBounds(e.rangeStart, rects);
+    };
+    this.handlers.textformatupdate = (e) => {
+      let deco = [];
+      for (let format of e.getTextFormats()) {
+        let lineStyle = format.underlineStyle, thickness = format.underlineThickness;
+        if (!/none/i.test(lineStyle) && !/none/i.test(thickness)) {
+          let from = this.toEditorPos(format.rangeStart), to = this.toEditorPos(format.rangeEnd);
+          if (from < to) {
+            let style = `text-decoration: underline ${/^[a-z]/.test(lineStyle) ? lineStyle + " " : lineStyle == "Dashed" ? "dashed " : lineStyle == "Squiggle" ? "wavy " : ""}${/thin/i.test(thickness) ? 1 : 2}px`;
+            deco.push(Decoration.mark({ attributes: { style } }).range(from, to));
+          }
+        }
+      }
+      view.dispatch({ effects: setEditContextFormatting.of(Decoration.set(deco)) });
+    };
+    this.handlers.compositionstart = () => {
+      if (view.inputState.composing < 0) {
+        view.inputState.composing = 0;
+        view.inputState.compositionFirstChange = true;
+      }
+    };
+    this.handlers.compositionend = () => {
+      view.inputState.composing = -1;
+      view.inputState.compositionFirstChange = null;
+      if (this.composing) {
+        let { drifted } = this.composing;
+        this.composing = null;
+        if (drifted)
+          this.reset(view.state);
+      }
+    };
+    for (let event in this.handlers)
+      context.addEventListener(event, this.handlers[event]);
+    this.measureReq = { read: (view2) => {
+      let sel = getSelection(view2.root);
+      if (sel && sel.rangeCount)
+        this.editContext.updateSelectionBounds(sel.getRangeAt(0).getBoundingClientRect());
+    } };
+  }
+  applyEdits(update) {
+    let off = 0, abort = false, pending = this.pendingContextChange;
+    update.changes.iterChanges((fromA, toA, _fromB, _toB, insert2) => {
+      if (abort)
+        return;
+      let dLen = insert2.length - (toA - fromA);
+      if (pending && toA >= pending.to) {
+        if (pending.from == fromA && pending.to == toA && pending.insert.eq(insert2)) {
+          pending = this.pendingContextChange = null;
+          off += dLen;
+          this.to += dLen;
+          return;
+        } else {
+          pending = null;
+          this.revertPending(update.state);
+        }
+      }
+      fromA += off;
+      toA += off;
+      if (toA <= this.from) {
+        this.from += dLen;
+        this.to += dLen;
+      } else if (fromA < this.to) {
+        if (fromA < this.from || toA > this.to || this.to - this.from + insert2.length > 3e4) {
+          abort = true;
+          return;
+        }
+        this.editContext.updateText(this.toContextPos(fromA), this.toContextPos(toA), insert2.toString());
+        this.to += dLen;
+      }
+      off += dLen;
+    });
+    if (pending && !abort)
+      this.revertPending(update.state);
+    return !abort;
+  }
+  update(update) {
+    let reverted = this.pendingContextChange, startSel = update.startState.selection.main;
+    if (this.composing && (this.composing.drifted || !update.changes.touchesRange(startSel.from, startSel.to) && update.transactions.some((tr) => !tr.isUserEvent("input.type") && tr.changes.touchesRange(this.from, this.to)))) {
+      this.composing.drifted = true;
+      this.composing.editorBase = update.changes.mapPos(this.composing.editorBase);
+    } else if (!this.applyEdits(update) || !this.rangeIsValid(update.state)) {
+      this.pendingContextChange = null;
+      this.reset(update.state);
+    } else if (update.docChanged || update.selectionSet || reverted) {
+      this.setSelection(update.state);
+    }
+    if (update.geometryChanged || update.docChanged || update.selectionSet)
+      update.view.requestMeasure(this.measureReq);
+  }
+  resetRange(state) {
+    let { head } = state.selection.main;
+    this.from = Math.max(
+      0,
+      head - 1e4
+      /* CxVp.Margin */
+    );
+    this.to = Math.min(
+      state.doc.length,
+      head + 1e4
+      /* CxVp.Margin */
+    );
+  }
+  reset(state) {
+    this.resetRange(state);
+    this.editContext.updateText(0, this.editContext.text.length, state.doc.sliceString(this.from, this.to));
+    this.setSelection(state);
+  }
+  revertPending(state) {
+    let pending = this.pendingContextChange;
+    this.pendingContextChange = null;
+    this.editContext.updateText(this.toContextPos(pending.from), this.toContextPos(pending.from + pending.insert.length), state.doc.sliceString(pending.from, pending.to));
+  }
+  setSelection(state) {
+    let { main } = state.selection;
+    let start = this.toContextPos(Math.max(this.from, Math.min(this.to, main.anchor)));
+    let end = this.toContextPos(main.head);
+    if (this.editContext.selectionStart != start || this.editContext.selectionEnd != end)
+      this.editContext.updateSelection(start, end);
+  }
+  rangeIsValid(state) {
+    let { head } = state.selection.main;
+    return !(this.from > 0 && head - this.from < 500 || this.to < state.doc.length && this.to - head < 500 || this.to - this.from > 1e4 * 3);
+  }
+  toEditorPos(contextPos, clipLen = this.to - this.from) {
+    contextPos = Math.min(contextPos, clipLen);
+    let c = this.composing;
+    return c && c.drifted ? c.editorBase + (contextPos - c.contextBase) : contextPos + this.from;
+  }
+  toContextPos(editorPos) {
+    let c = this.composing;
+    return c && c.drifted ? c.contextBase + (editorPos - c.editorBase) : editorPos - this.from;
+  }
+  destroy() {
+    for (let event in this.handlers)
+      this.editContext.removeEventListener(event, this.handlers[event]);
+  }
+};
+var EditorView = class _EditorView {
+  /**
+  The current editor state.
+  */
+  get state() {
+    return this.viewState.state;
+  }
+  /**
+  To be able to display large documents without consuming too much
+  memory or overloading the browser, CodeMirror only draws the
+  code that is visible (plus a margin around it) to the DOM. This
+  property tells you the extent of the current drawn viewport, in
+  document positions.
+  */
+  get viewport() {
+    return this.viewState.viewport;
+  }
+  /**
+  When there are, for example, large collapsed ranges in the
+  viewport, its size can be a lot bigger than the actual visible
+  content. Thus, if you are doing something like styling the
+  content in the viewport, it is preferable to only do so for
+  these ranges, which are the subset of the viewport that is
+  actually drawn.
+  */
+  get visibleRanges() {
+    return this.viewState.visibleRanges;
+  }
+  /**
+  Returns false when the editor is entirely scrolled out of view
+  or otherwise hidden.
+  */
+  get inView() {
+    return this.viewState.inView;
+  }
+  /**
+  Indicates whether the user is currently composing text via
+  [IME](https://en.wikipedia.org/wiki/Input_method), and at least
+  one change has been made in the current composition.
+  */
+  get composing() {
+    return !!this.inputState && this.inputState.composing > 0;
+  }
+  /**
+  Indicates whether the user is currently in composing state. Note
+  that on some platforms, like Android, this will be the case a
+  lot, since just putting the cursor on a word starts a
+  composition there.
+  */
+  get compositionStarted() {
+    return !!this.inputState && this.inputState.composing >= 0;
+  }
+  /**
+  The document or shadow root that the view lives in.
+  */
+  get root() {
+    return this._root;
+  }
+  /**
+  @internal
+  */
+  get win() {
+    return this.dom.ownerDocument.defaultView || window;
+  }
+  /**
+  Construct a new view. You'll want to either provide a `parent`
+  option, or put `view.dom` into your document after creating a
+  view, so that the user can see the editor.
+  */
+  constructor(config = {}) {
+    var _a2;
+    this.plugins = [];
+    this.pluginMap = /* @__PURE__ */ new Map();
+    this.editorAttrs = {};
+    this.contentAttrs = {};
+    this.bidiCache = [];
+    this.destroyed = false;
+    this.updateState = 2;
+    this.measureScheduled = -1;
+    this.measureRequests = [];
+    this.contentDOM = document.createElement("div");
+    this.scrollDOM = document.createElement("div");
+    this.scrollDOM.tabIndex = -1;
+    this.scrollDOM.className = "cm-scroller";
+    this.scrollDOM.appendChild(this.contentDOM);
+    this.announceDOM = document.createElement("div");
+    this.announceDOM.className = "cm-announced";
+    this.announceDOM.setAttribute("aria-live", "polite");
+    this.dom = document.createElement("div");
+    this.dom.appendChild(this.announceDOM);
+    this.dom.appendChild(this.scrollDOM);
+    if (config.parent)
+      config.parent.appendChild(this.dom);
+    let { dispatch } = config;
+    this.dispatchTransactions = config.dispatchTransactions || dispatch && ((trs) => trs.forEach((tr) => dispatch(tr, this))) || ((trs) => this.update(trs));
+    this.dispatch = this.dispatch.bind(this);
+    this._root = config.root || getRoot(config.parent) || document;
+    this.viewState = new ViewState(this, config.state || EditorState.create(config));
+    if (config.scrollTo && config.scrollTo.is(scrollIntoView))
+      this.viewState.scrollTarget = config.scrollTo.value.clip(this.viewState.state);
+    this.plugins = this.state.facet(viewPlugin).map((spec) => new PluginInstance(spec));
+    for (let plugin of this.plugins)
+      plugin.update(this);
+    this.observer = new DOMObserver(this);
+    this.inputState = new InputState(this);
+    this.inputState.ensureHandlers(this.plugins);
+    this.docView = new DocView(this);
+    this.mountStyles();
+    this.updateAttrs();
+    this.updateState = 0;
+    this.requestMeasure();
+    if ((_a2 = document.fonts) === null || _a2 === void 0 ? void 0 : _a2.ready)
+      document.fonts.ready.then(() => {
+        this.viewState.mustMeasureContent = "refresh";
+        this.requestMeasure();
+      });
+  }
+  dispatch(...input) {
+    let trs = input.length == 1 && input[0] instanceof Transaction ? input : input.length == 1 && Array.isArray(input[0]) ? input[0] : [this.state.update(...input)];
+    this.dispatchTransactions(trs, this);
+  }
+  /**
+  Update the view for the given array of transactions. This will
+  update the visible document and selection to match the state
+  produced by the transactions, and notify view plugins of the
+  change. You should usually call
+  [`dispatch`](https://codemirror.net/6/docs/ref/#view.EditorView.dispatch) instead, which uses this
+  as a primitive.
+  */
+  update(transactions) {
+    if (this.updateState != 0)
+      throw new Error("Calls to EditorView.update are not allowed while an update is in progress");
+    let redrawn = false, attrsChanged = false, update;
+    let state = this.state;
+    for (let tr of transactions) {
+      if (tr.startState != state)
+        throw new RangeError("Trying to update state with a transaction that doesn't start from the previous state.");
+      state = tr.state;
+    }
+    if (this.destroyed) {
+      this.viewState.state = state;
+      return;
+    }
+    let focus = this.hasFocus, focusFlag = 0, dispatchFocus = null;
+    if (transactions.some((tr) => tr.annotation(isFocusChange))) {
+      this.inputState.notifiedFocused = focus;
+      focusFlag = 1;
+    } else if (focus != this.inputState.notifiedFocused) {
+      this.inputState.notifiedFocused = focus;
+      dispatchFocus = focusChangeTransaction(state, focus);
+      if (!dispatchFocus)
+        focusFlag = 1;
+    }
+    let pendingKey = this.observer.delayedAndroidKey, domChange = null;
+    if (pendingKey) {
+      this.observer.clearDelayedAndroidKey();
+      domChange = this.observer.readChange();
+      if (domChange && !this.state.doc.eq(state.doc) || !this.state.selection.eq(state.selection))
+        domChange = null;
+    } else {
+      this.observer.clear();
+    }
+    if (state.facet(EditorState.phrases) != this.state.facet(EditorState.phrases))
+      return this.setState(state);
+    update = ViewUpdate.create(this, state, transactions);
+    update.flags |= focusFlag;
+    let scrollTarget = this.viewState.scrollTarget;
+    try {
+      this.updateState = 2;
+      for (let tr of transactions) {
+        if (scrollTarget)
+          scrollTarget = scrollTarget.map(tr.changes);
+        if (tr.scrollIntoView) {
+          let { main } = tr.state.selection;
+          let { x, y } = this.state.facet(_EditorView.cursorScrollMargin);
+          scrollTarget = new ScrollTarget(main.empty ? main : EditorSelection.cursor(main.head, main.head > main.anchor ? -1 : 1), "nearest", "nearest", y, x);
+        }
+        for (let e of tr.effects)
+          if (e.is(scrollIntoView))
+            scrollTarget = e.value.clip(this.state);
+      }
+      this.viewState.update(update, scrollTarget);
+      this.bidiCache = CachedOrder.update(this.bidiCache, update.changes);
+      if (!update.empty) {
+        this.updatePlugins(update);
+        this.inputState.update(update);
+      }
+      redrawn = this.docView.update(update);
+      if (this.state.facet(styleModule) != this.styleModules)
+        this.mountStyles();
+      attrsChanged = this.updateAttrs();
+      this.showAnnouncements(transactions);
+      this.docView.updateSelection(redrawn, transactions.some((tr) => tr.isUserEvent("select.pointer")));
+    } finally {
+      this.updateState = 0;
+    }
+    if (update.startState.facet(theme) != update.state.facet(theme))
+      this.viewState.mustMeasureContent = true;
+    if (redrawn || attrsChanged || scrollTarget || this.viewState.mustEnforceCursorAssoc || this.viewState.mustMeasureContent)
+      this.requestMeasure();
+    if (redrawn)
+      this.docViewUpdate();
+    if (!update.empty)
+      for (let listener of this.state.facet(updateListener)) {
+        try {
+          listener(update);
+        } catch (e) {
+          logException(this.state, e, "update listener");
+        }
+      }
+    if (dispatchFocus || domChange)
+      Promise.resolve().then(() => {
+        if (dispatchFocus && this.state == dispatchFocus.startState)
+          this.dispatch(dispatchFocus);
+        if (domChange) {
+          if (!applyDOMChange(this, domChange) && pendingKey.force)
+            dispatchKey(this.contentDOM, pendingKey.key, pendingKey.keyCode);
+        }
+      });
+  }
+  /**
+  Reset the view to the given state. (This will cause the entire
+  document to be redrawn and all view plugins to be reinitialized,
+  so you should probably only use it when the new state isn't
+  derived from the old state. Otherwise, use
+  [`dispatch`](https://codemirror.net/6/docs/ref/#view.EditorView.dispatch) instead.)
+  */
+  setState(newState) {
+    if (this.updateState != 0)
+      throw new Error("Calls to EditorView.setState are not allowed while an update is in progress");
+    if (this.destroyed) {
+      this.viewState.state = newState;
+      return;
+    }
+    this.updateState = 2;
+    let hadFocus = this.hasFocus;
+    try {
+      for (let plugin of this.plugins)
+        plugin.destroy(this);
+      this.viewState = new ViewState(this, newState);
+      this.plugins = newState.facet(viewPlugin).map((spec) => new PluginInstance(spec));
+      this.pluginMap.clear();
+      for (let plugin of this.plugins)
+        plugin.update(this);
+      this.docView.destroy();
+      this.docView = new DocView(this);
+      this.inputState.ensureHandlers(this.plugins);
+      this.mountStyles();
+      this.updateAttrs();
+      this.bidiCache = [];
+    } finally {
+      this.updateState = 0;
+    }
+    if (hadFocus)
+      this.focus();
+    this.requestMeasure();
+  }
+  updatePlugins(update) {
+    let prevSpecs = update.startState.facet(viewPlugin), specs = update.state.facet(viewPlugin);
+    if (prevSpecs != specs) {
+      let newPlugins = [];
+      for (let spec of specs) {
+        let found = prevSpecs.indexOf(spec);
+        if (found < 0) {
+          newPlugins.push(new PluginInstance(spec));
+        } else {
+          let plugin = this.plugins[found];
+          plugin.mustUpdate = update;
+          newPlugins.push(plugin);
+        }
+      }
+      for (let plugin of this.plugins)
+        if (plugin.mustUpdate != update)
+          plugin.destroy(this);
+      this.plugins = newPlugins;
+      this.pluginMap.clear();
+    } else {
+      for (let p of this.plugins)
+        p.mustUpdate = update;
+    }
+    for (let i2 = 0; i2 < this.plugins.length; i2++)
+      this.plugins[i2].update(this);
+    if (prevSpecs != specs)
+      this.inputState.ensureHandlers(this.plugins);
+  }
+  docViewUpdate() {
+    for (let plugin of this.plugins) {
+      let val = plugin.value;
+      if (val && val.docViewUpdate) {
+        try {
+          val.docViewUpdate(this);
+        } catch (e) {
+          logException(this.state, e, "doc view update listener");
+        }
+      }
+    }
+  }
+  /**
+  @internal
+  */
+  measure(flush = true) {
+    if (this.destroyed)
+      return;
+    if (this.measureScheduled > -1)
+      this.win.cancelAnimationFrame(this.measureScheduled);
+    if (this.observer.delayedAndroidKey) {
+      this.measureScheduled = -1;
+      this.requestMeasure();
+      return;
+    }
+    this.measureScheduled = 0;
+    if (flush)
+      this.observer.forceFlush();
+    let updated = null;
+    let scroll = this.viewState.scrollParent, scrollOffset = this.viewState.getScrollOffset();
+    let { scrollAnchorPos, scrollAnchorHeight } = this.viewState;
+    if (Math.abs(scrollOffset - this.viewState.scrollOffset) > 1)
+      scrollAnchorHeight = -1;
+    this.viewState.scrollAnchorHeight = -1;
+    try {
+      for (let i2 = 0; ; i2++) {
+        if (scrollAnchorHeight < 0) {
+          if (isScrolledToBottom(scroll || this.win)) {
+            scrollAnchorPos = -1;
+            scrollAnchorHeight = this.viewState.heightMap.height;
+          } else {
+            let block = this.viewState.scrollAnchorAt(scrollOffset);
+            scrollAnchorPos = block.from;
+            scrollAnchorHeight = block.top;
+          }
+        }
+        this.updateState = 1;
+        let changed = this.viewState.measure();
+        if (!changed && !this.measureRequests.length && this.viewState.scrollTarget == null)
+          break;
+        if (i2 > 5) {
+          console.warn(this.measureRequests.length ? "Measure loop restarted more than 5 times" : "Viewport failed to stabilize");
+          break;
+        }
+        let measuring = [];
+        if (!(changed & 4))
+          [this.measureRequests, measuring] = [measuring, this.measureRequests];
+        let measured = measuring.map((m) => {
+          try {
+            return m.read(this);
+          } catch (e) {
+            logException(this.state, e);
+            return BadMeasure;
+          }
+        });
+        let update = ViewUpdate.create(this, this.state, []), redrawn = false;
+        update.flags |= changed;
+        if (!updated)
+          updated = update;
+        else
+          updated.flags |= changed;
+        this.updateState = 2;
+        if (!update.empty) {
+          this.updatePlugins(update);
+          this.inputState.update(update);
+          this.updateAttrs();
+          redrawn = this.docView.update(update);
+          if (redrawn)
+            this.docViewUpdate();
+        }
+        for (let i3 = 0; i3 < measuring.length; i3++)
+          if (measured[i3] != BadMeasure) {
+            try {
+              let m = measuring[i3];
+              if (m.write)
+                m.write(measured[i3], this);
+            } catch (e) {
+              logException(this.state, e);
+            }
+          }
+        if (redrawn)
+          this.docView.updateSelection(true);
+        if (!update.viewportChanged && this.measureRequests.length == 0) {
+          if (this.viewState.editorHeight) {
+            if (this.viewState.scrollTarget) {
+              this.docView.scrollIntoView(this.viewState.scrollTarget);
+              this.viewState.scrollTarget = null;
+              scrollAnchorHeight = -1;
+              continue;
+            } else {
+              let newAnchorHeight = scrollAnchorPos < 0 ? this.viewState.heightMap.height : this.viewState.lineBlockAt(scrollAnchorPos).top;
+              let diff = (newAnchorHeight - scrollAnchorHeight) / this.scaleY;
+              if ((diff > 1 || diff < -1) && (scroll == this.scrollDOM || this.hasFocus || Math.max(this.inputState.lastWheelEvent, this.inputState.lastTouchTime) > Date.now() - 100)) {
+                scrollOffset = scrollOffset + diff;
+                if (scroll)
+                  scroll.scrollTop += diff;
+                else
+                  this.win.scrollBy(0, diff);
+                scrollAnchorHeight = -1;
+                continue;
+              }
+            }
+          }
+          break;
+        }
+      }
+    } finally {
+      this.updateState = 0;
+      this.measureScheduled = -1;
+    }
+    if (updated && !updated.empty)
+      for (let listener of this.state.facet(updateListener))
+        listener(updated);
+  }
+  /**
+  Get the CSS classes for the currently active editor themes.
+  */
+  get themeClasses() {
+    return baseThemeID + " " + (this.state.facet(darkTheme) ? baseDarkID : baseLightID) + " " + this.state.facet(theme);
+  }
+  updateAttrs() {
+    let editorAttrs = attrsFromFacet(this, editorAttributes, {
+      class: "cm-editor" + (this.hasFocus ? " cm-focused " : " ") + this.themeClasses
+    });
+    let contentAttrs = {
+      spellcheck: "false",
+      autocorrect: "off",
+      autocapitalize: "off",
+      writingsuggestions: "false",
+      translate: "no",
+      contenteditable: !this.state.facet(editable) ? "false" : "true",
+      class: "cm-content",
+      style: `${browser.tabSize}: ${this.state.tabSize}`,
+      role: "textbox",
+      "aria-multiline": "true"
+    };
+    if (this.state.readOnly)
+      contentAttrs["aria-readonly"] = "true";
+    attrsFromFacet(this, contentAttributes, contentAttrs);
+    let changed = this.observer.ignore(() => {
+      let changedContent = updateAttrs(this.contentDOM, this.contentAttrs, contentAttrs);
+      let changedEditor = updateAttrs(this.dom, this.editorAttrs, editorAttrs);
+      return changedContent || changedEditor;
+    });
+    this.editorAttrs = editorAttrs;
+    this.contentAttrs = contentAttrs;
+    return changed;
+  }
+  showAnnouncements(trs) {
+    let first = true;
+    for (let tr of trs)
+      for (let effect of tr.effects)
+        if (effect.is(_EditorView.announce)) {
+          if (first)
+            this.announceDOM.textContent = "";
+          first = false;
+          let div = this.announceDOM.appendChild(document.createElement("div"));
+          div.textContent = effect.value;
+        }
+  }
+  mountStyles() {
+    this.styleModules = this.state.facet(styleModule);
+    let nonce = this.state.facet(_EditorView.cspNonce);
+    StyleModule.mount(this.root, this.styleModules.concat(baseTheme$1).reverse(), nonce ? { nonce } : void 0);
+  }
+  readMeasured() {
+    if (this.updateState == 2)
+      throw new Error("Reading the editor layout isn't allowed during an update");
+    if (this.updateState == 0 && this.measureScheduled > -1)
+      this.measure(false);
+  }
+  /**
+  Schedule a layout measurement, optionally providing callbacks to
+  do custom DOM measuring followed by a DOM write phase. Using
+  this is preferable reading DOM layout directly from, for
+  example, an event handler, because it'll make sure measuring and
+  drawing done by other components is synchronized, avoiding
+  unnecessary DOM layout computations.
+  */
+  requestMeasure(request) {
+    if (this.measureScheduled < 0)
+      this.measureScheduled = this.win.requestAnimationFrame(() => this.measure());
+    if (request) {
+      if (this.measureRequests.indexOf(request) > -1)
+        return;
+      if (request.key != null)
+        for (let i2 = 0; i2 < this.measureRequests.length; i2++) {
+          if (this.measureRequests[i2].key === request.key) {
+            this.measureRequests[i2] = request;
+            return;
+          }
+        }
+      this.measureRequests.push(request);
+    }
+  }
+  /**
+  Get the value of a specific plugin, if present. Note that
+  plugins that crash can be dropped from a view, so even when you
+  know you registered a given plugin, it is recommended to check
+  the return value of this method.
+  */
+  plugin(plugin) {
+    let known = this.pluginMap.get(plugin);
+    if (known === void 0 || known && known.plugin != plugin)
+      this.pluginMap.set(plugin, known = this.plugins.find((p) => p.plugin == plugin) || null);
+    return known && known.update(this).value;
+  }
+  /**
+  The top position of the document, in screen coordinates. This
+  may be negative when the editor is scrolled down. Points
+  directly to the top of the first line, not above the padding.
+  */
+  get documentTop() {
+    return this.contentDOM.getBoundingClientRect().top + this.viewState.paddingTop;
+  }
+  /**
+  Reports the padding above and below the document.
+  */
+  get documentPadding() {
+    return { top: this.viewState.paddingTop, bottom: this.viewState.paddingBottom };
+  }
+  /**
+  If the editor is transformed with CSS, this provides the scale
+  along the X axis. Otherwise, it will just be 1. Note that
+  transforms other than translation and scaling are not supported.
+  */
+  get scaleX() {
+    return this.viewState.scaleX;
+  }
+  /**
+  Provide the CSS transformed scale along the Y axis.
+  */
+  get scaleY() {
+    return this.viewState.scaleY;
+  }
+  /**
+  Find the text line or block widget at the given vertical
+  position (which is interpreted as relative to the [top of the
+  document](https://codemirror.net/6/docs/ref/#view.EditorView.documentTop)).
+  */
+  elementAtHeight(height) {
+    this.readMeasured();
+    return this.viewState.elementAtHeight(height);
+  }
+  /**
+  Find the line block (see
+  [`lineBlockAt`](https://codemirror.net/6/docs/ref/#view.EditorView.lineBlockAt)) at the given
+  height, again interpreted relative to the [top of the
+  document](https://codemirror.net/6/docs/ref/#view.EditorView.documentTop).
+  */
+  lineBlockAtHeight(height) {
+    this.readMeasured();
+    return this.viewState.lineBlockAtHeight(height);
+  }
+  /**
+  Get the extent and vertical position of all [line
+  blocks](https://codemirror.net/6/docs/ref/#view.EditorView.lineBlockAt) in the viewport. Positions
+  are relative to the [top of the
+  document](https://codemirror.net/6/docs/ref/#view.EditorView.documentTop);
+  */
+  get viewportLineBlocks() {
+    return this.viewState.viewportLines;
+  }
+  /**
+  Find the line block around the given document position. A line
+  block is a range delimited on both sides by either a
+  non-[hidden](https://codemirror.net/6/docs/ref/#view.Decoration^replace) line break, or the
+  start/end of the document. It will usually just hold a line of
+  text, but may be broken into multiple textblocks by block
+  widgets.
+  */
+  lineBlockAt(pos) {
+    return this.viewState.lineBlockAt(pos);
+  }
+  /**
+  The editor's total content height.
+  */
+  get contentHeight() {
+    return this.viewState.contentHeight;
+  }
+  /**
+  Move a cursor position by [grapheme
+  cluster](https://codemirror.net/6/docs/ref/#state.findClusterBreak). `forward` determines whether
+  the motion is away from the line start, or towards it. In
+  bidirectional text, the line is traversed in visual order, using
+  the editor's [text direction](https://codemirror.net/6/docs/ref/#view.EditorView.textDirection).
+  When the start position was the last one on the line, the
+  returned position will be across the line break. If there is no
+  further line, the original position is returned.
+  
+  By default, this method moves over a single cluster. The
+  optional `by` argument can be used to move across more. It will
+  be called with the first cluster as argument, and should return
+  a predicate that determines, for each subsequent cluster,
+  whether it should also be moved over.
+  */
+  moveByChar(start, forward, by) {
+    return skipAtoms(this, start, moveByChar(this, start, forward, by));
+  }
+  /**
+  Move a cursor position across the next group of either
+  [letters](https://codemirror.net/6/docs/ref/#state.EditorState.charCategorizer) or non-letter
+  non-whitespace characters.
+  */
+  moveByGroup(start, forward) {
+    return skipAtoms(this, start, moveByChar(this, start, forward, (initial) => byGroup(this, start.head, initial)));
+  }
+  /**
+  Get the cursor position visually at the start or end of a line.
+  Note that this may differ from the _logical_ position at its
+  start or end (which is simply at `line.from`/`line.to`) if text
+  at the start or end goes against the line's base text direction.
+  */
+  visualLineSide(line, end) {
+    let order = this.bidiSpans(line), dir = this.textDirectionAt(line.from);
+    let span = order[end ? order.length - 1 : 0];
+    return EditorSelection.cursor(span.side(end, dir) + line.from, span.forward(!end, dir) ? 1 : -1);
+  }
+  /**
+  Move to the next line boundary in the given direction. If
+  `includeWrap` is true, line wrapping is on, and there is a
+  further wrap point on the current line, the wrap point will be
+  returned. Otherwise this function will return the start or end
+  of the line.
+  */
+  moveToLineBoundary(start, forward, includeWrap = true) {
+    return moveToLineBoundary(this, start, forward, includeWrap);
+  }
+  /**
+  Move a cursor position vertically. When `distance` isn't given,
+  it defaults to moving to the next line (including wrapped
+  lines). Otherwise, `distance` should provide a positive distance
+  in pixels.
+  
+  When `start` has a
+  [`goalColumn`](https://codemirror.net/6/docs/ref/#state.SelectionRange.goalColumn), the vertical
+  motion will use that as a target horizontal position. Otherwise,
+  the cursor's own horizontal position is used. The returned
+  cursor will have its goal column set to whichever column was
+  used.
+  */
+  moveVertically(start, forward, distance) {
+    return skipAtoms(this, start, moveVertically(this, start, forward, distance));
+  }
+  /**
+  Find the DOM parent node and offset (child offset if `node` is
+  an element, character offset when it is a text node) at the
+  given document position.
+  
+  Note that for positions that aren't currently in
+  `visibleRanges`, the resulting DOM position isn't necessarily
+  meaningful (it may just point before or after a placeholder
+  element).
+  */
+  domAtPos(pos, side = 1) {
+    return this.docView.domAtPos(pos, side);
+  }
+  /**
+  Find the document position at the given DOM node. Can be useful
+  for associating positions with DOM events. Will raise an error
+  when `node` isn't part of the editor content.
+  */
+  posAtDOM(node, offset = 0) {
+    return this.docView.posFromDOM(node, offset);
+  }
+  posAtCoords(coords, precise = true) {
+    this.readMeasured();
+    let found = posAtCoords(this, coords, precise);
+    return found && found.pos;
+  }
+  posAndSideAtCoords(coords, precise = true) {
+    this.readMeasured();
+    return posAtCoords(this, coords, precise);
+  }
+  /**
+  Get the screen coordinates at the given document position.
+  `side` determines whether the coordinates are based on the
+  element before (-1) or after (1) the position (if no element is
+  available on the given side, the method will transparently use
+  another strategy to get reasonable coordinates).
+  */
+  coordsAtPos(pos, side = 1) {
+    this.readMeasured();
+    let rect = this.docView.coordsAt(pos, side);
+    if (!rect || rect.left == rect.right)
+      return rect;
+    let line = this.state.doc.lineAt(pos), order = this.bidiSpans(line);
+    let span = order[BidiSpan.find(order, pos - line.from, -1, side)];
+    return flattenRect(rect, span.dir == Direction.LTR == side > 0);
+  }
+  /**
+  Return the rectangle around a given character. If `pos` does not
+  point in front of a character that is in the viewport and
+  rendered (i.e. not replaced, not a line break), this will return
+  null. For space characters that are a line wrap point, this will
+  return the position before the line break.
+  */
+  coordsForChar(pos) {
+    this.readMeasured();
+    return this.docView.coordsForChar(pos);
+  }
+  /**
+  The default width of a character in the editor. May not
+  accurately reflect the width of all characters (given variable
+  width fonts or styling of invididual ranges).
+  */
+  get defaultCharacterWidth() {
+    return this.viewState.heightOracle.charWidth;
+  }
+  /**
+  The default height of a line in the editor. May not be accurate
+  for all lines.
+  */
+  get defaultLineHeight() {
+    return this.viewState.heightOracle.lineHeight;
+  }
+  /**
+  The text direction
+  ([`direction`](https://developer.mozilla.org/en-US/docs/Web/CSS/direction)
+  CSS property) of the editor's content element.
+  */
+  get textDirection() {
+    return this.viewState.defaultTextDirection;
+  }
+  /**
+  Find the text direction of the block at the given position, as
+  assigned by CSS. If
+  [`perLineTextDirection`](https://codemirror.net/6/docs/ref/#view.EditorView^perLineTextDirection)
+  isn't enabled, or the given position is outside of the viewport,
+  this will always return the same as
+  [`textDirection`](https://codemirror.net/6/docs/ref/#view.EditorView.textDirection). Note that
+  this may trigger a DOM layout.
+  */
+  textDirectionAt(pos) {
+    let perLine = this.state.facet(perLineTextDirection);
+    if (!perLine || pos < this.viewport.from || pos > this.viewport.to)
+      return this.textDirection;
+    this.readMeasured();
+    return this.docView.textDirectionAt(pos);
+  }
+  /**
+  Whether this editor [wraps lines](https://codemirror.net/6/docs/ref/#view.EditorView.lineWrapping)
+  (as determined by the
+  [`white-space`](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space)
+  CSS property of its content element).
+  */
+  get lineWrapping() {
+    return this.viewState.heightOracle.lineWrapping;
+  }
+  /**
+  Returns the bidirectional text structure of the given line
+  (which should be in the current document) as an array of span
+  objects. The order of these spans matches the [text
+  direction](https://codemirror.net/6/docs/ref/#view.EditorView.textDirection)—if that is
+  left-to-right, the leftmost spans come first, otherwise the
+  rightmost spans come first.
+  */
+  bidiSpans(line) {
+    if (line.length > MaxBidiLine)
+      return trivialOrder(line.length);
+    let dir = this.textDirectionAt(line.from), isolates;
+    for (let entry of this.bidiCache) {
+      if (entry.from == line.from && entry.dir == dir && (entry.fresh || isolatesEq(entry.isolates, isolates = getIsolatedRanges(this, line))))
+        return entry.order;
+    }
+    if (!isolates)
+      isolates = getIsolatedRanges(this, line);
+    let order = computeOrder(line.text, dir, isolates);
+    this.bidiCache.push(new CachedOrder(line.from, line.to, dir, isolates, true, order));
+    return order;
+  }
+  /**
+  Check whether the editor has focus.
+  */
+  get hasFocus() {
+    var _a2;
+    return (this.dom.ownerDocument.hasFocus() || browser.safari && ((_a2 = this.inputState) === null || _a2 === void 0 ? void 0 : _a2.lastContextMenu) > Date.now() - 3e4) && this.root.activeElement == this.contentDOM;
+  }
+  /**
+  Put focus on the editor.
+  */
+  focus() {
+    this.observer.ignore(() => {
+      focusPreventScroll(this.contentDOM);
+      this.docView.updateSelection();
+    });
+  }
+  /**
+  Update the [root](https://codemirror.net/6/docs/ref/##view.EditorViewConfig.root) in which the editor lives. This is only
+  necessary when moving the editor's existing DOM to a new window or shadow root.
+  */
+  setRoot(root) {
+    if (this._root != root) {
+      this._root = root;
+      this.observer.setWindow((root.nodeType == 9 ? root : root.ownerDocument).defaultView || window);
+      this.mountStyles();
+    }
+  }
+  /**
+  Clean up this editor view, removing its element from the
+  document, unregistering event handlers, and notifying
+  plugins. The view instance can no longer be used after
+  calling this.
+  */
+  destroy() {
+    if (this.root.activeElement == this.contentDOM)
+      this.contentDOM.blur();
+    for (let plugin of this.plugins)
+      plugin.destroy(this);
+    this.plugins = [];
+    this.inputState.destroy();
+    this.docView.destroy();
+    this.dom.remove();
+    this.observer.destroy();
+    if (this.measureScheduled > -1)
+      this.win.cancelAnimationFrame(this.measureScheduled);
+    this.destroyed = true;
+  }
+  /**
+  Returns an effect that can be
+  [added](https://codemirror.net/6/docs/ref/#state.TransactionSpec.effects) to a transaction to
+  cause it to scroll the given position or range into view.
+  */
+  static scrollIntoView(pos, options = {}) {
+    var _a2, _b, _c, _d;
+    return scrollIntoView.of(new ScrollTarget(typeof pos == "number" ? EditorSelection.cursor(pos) : pos, (_a2 = options.y) !== null && _a2 !== void 0 ? _a2 : "nearest", (_b = options.x) !== null && _b !== void 0 ? _b : "nearest", (_c = options.yMargin) !== null && _c !== void 0 ? _c : 5, (_d = options.xMargin) !== null && _d !== void 0 ? _d : 5));
+  }
+  /**
+  Return an effect that resets the editor to its current (at the
+  time this method was called) scroll position. Note that this
+  only affects the editor's own scrollable element, not parents.
+  See also
+  [`EditorViewConfig.scrollTo`](https://codemirror.net/6/docs/ref/#view.EditorViewConfig.scrollTo).
+  
+  The effect should be used with a document identical to the one
+  it was created for. Failing to do so is not an error, but may
+  not scroll to the expected position. You can
+  [map](https://codemirror.net/6/docs/ref/#state.StateEffect.map) the effect to account for changes.
+  */
+  scrollSnapshot() {
+    let { scrollTop, scrollLeft } = this.scrollDOM;
+    let ref = this.viewState.scrollAnchorAt(scrollTop);
+    return scrollIntoView.of(new ScrollTarget(EditorSelection.cursor(ref.from), "start", "start", ref.top - scrollTop, scrollLeft, true));
+  }
+  /**
+  Enable or disable tab-focus mode, which disables key bindings
+  for Tab and Shift-Tab, letting the browser's default
+  focus-changing behavior go through instead. This is useful to
+  prevent trapping keyboard users in your editor.
+  
+  Without argument, this toggles the mode. With a boolean, it
+  enables (true) or disables it (false). Given a number, it
+  temporarily enables the mode until that number of milliseconds
+  have passed or another non-Tab key is pressed.
+  */
+  setTabFocusMode(to) {
+    if (to == null)
+      this.inputState.tabFocusMode = this.inputState.tabFocusMode < 0 ? 0 : -1;
+    else if (typeof to == "boolean")
+      this.inputState.tabFocusMode = to ? 0 : -1;
+    else if (this.inputState.tabFocusMode != 0)
+      this.inputState.tabFocusMode = Date.now() + to;
+  }
+  /**
+  Returns an extension that can be used to add DOM event handlers.
+  The value should be an object mapping event names to handler
+  functions. For any given event, such functions are ordered by
+  extension precedence, and the first handler to return true will
+  be assumed to have handled that event, and no other handlers or
+  built-in behavior will be activated for it. These are registered
+  on the [content element](https://codemirror.net/6/docs/ref/#view.EditorView.contentDOM), except
+  for `scroll` handlers, which will be called any time the
+  editor's [scroll element](https://codemirror.net/6/docs/ref/#view.EditorView.scrollDOM) or one of
+  its parent nodes is scrolled.
+  */
+  static domEventHandlers(handlers2) {
+    return ViewPlugin.define(() => ({}), { eventHandlers: handlers2 });
+  }
+  /**
+  Create an extension that registers DOM event observers. Contrary
+  to event [handlers](https://codemirror.net/6/docs/ref/#view.EditorView^domEventHandlers),
+  observers can't be prevented from running by a higher-precedence
+  handler returning true. They also don't prevent other handlers
+  and observers from running when they return true, and should not
+  call `preventDefault`.
+  */
+  static domEventObservers(observers2) {
+    return ViewPlugin.define(() => ({}), { eventObservers: observers2 });
+  }
+  /**
+  Create a theme extension. The first argument can be a
+  [`style-mod`](https://code.haverbeke.berlin/marijn/style-mod#documentation)
+  style spec providing the styles for the theme. These will be
+  prefixed with a generated class for the style.
+  
+  Because the selectors will be prefixed with a scope class, rule
+  that directly match the editor's [wrapper
+  element](https://codemirror.net/6/docs/ref/#view.EditorView.dom)—to which the scope class will be
+  added—need to be explicitly differentiated by adding an `&` to
+  the selector for that element—for example
+  `&.cm-focused`.
+  
+  When `dark` is set to true, the theme will be marked as dark,
+  which will cause the `&dark` rules from [base
+  themes](https://codemirror.net/6/docs/ref/#view.EditorView^baseTheme) to be used (as opposed to
+  `&light` when a light theme is active).
+  */
+  static theme(spec, options) {
+    let prefix = StyleModule.newName();
+    let result = [theme.of(prefix), styleModule.of(buildTheme(`.${prefix}`, spec))];
+    if (options && options.dark)
+      result.push(darkTheme.of(true));
+    return result;
+  }
+  /**
+  Create an extension that adds styles to the base theme. Like
+  with [`theme`](https://codemirror.net/6/docs/ref/#view.EditorView^theme), use `&` to indicate the
+  place of the editor wrapper element when directly targeting
+  that. You can also use `&dark` or `&light` instead to only
+  target editors with a dark or light theme.
+  */
+  static baseTheme(spec) {
+    return Prec.lowest(styleModule.of(buildTheme("." + baseThemeID, spec, lightDarkIDs)));
+  }
+  /**
+  Retrieve an editor view instance from the view's DOM
+  representation.
+  */
+  static findFromDOM(dom) {
+    var _a2;
+    let content2 = dom.querySelector(".cm-content");
+    let tile = content2 && Tile.get(content2) || Tile.get(dom);
+    return ((_a2 = tile === null || tile === void 0 ? void 0 : tile.root) === null || _a2 === void 0 ? void 0 : _a2.view) || null;
+  }
+};
+EditorView.styleModule = styleModule;
+EditorView.inputHandler = inputHandler;
+EditorView.clipboardInputFilter = clipboardInputFilter;
+EditorView.clipboardOutputFilter = clipboardOutputFilter;
+EditorView.scrollHandler = scrollHandler;
+EditorView.focusChangeEffect = focusChangeEffect;
+EditorView.perLineTextDirection = perLineTextDirection;
+EditorView.exceptionSink = exceptionSink;
+EditorView.updateListener = updateListener;
+EditorView.editable = editable;
+EditorView.mouseSelectionStyle = mouseSelectionStyle;
+EditorView.dragMovesSelection = dragMovesSelection$1;
+EditorView.clickAddsSelectionRange = clickAddsSelectionRange;
+EditorView.decorations = decorations;
+EditorView.blockWrappers = blockWrappers;
+EditorView.outerDecorations = outerDecorations;
+EditorView.atomicRanges = atomicRanges;
+EditorView.bidiIsolatedRanges = bidiIsolatedRanges;
+EditorView.cursorScrollMargin = /* @__PURE__ */ Facet.define({
+  combine: (inputs) => {
+    let x = 5, y = 5;
+    for (let i2 of inputs) {
+      if (typeof i2 == "number")
+        x = y = i2;
+      else
+        ({ x, y } = i2);
+    }
+    return { x, y };
+  }
+});
+EditorView.scrollMargins = scrollMargins;
+EditorView.darkTheme = darkTheme;
+EditorView.cspNonce = /* @__PURE__ */ Facet.define({ combine: (values) => values.length ? values[0] : "" });
+EditorView.contentAttributes = contentAttributes;
+EditorView.editorAttributes = editorAttributes;
+EditorView.lineWrapping = /* @__PURE__ */ EditorView.contentAttributes.of({ "class": "cm-lineWrapping" });
+EditorView.announce = /* @__PURE__ */ StateEffect.define();
+var MaxBidiLine = 4096;
+var BadMeasure = {};
+var CachedOrder = class _CachedOrder {
+  constructor(from, to, dir, isolates, fresh, order) {
+    this.from = from;
+    this.to = to;
+    this.dir = dir;
+    this.isolates = isolates;
+    this.fresh = fresh;
+    this.order = order;
+  }
+  static update(cache2, changes) {
+    if (changes.empty && !cache2.some((c) => c.fresh))
+      return cache2;
+    let result = [], lastDir = cache2.length ? cache2[cache2.length - 1].dir : Direction.LTR;
+    for (let i2 = Math.max(0, cache2.length - 10); i2 < cache2.length; i2++) {
+      let entry = cache2[i2];
+      if (entry.dir == lastDir && !changes.touchesRange(entry.from, entry.to))
+        result.push(new _CachedOrder(changes.mapPos(entry.from, 1), changes.mapPos(entry.to, -1), entry.dir, entry.isolates, false, entry.order));
+    }
+    return result;
+  }
+};
+function attrsFromFacet(view, facet, base2) {
+  for (let sources = view.state.facet(facet), i2 = sources.length - 1; i2 >= 0; i2--) {
+    let source = sources[i2], value = typeof source == "function" ? source(view) : source;
+    if (value)
+      combineAttrs(value, base2);
+  }
+  return base2;
+}
+var currentPlatform = browser.mac ? "mac" : browser.windows ? "win" : browser.linux ? "linux" : "key";
+function normalizeKeyName(name2, platform) {
+  const parts = name2.split(/-(?!$)/);
+  let result = parts[parts.length - 1];
+  if (result == "Space")
+    result = " ";
+  let alt, ctrl, shift2, meta2;
+  for (let i2 = 0; i2 < parts.length - 1; ++i2) {
+    const mod = parts[i2];
+    if (/^(cmd|meta|m)$/i.test(mod))
+      meta2 = true;
+    else if (/^a(lt)?$/i.test(mod))
+      alt = true;
+    else if (/^(c|ctrl|control)$/i.test(mod))
+      ctrl = true;
+    else if (/^s(hift)?$/i.test(mod))
+      shift2 = true;
+    else if (/^mod$/i.test(mod)) {
+      if (platform == "mac")
+        meta2 = true;
+      else
+        ctrl = true;
+    } else
+      throw new Error("Unrecognized modifier name: " + mod);
+  }
+  if (alt)
+    result = "Alt-" + result;
+  if (ctrl)
+    result = "Ctrl-" + result;
+  if (meta2)
+    result = "Meta-" + result;
+  if (shift2)
+    result = "Shift-" + result;
+  return result;
+}
+function modifiers(name2, event, shift2) {
+  if (event.altKey)
+    name2 = "Alt-" + name2;
+  if (event.ctrlKey)
+    name2 = "Ctrl-" + name2;
+  if (event.metaKey)
+    name2 = "Meta-" + name2;
+  if (shift2 !== false && event.shiftKey)
+    name2 = "Shift-" + name2;
+  return name2;
+}
+var handleKeyEvents = /* @__PURE__ */ Prec.default(/* @__PURE__ */ EditorView.domEventHandlers({
+  keydown(event, view) {
+    return runHandlers(getKeymap(view.state), event, view, "editor");
+  }
+}));
+var keymap = /* @__PURE__ */ Facet.define({ enables: handleKeyEvents });
+var Keymaps = /* @__PURE__ */ new WeakMap();
+function getKeymap(state) {
+  let bindings = state.facet(keymap);
+  let map = Keymaps.get(bindings);
+  if (!map)
+    Keymaps.set(bindings, map = buildKeymap(bindings.reduce((a, b) => a.concat(b), [])));
+  return map;
+}
+var storedPrefix = null;
+var PrefixTimeout = 4e3;
+function buildKeymap(bindings, platform = currentPlatform) {
+  let bound = /* @__PURE__ */ Object.create(null);
+  let isPrefix = /* @__PURE__ */ Object.create(null);
+  let checkPrefix = (name2, is) => {
+    let current = isPrefix[name2];
+    if (current == null)
+      isPrefix[name2] = is;
+    else if (current != is)
+      throw new Error("Key binding " + name2 + " is used both as a regular binding and as a multi-stroke prefix");
+  };
+  let add = (scope, key, command, preventDefault, stopPropagation) => {
+    var _a2, _b;
+    let scopeObj = bound[scope] || (bound[scope] = /* @__PURE__ */ Object.create(null));
+    let parts = key.split(/ (?!$)/).map((k) => normalizeKeyName(k, platform));
+    for (let i2 = 1; i2 < parts.length; i2++) {
+      let prefix = parts.slice(0, i2).join(" ");
+      checkPrefix(prefix, true);
+      if (!scopeObj[prefix])
+        scopeObj[prefix] = {
+          preventDefault: true,
+          stopPropagation: false,
+          run: [(view) => {
+            let ourObj = storedPrefix = { view, prefix, scope };
+            setTimeout(() => {
+              if (storedPrefix == ourObj)
+                storedPrefix = null;
+            }, PrefixTimeout);
+            return true;
+          }]
+        };
+    }
+    let full = parts.join(" ");
+    checkPrefix(full, false);
+    let binding = scopeObj[full] || (scopeObj[full] = {
+      preventDefault: false,
+      stopPropagation: false,
+      run: ((_b = (_a2 = scopeObj._any) === null || _a2 === void 0 ? void 0 : _a2.run) === null || _b === void 0 ? void 0 : _b.slice()) || []
+    });
+    if (command)
+      binding.run.push(command);
+    if (preventDefault)
+      binding.preventDefault = true;
+    if (stopPropagation)
+      binding.stopPropagation = true;
+  };
+  for (let b of bindings) {
+    let scopes = b.scope ? b.scope.split(" ") : ["editor"];
+    if (b.any)
+      for (let scope of scopes) {
+        let scopeObj = bound[scope] || (bound[scope] = /* @__PURE__ */ Object.create(null));
+        if (!scopeObj._any)
+          scopeObj._any = { preventDefault: false, stopPropagation: false, run: [] };
+        let { any } = b;
+        for (let key in scopeObj)
+          scopeObj[key].run.push((view) => any(view, currentKeyEvent));
+      }
+    let name2 = b[platform] || b.key;
+    if (!name2)
+      continue;
+    for (let scope of scopes) {
+      add(scope, name2, b.run, b.preventDefault, b.stopPropagation);
+      if (b.shift)
+        add(scope, "Shift-" + name2, b.shift, b.preventDefault, b.stopPropagation);
+    }
+  }
+  return bound;
+}
+var currentKeyEvent = null;
+function runHandlers(map, event, view, scope) {
+  currentKeyEvent = event;
+  let name2 = keyName(event);
+  let charCode = codePointAt2(name2, 0), isChar = codePointSize2(charCode) == name2.length && name2 != " ";
+  let prefix = "", handled = false, prevented = false, stopPropagation = false;
+  if (storedPrefix && storedPrefix.view == view && storedPrefix.scope == scope) {
+    prefix = storedPrefix.prefix + " ";
+    if (modifierCodes.indexOf(event.keyCode) < 0) {
+      prevented = true;
+      storedPrefix = null;
+    }
+  }
+  let ran = /* @__PURE__ */ new Set();
+  let runFor = (binding) => {
+    if (binding) {
+      for (let cmd of binding.run)
+        if (!ran.has(cmd)) {
+          ran.add(cmd);
+          if (cmd(view)) {
+            if (binding.stopPropagation)
+              stopPropagation = true;
+            return true;
+          }
+        }
+      if (binding.preventDefault) {
+        if (binding.stopPropagation)
+          stopPropagation = true;
+        prevented = true;
+      }
+    }
+    return false;
+  };
+  let scopeObj = map[scope], baseName, shiftName;
+  if (scopeObj) {
+    if (runFor(scopeObj[prefix + modifiers(name2, event, !isChar)])) {
+      handled = true;
+    } else if (isChar && (event.altKey || event.metaKey || event.ctrlKey) && // Ctrl-Alt may be used for AltGr on Windows
+    !(browser.windows && event.ctrlKey && event.altKey) && // Alt-combinations on macOS tend to be typed characters
+    !(browser.mac && event.altKey && !(event.ctrlKey || event.metaKey)) && (baseName = base[event.keyCode]) && baseName != name2) {
+      if (runFor(scopeObj[prefix + modifiers(baseName, event, true)])) {
+        handled = true;
+      } else if (event.shiftKey && (shiftName = shift[event.keyCode]) != name2 && shiftName != baseName && runFor(scopeObj[prefix + modifiers(shiftName, event, false)])) {
+        handled = true;
+      }
+    } else if (isChar && event.shiftKey && runFor(scopeObj[prefix + modifiers(name2, event, true)])) {
+      handled = true;
+    }
+    if (!handled && runFor(scopeObj._any))
+      handled = true;
+  }
+  if (prevented)
+    handled = true;
+  if (handled && stopPropagation)
+    event.stopPropagation();
+  currentKeyEvent = null;
+  return handled;
+}
+var UnicodeRegexpSupport = /x/.unicode != null ? "gu" : "g";
+function highlightActiveLine() {
+  return activeLineHighlighter;
+}
+var lineDeco = /* @__PURE__ */ Decoration.line({ class: "cm-activeLine" });
+var activeLineHighlighter = /* @__PURE__ */ ViewPlugin.fromClass(class {
+  constructor(view) {
+    this.decorations = this.getDeco(view);
+  }
+  update(update) {
+    if (update.docChanged || update.selectionSet)
+      this.decorations = this.getDeco(update.view);
+  }
+  getDeco(view) {
+    let lastLineStart = -1, deco = [];
+    for (let r2 of view.state.selection.ranges) {
+      let line = view.lineBlockAt(r2.head);
+      if (line.from > lastLineStart) {
+        deco.push(lineDeco.range(line.from));
+        lastLineStart = line.from;
+      }
+    }
+    return Decoration.set(deco);
+  }
+}, {
+  decorations: (v) => v.decorations
+});
+var baseTheme = /* @__PURE__ */ EditorView.baseTheme({
+  ".cm-tooltip": {
+    zIndex: 500,
+    boxSizing: "border-box"
+  },
+  "&light .cm-tooltip": {
+    border: "1px solid #bbb",
+    backgroundColor: "#f5f5f5"
+  },
+  "&light .cm-tooltip-section:not(:first-child)": {
+    borderTop: "1px solid #bbb"
+  },
+  "&dark .cm-tooltip": {
+    backgroundColor: "#333338",
+    color: "white"
+  },
+  ".cm-tooltip-arrow": {
+    height: `${7}px`,
+    width: `${7 * 2}px`,
+    position: "absolute",
+    zIndex: -1,
+    overflow: "hidden",
+    "&:before, &:after": {
+      content: "''",
+      position: "absolute",
+      width: 0,
+      height: 0,
+      borderLeft: `${7}px solid transparent`,
+      borderRight: `${7}px solid transparent`
+    },
+    ".cm-tooltip-above &": {
+      bottom: `-${7}px`,
+      "&:before": {
+        borderTop: `${7}px solid #bbb`
+      },
+      "&:after": {
+        borderTop: `${7}px solid #f5f5f5`,
+        bottom: "1px"
+      }
+    },
+    ".cm-tooltip-below &": {
+      top: `-${7}px`,
+      "&:before": {
+        borderBottom: `${7}px solid #bbb`
+      },
+      "&:after": {
+        borderBottom: `${7}px solid #f5f5f5`,
+        top: "1px"
+      }
+    }
+  },
+  "&dark .cm-tooltip .cm-tooltip-arrow": {
+    "&:before": {
+      borderTopColor: "#333338",
+      borderBottomColor: "#333338"
+    },
+    "&:after": {
+      borderTopColor: "transparent",
+      borderBottomColor: "transparent"
+    }
+  }
+});
+var GutterMarker = class extends RangeValue {
+  /**
+  @internal
+  */
+  compare(other) {
+    return this == other || this.constructor == other.constructor && this.eq(other);
+  }
+  /**
+  Compare this marker to another marker of the same type.
+  */
+  eq(other) {
+    return false;
+  }
+  /**
+  Called if the marker has a `toDOM` method and its representation
+  was removed from a gutter.
+  */
+  destroy(dom) {
+  }
+};
+GutterMarker.prototype.elementClass = "";
+GutterMarker.prototype.toDOM = void 0;
+GutterMarker.prototype.mapMode = MapMode.TrackBefore;
+GutterMarker.prototype.startSide = GutterMarker.prototype.endSide = -1;
+GutterMarker.prototype.point = true;
+var gutterLineClass = /* @__PURE__ */ Facet.define();
+var gutterWidgetClass = /* @__PURE__ */ Facet.define();
+var activeGutters = /* @__PURE__ */ Facet.define();
+var unfixGutters = /* @__PURE__ */ Facet.define({
+  combine: (values) => values.some((x) => x)
+});
+function gutters(config) {
+  let result = [
+    gutterView
+  ];
+  if (config && config.fixed === false)
+    result.push(unfixGutters.of(true));
+  return result;
+}
+var gutterView = /* @__PURE__ */ ViewPlugin.fromClass(class {
+  constructor(view) {
+    this.view = view;
+    this.domAfter = null;
+    this.prevViewport = view.viewport;
+    this.dom = document.createElement("div");
+    this.dom.className = "cm-gutters cm-gutters-before";
+    this.dom.setAttribute("aria-hidden", "true");
+    this.dom.style.minHeight = this.view.contentHeight / this.view.scaleY + "px";
+    this.gutters = view.state.facet(activeGutters).map((conf) => new SingleGutterView(view, conf));
+    this.fixed = !view.state.facet(unfixGutters);
+    for (let gutter2 of this.gutters) {
+      if (gutter2.config.side == "after")
+        this.getDOMAfter().appendChild(gutter2.dom);
+      else
+        this.dom.appendChild(gutter2.dom);
+    }
+    if (this.fixed) {
+      this.dom.style.position = "sticky";
+    }
+    this.syncGutters(false);
+    view.scrollDOM.insertBefore(this.dom, view.contentDOM);
+  }
+  getDOMAfter() {
+    if (!this.domAfter) {
+      this.domAfter = document.createElement("div");
+      this.domAfter.className = "cm-gutters cm-gutters-after";
+      this.domAfter.setAttribute("aria-hidden", "true");
+      this.domAfter.style.minHeight = this.view.contentHeight / this.view.scaleY + "px";
+      this.domAfter.style.position = this.fixed ? "sticky" : "";
+      this.view.scrollDOM.appendChild(this.domAfter);
+    }
+    return this.domAfter;
+  }
+  update(update) {
+    if (this.updateGutters(update)) {
+      let vpA = this.prevViewport, vpB = update.view.viewport;
+      let vpOverlap = Math.min(vpA.to, vpB.to) - Math.max(vpA.from, vpB.from);
+      this.syncGutters(vpOverlap < (vpB.to - vpB.from) * 0.8);
+    }
+    if (update.geometryChanged) {
+      let min = this.view.contentHeight / this.view.scaleY + "px";
+      this.dom.style.minHeight = min;
+      if (this.domAfter)
+        this.domAfter.style.minHeight = min;
+    }
+    if (this.view.state.facet(unfixGutters) != !this.fixed) {
+      this.fixed = !this.fixed;
+      this.dom.style.position = this.fixed ? "sticky" : "";
+      if (this.domAfter)
+        this.domAfter.style.position = this.fixed ? "sticky" : "";
+    }
+    this.prevViewport = update.view.viewport;
+  }
+  syncGutters(detach) {
+    let after = this.dom.nextSibling;
+    if (detach) {
+      this.dom.remove();
+      if (this.domAfter)
+        this.domAfter.remove();
+    }
+    let lineClasses = RangeSet.iter(this.view.state.facet(gutterLineClass), this.view.viewport.from);
+    let classSet = [];
+    let contexts = this.gutters.map((gutter2) => new UpdateContext(gutter2, this.view.viewport, -this.view.documentPadding.top));
+    for (let line of this.view.viewportLineBlocks) {
+      if (classSet.length)
+        classSet = [];
+      if (Array.isArray(line.type)) {
+        let first = true;
+        for (let b of line.type) {
+          if (b.type == BlockType.Text && first) {
+            advanceCursor(lineClasses, classSet, b.from);
+            for (let cx of contexts)
+              cx.line(this.view, b, classSet);
+            first = false;
+          } else if (b.widget) {
+            for (let cx of contexts)
+              cx.widget(this.view, b);
+          }
+        }
+      } else if (line.type == BlockType.Text) {
+        advanceCursor(lineClasses, classSet, line.from);
+        for (let cx of contexts)
+          cx.line(this.view, line, classSet);
+      } else if (line.widget) {
+        for (let cx of contexts)
+          cx.widget(this.view, line);
+      }
+    }
+    for (let cx of contexts)
+      cx.finish();
+    if (detach) {
+      this.view.scrollDOM.insertBefore(this.dom, after);
+      if (this.domAfter)
+        this.view.scrollDOM.appendChild(this.domAfter);
+    }
+  }
+  updateGutters(update) {
+    let prev = update.startState.facet(activeGutters), cur = update.state.facet(activeGutters);
+    let change = update.docChanged || update.heightChanged || update.viewportChanged || !RangeSet.eq(update.startState.facet(gutterLineClass), update.state.facet(gutterLineClass), update.view.viewport.from, update.view.viewport.to);
+    if (prev == cur) {
+      for (let gutter2 of this.gutters)
+        if (gutter2.update(update))
+          change = true;
+    } else {
+      change = true;
+      let gutters2 = [];
+      for (let conf of cur) {
+        let known = prev.indexOf(conf);
+        if (known < 0) {
+          gutters2.push(new SingleGutterView(this.view, conf));
+        } else {
+          this.gutters[known].update(update);
+          gutters2.push(this.gutters[known]);
+        }
+      }
+      for (let g of this.gutters) {
+        g.dom.remove();
+        if (gutters2.indexOf(g) < 0)
+          g.destroy();
+      }
+      for (let g of gutters2) {
+        if (g.config.side == "after")
+          this.getDOMAfter().appendChild(g.dom);
+        else
+          this.dom.appendChild(g.dom);
+      }
+      this.gutters = gutters2;
+    }
+    return change;
+  }
+  destroy() {
+    for (let view of this.gutters)
+      view.destroy();
+    this.dom.remove();
+    if (this.domAfter)
+      this.domAfter.remove();
+  }
+}, {
+  provide: (plugin) => EditorView.scrollMargins.of((view) => {
+    let value = view.plugin(plugin);
+    if (!value || value.gutters.length == 0 || !value.fixed)
+      return null;
+    let before = value.dom.offsetWidth * view.scaleX, after = value.domAfter ? value.domAfter.offsetWidth * view.scaleX : 0;
+    return view.textDirection == Direction.LTR ? { left: before, right: after } : { right: before, left: after };
+  })
+});
+function asArray2(val) {
+  return Array.isArray(val) ? val : [val];
+}
+function advanceCursor(cursor, collect, pos) {
+  while (cursor.value && cursor.from <= pos) {
+    if (cursor.from == pos)
+      collect.push(cursor.value);
+    cursor.next();
+  }
+}
+var UpdateContext = class {
+  constructor(gutter2, viewport, height) {
+    this.gutter = gutter2;
+    this.height = height;
+    this.i = 0;
+    this.cursor = RangeSet.iter(gutter2.markers, viewport.from);
+  }
+  addElement(view, block, markers) {
+    let { gutter: gutter2 } = this, above = (block.top - this.height) / view.scaleY, height = block.height / view.scaleY;
+    if (this.i == gutter2.elements.length) {
+      let newElt = new GutterElement(view, height, above, markers);
+      gutter2.elements.push(newElt);
+      gutter2.dom.appendChild(newElt.dom);
+    } else {
+      gutter2.elements[this.i].update(view, height, above, markers);
+    }
+    this.height = block.bottom;
+    this.i++;
+  }
+  line(view, line, extraMarkers) {
+    let localMarkers = [];
+    advanceCursor(this.cursor, localMarkers, line.from);
+    if (extraMarkers.length)
+      localMarkers = localMarkers.concat(extraMarkers);
+    let forLine = this.gutter.config.lineMarker(view, line, localMarkers);
+    if (forLine)
+      localMarkers.unshift(forLine);
+    let gutter2 = this.gutter;
+    if (localMarkers.length == 0 && !gutter2.config.renderEmptyElements)
+      return;
+    this.addElement(view, line, localMarkers);
+  }
+  widget(view, block) {
+    let marker = this.gutter.config.widgetMarker(view, block.widget, block), markers = marker ? [marker] : null;
+    for (let cls of view.state.facet(gutterWidgetClass)) {
+      let marker2 = cls(view, block.widget, block);
+      if (marker2)
+        (markers || (markers = [])).push(marker2);
+    }
+    if (markers)
+      this.addElement(view, block, markers);
+  }
+  finish() {
+    let gutter2 = this.gutter;
+    while (gutter2.elements.length > this.i) {
+      let last = gutter2.elements.pop();
+      gutter2.dom.removeChild(last.dom);
+      last.destroy();
+    }
+  }
+};
+var SingleGutterView = class {
+  constructor(view, config) {
+    this.view = view;
+    this.config = config;
+    this.elements = [];
+    this.spacer = null;
+    this.dom = document.createElement("div");
+    this.dom.className = "cm-gutter" + (this.config.class ? " " + this.config.class : "");
+    for (let prop in config.domEventHandlers) {
+      this.dom.addEventListener(prop, (event) => {
+        let target = event.target, y;
+        if (target != this.dom && this.dom.contains(target)) {
+          while (target.parentNode != this.dom)
+            target = target.parentNode;
+          let rect = target.getBoundingClientRect();
+          y = (rect.top + rect.bottom) / 2;
+        } else {
+          y = event.clientY;
+        }
+        let line = view.lineBlockAtHeight(y - view.documentTop);
+        if (config.domEventHandlers[prop](view, line, event))
+          event.preventDefault();
+      });
+    }
+    this.markers = asArray2(config.markers(view));
+    if (config.initialSpacer) {
+      this.spacer = new GutterElement(view, 0, 0, [config.initialSpacer(view)]);
+      this.dom.appendChild(this.spacer.dom);
+      this.spacer.dom.style.cssText += "visibility: hidden; pointer-events: none";
+    }
+  }
+  update(update) {
+    let prevMarkers = this.markers;
+    this.markers = asArray2(this.config.markers(update.view));
+    if (this.spacer && this.config.updateSpacer) {
+      let updated = this.config.updateSpacer(this.spacer.markers[0], update);
+      if (updated != this.spacer.markers[0])
+        this.spacer.update(update.view, 0, 0, [updated]);
+    }
+    let vp = update.view.viewport;
+    return !RangeSet.eq(this.markers, prevMarkers, vp.from, vp.to) || (this.config.lineMarkerChange ? this.config.lineMarkerChange(update) : false);
+  }
+  destroy() {
+    for (let elt of this.elements)
+      elt.destroy();
+  }
+};
+var GutterElement = class {
+  constructor(view, height, above, markers) {
+    this.height = -1;
+    this.above = 0;
+    this.markers = [];
+    this.dom = document.createElement("div");
+    this.dom.className = "cm-gutterElement";
+    this.update(view, height, above, markers);
+  }
+  update(view, height, above, markers) {
+    if (this.height != height) {
+      this.height = height;
+      this.dom.style.height = height + "px";
+    }
+    if (this.above != above)
+      this.dom.style.marginTop = (this.above = above) ? above + "px" : "";
+    if (!sameMarkers(this.markers, markers))
+      this.setMarkers(view, markers);
+  }
+  setMarkers(view, markers) {
+    let cls = "cm-gutterElement", domPos = this.dom.firstChild;
+    for (let iNew = 0, iOld = 0; ; ) {
+      let skipTo = iOld, marker = iNew < markers.length ? markers[iNew++] : null, matched = false;
+      if (marker) {
+        let c = marker.elementClass;
+        if (c)
+          cls += " " + c;
+        for (let i2 = iOld; i2 < this.markers.length; i2++)
+          if (this.markers[i2].compare(marker)) {
+            skipTo = i2;
+            matched = true;
+            break;
+          }
+      } else {
+        skipTo = this.markers.length;
+      }
+      while (iOld < skipTo) {
+        let next = this.markers[iOld++];
+        if (next.toDOM) {
+          next.destroy(domPos);
+          let after = domPos.nextSibling;
+          domPos.remove();
+          domPos = after;
+        }
+      }
+      if (!marker)
+        break;
+      if (marker.toDOM) {
+        if (matched)
+          domPos = domPos.nextSibling;
+        else
+          this.dom.insertBefore(marker.toDOM(view), domPos);
+      }
+      if (matched)
+        iOld++;
+    }
+    this.dom.className = cls;
+    this.markers = markers;
+  }
+  destroy() {
+    this.setMarkers(null, []);
+  }
+};
+function sameMarkers(a, b) {
+  if (a.length != b.length)
+    return false;
+  for (let i2 = 0; i2 < a.length; i2++)
+    if (!a[i2].compare(b[i2]))
+      return false;
+  return true;
+}
+var lineNumberMarkers = /* @__PURE__ */ Facet.define();
+var lineNumberWidgetMarker = /* @__PURE__ */ Facet.define();
+var lineNumberConfig = /* @__PURE__ */ Facet.define({
+  combine(values) {
+    return combineConfig(values, { formatNumber: String, domEventHandlers: {} }, {
+      domEventHandlers(a, b) {
+        let result = Object.assign({}, a);
+        for (let event in b) {
+          let exists = result[event], add = b[event];
+          result[event] = exists ? (view, line, event2) => exists(view, line, event2) || add(view, line, event2) : add;
+        }
+        return result;
+      }
+    });
+  }
+});
+var NumberMarker = class extends GutterMarker {
+  constructor(number2) {
+    super();
+    this.number = number2;
+  }
+  eq(other) {
+    return this.number == other.number;
+  }
+  toDOM() {
+    return document.createTextNode(this.number);
+  }
+};
+function formatNumber(view, number2) {
+  return view.state.facet(lineNumberConfig).formatNumber(number2, view.state);
+}
+var lineNumberGutter = /* @__PURE__ */ activeGutters.compute([lineNumberConfig], (state) => ({
+  class: "cm-lineNumbers",
+  renderEmptyElements: false,
+  markers(view) {
+    return view.state.facet(lineNumberMarkers);
+  },
+  lineMarker(view, line, others) {
+    if (others.some((m) => m.toDOM))
+      return null;
+    return new NumberMarker(formatNumber(view, view.state.doc.lineAt(line.from).number));
+  },
+  widgetMarker: (view, widget, block) => {
+    for (let m of view.state.facet(lineNumberWidgetMarker)) {
+      let result = m(view, widget, block);
+      if (result)
+        return result;
+    }
+    return null;
+  },
+  lineMarkerChange: (update) => update.startState.facet(lineNumberConfig) != update.state.facet(lineNumberConfig),
+  initialSpacer(view) {
+    return new NumberMarker(formatNumber(view, maxLineNumber(view.state.doc.lines)));
+  },
+  updateSpacer(spacer, update) {
+    let max = formatNumber(update.view, maxLineNumber(update.view.state.doc.lines));
+    return max == spacer.number ? spacer : new NumberMarker(max);
+  },
+  domEventHandlers: state.facet(lineNumberConfig).domEventHandlers,
+  side: "before"
+}));
+function lineNumbers(config = {}) {
+  return [
+    lineNumberConfig.of(config),
+    gutters(),
+    lineNumberGutter
+  ];
+}
+function maxLineNumber(lines) {
+  let last = 9;
+  while (last < lines)
+    last = last * 10 + 9;
+  return last;
+}
+
+// node_modules/@lezer/common/dist/index.js
+var DefaultBufferLength = 1024;
+var nextPropID = 0;
+var Range2 = class {
+  constructor(from, to) {
+    this.from = from;
+    this.to = to;
+  }
+};
+var NodeProp = class {
+  /**
+  Create a new node prop type.
+  */
+  constructor(config = {}) {
+    this.id = nextPropID++;
+    this.perNode = !!config.perNode;
+    this.deserialize = config.deserialize || (() => {
+      throw new Error("This node type doesn't define a deserialize function");
+    });
+    this.combine = config.combine || null;
+  }
+  /**
+  This is meant to be used with
+  [`NodeSet.extend`](#common.NodeSet.extend) or
+  [`LRParser.configure`](#lr.ParserConfig.props) to compute
+  prop values for each node type in the set. Takes a [match
+  object](#common.NodeType^match) or function that returns undefined
+  if the node type doesn't get this prop, and the prop's value if
+  it does.
+  */
+  add(match) {
+    if (this.perNode)
+      throw new RangeError("Can't add per-node props to node types");
+    if (typeof match != "function")
+      match = NodeType.match(match);
+    return (type) => {
+      let result = match(type);
+      return result === void 0 ? null : [this, result];
+    };
+  }
+};
+NodeProp.closedBy = new NodeProp({ deserialize: (str) => str.split(" ") });
+NodeProp.openedBy = new NodeProp({ deserialize: (str) => str.split(" ") });
+NodeProp.group = new NodeProp({ deserialize: (str) => str.split(" ") });
+NodeProp.isolate = new NodeProp({ deserialize: (value) => {
+  if (value && value != "rtl" && value != "ltr" && value != "auto")
+    throw new RangeError("Invalid value for isolate: " + value);
+  return value || "auto";
+} });
+NodeProp.contextHash = new NodeProp({ perNode: true });
+NodeProp.lookAhead = new NodeProp({ perNode: true });
+NodeProp.mounted = new NodeProp({ perNode: true });
+var MountedTree = class {
+  constructor(tree, overlay, parser3, bracketed2 = false) {
+    this.tree = tree;
+    this.overlay = overlay;
+    this.parser = parser3;
+    this.bracketed = bracketed2;
+  }
+  /**
+  @internal
+  */
+  static get(tree) {
+    return tree && tree.props && tree.props[NodeProp.mounted.id];
+  }
+};
+var noProps = /* @__PURE__ */ Object.create(null);
+var NodeType = class _NodeType {
+  /**
+  @internal
+  */
+  constructor(name2, props, id2, flags = 0) {
+    this.name = name2;
+    this.props = props;
+    this.id = id2;
+    this.flags = flags;
+  }
+  /**
+  Define a node type.
+  */
+  static define(spec) {
+    let props = spec.props && spec.props.length ? /* @__PURE__ */ Object.create(null) : noProps;
+    let flags = (spec.top ? 1 : 0) | (spec.skipped ? 2 : 0) | (spec.error ? 4 : 0) | (spec.name == null ? 8 : 0);
+    let type = new _NodeType(spec.name || "", props, spec.id, flags);
+    if (spec.props)
+      for (let src of spec.props) {
+        if (!Array.isArray(src))
+          src = src(type);
+        if (src) {
+          if (src[0].perNode)
+            throw new RangeError("Can't store a per-node prop on a node type");
+          props[src[0].id] = src[1];
+        }
+      }
+    return type;
+  }
+  /**
+  Retrieves a node prop for this type. Will return `undefined` if
+  the prop isn't present on this node.
+  */
+  prop(prop) {
+    return this.props[prop.id];
+  }
+  /**
+  True when this is the top node of a grammar.
+  */
+  get isTop() {
+    return (this.flags & 1) > 0;
+  }
+  /**
+  True when this node is produced by a skip rule.
+  */
+  get isSkipped() {
+    return (this.flags & 2) > 0;
+  }
+  /**
+  Indicates whether this is an error node.
+  */
+  get isError() {
+    return (this.flags & 4) > 0;
+  }
+  /**
+  When true, this node type doesn't correspond to a user-declared
+  named node, for example because it is used to cache repetition.
+  */
+  get isAnonymous() {
+    return (this.flags & 8) > 0;
+  }
+  /**
+  Returns true when this node's name or one of its
+  [groups](#common.NodeProp^group) matches the given string.
+  */
+  is(name2) {
+    if (typeof name2 == "string") {
+      if (this.name == name2)
+        return true;
+      let group = this.prop(NodeProp.group);
+      return group ? group.indexOf(name2) > -1 : false;
+    }
+    return this.id == name2;
+  }
+  /**
+  Create a function from node types to arbitrary values by
+  specifying an object whose property names are node or
+  [group](#common.NodeProp^group) names. Often useful with
+  [`NodeProp.add`](#common.NodeProp.add). You can put multiple
+  names, separated by spaces, in a single property name to map
+  multiple node names to a single value.
+  */
+  static match(map) {
+    let direct = /* @__PURE__ */ Object.create(null);
+    for (let prop in map)
+      for (let name2 of prop.split(" "))
+        direct[name2] = map[prop];
+    return (node) => {
+      for (let groups = node.prop(NodeProp.group), i2 = -1; i2 < (groups ? groups.length : 0); i2++) {
+        let found = direct[i2 < 0 ? node.name : groups[i2]];
+        if (found)
+          return found;
+      }
+    };
+  }
+};
+NodeType.none = new NodeType(
+  "",
+  /* @__PURE__ */ Object.create(null),
+  0,
+  8
+  /* NodeFlag.Anonymous */
+);
+var NodeSet = class _NodeSet {
+  /**
+  Create a set with the given types. The `id` property of each
+  type should correspond to its position within the array.
+  */
+  constructor(types2) {
+    this.types = types2;
+    for (let i2 = 0; i2 < types2.length; i2++)
+      if (types2[i2].id != i2)
+        throw new RangeError("Node type ids should correspond to array positions when creating a node set");
+  }
+  /**
+  Create a copy of this set with some node properties added. The
+  arguments to this method can be created with
+  [`NodeProp.add`](#common.NodeProp.add).
+  */
+  extend(...props) {
+    let newTypes = [];
+    for (let type of this.types) {
+      let newProps = null;
+      for (let source of props) {
+        let add = source(type);
+        if (add) {
+          if (!newProps)
+            newProps = Object.assign({}, type.props);
+          let value = add[1], prop = add[0];
+          if (prop.combine && prop.id in newProps)
+            value = prop.combine(newProps[prop.id], value);
+          newProps[prop.id] = value;
+        }
+      }
+      newTypes.push(newProps ? new NodeType(type.name, newProps, type.id, type.flags) : type);
+    }
+    return new _NodeSet(newTypes);
+  }
+};
+var CachedNode = /* @__PURE__ */ new WeakMap();
+var CachedInnerNode = /* @__PURE__ */ new WeakMap();
+var IterMode;
+(function(IterMode2) {
+  IterMode2[IterMode2["ExcludeBuffers"] = 1] = "ExcludeBuffers";
+  IterMode2[IterMode2["IncludeAnonymous"] = 2] = "IncludeAnonymous";
+  IterMode2[IterMode2["IgnoreMounts"] = 4] = "IgnoreMounts";
+  IterMode2[IterMode2["IgnoreOverlays"] = 8] = "IgnoreOverlays";
+  IterMode2[IterMode2["EnterBracketed"] = 16] = "EnterBracketed";
+})(IterMode || (IterMode = {}));
+var Tree = class _Tree {
+  /**
+  Construct a new tree. See also [`Tree.build`](#common.Tree^build).
+  */
+  constructor(type, children, positions, length, props) {
+    this.type = type;
+    this.children = children;
+    this.positions = positions;
+    this.length = length;
+    this.props = null;
+    if (props && props.length) {
+      this.props = /* @__PURE__ */ Object.create(null);
+      for (let [prop, value] of props)
+        this.props[typeof prop == "number" ? prop : prop.id] = value;
+    }
+  }
+  /**
+  @internal
+  */
+  toString() {
+    let mounted = MountedTree.get(this);
+    if (mounted && !mounted.overlay)
+      return mounted.tree.toString();
+    let children = "";
+    for (let ch of this.children) {
+      let str = ch.toString();
+      if (str) {
+        if (children)
+          children += ",";
+        children += str;
+      }
+    }
+    return !this.type.name ? children : (/\W/.test(this.type.name) && !this.type.isError ? JSON.stringify(this.type.name) : this.type.name) + (children.length ? "(" + children + ")" : "");
+  }
+  /**
+  Get a [tree cursor](#common.TreeCursor) positioned at the top of
+  the tree. Mode can be used to [control](#common.IterMode) which
+  nodes the cursor visits.
+  */
+  cursor(mode = 0) {
+    return new TreeCursor(this.topNode, mode);
+  }
+  /**
+  Get a [tree cursor](#common.TreeCursor) pointing into this tree
+  at the given position and side (see
+  [`moveTo`](#common.TreeCursor.moveTo).
+  */
+  cursorAt(pos, side = 0, mode = 0) {
+    let scope = CachedNode.get(this) || this.topNode;
+    let cursor = new TreeCursor(scope);
+    cursor.moveTo(pos, side);
+    CachedNode.set(this, cursor._tree);
+    return cursor;
+  }
+  /**
+  Get a [syntax node](#common.SyntaxNode) object for the top of the
+  tree.
+  */
+  get topNode() {
+    return new TreeNode(this, 0, 0, null);
+  }
+  /**
+  Get the [syntax node](#common.SyntaxNode) at the given position.
+  If `side` is -1, this will move into nodes that end at the
+  position. If 1, it'll move into nodes that start at the
+  position. With 0, it'll only enter nodes that cover the position
+  from both sides.
+  
+  Note that this will not enter
+  [overlays](#common.MountedTree.overlay), and you often want
+  [`resolveInner`](#common.Tree.resolveInner) instead.
+  */
+  resolve(pos, side = 0) {
+    let node = resolveNode(CachedNode.get(this) || this.topNode, pos, side, false);
+    CachedNode.set(this, node);
+    return node;
+  }
+  /**
+  Like [`resolve`](#common.Tree.resolve), but will enter
+  [overlaid](#common.MountedTree.overlay) nodes, producing a syntax node
+  pointing into the innermost overlaid tree at the given position
+  (with parent links going through all parent structure, including
+  the host trees).
+  */
+  resolveInner(pos, side = 0) {
+    let node = resolveNode(CachedInnerNode.get(this) || this.topNode, pos, side, true);
+    CachedInnerNode.set(this, node);
+    return node;
+  }
+  /**
+  In some situations, it can be useful to iterate through all
+  nodes around a position, including those in overlays that don't
+  directly cover the position. This method gives you an iterator
+  that will produce all nodes, from small to big, around the given
+  position.
+  */
+  resolveStack(pos, side = 0) {
+    return stackIterator(this, pos, side);
+  }
+  /**
+  Iterate over the tree and its children, calling `enter` for any
+  node that touches the `from`/`to` region (if given) before
+  running over such a node's children, and `leave` (if given) when
+  leaving the node. When `enter` returns `false`, that node will
+  not have its children iterated over (or `leave` called).
+  */
+  iterate(spec) {
+    let { enter, leave, from = 0, to = this.length } = spec;
+    let mode = spec.mode || 0, anon = (mode & IterMode.IncludeAnonymous) > 0;
+    for (let c = this.cursor(mode | IterMode.IncludeAnonymous); ; ) {
+      let entered = false;
+      if (c.from <= to && c.to >= from && (!anon && c.type.isAnonymous || enter(c) !== false)) {
+        if (c.firstChild())
+          continue;
+        entered = true;
+      }
+      for (; ; ) {
+        if (entered && leave && (anon || !c.type.isAnonymous))
+          leave(c);
+        if (c.nextSibling())
+          break;
+        if (!c.parent())
+          return;
+        entered = true;
+      }
+    }
+  }
+  /**
+  Get the value of the given [node prop](#common.NodeProp) for this
+  node. Works with both per-node and per-type props.
+  */
+  prop(prop) {
+    return !prop.perNode ? this.type.prop(prop) : this.props ? this.props[prop.id] : void 0;
+  }
+  /**
+  Returns the node's [per-node props](#common.NodeProp.perNode) in a
+  format that can be passed to the [`Tree`](#common.Tree)
+  constructor.
+  */
+  get propValues() {
+    let result = [];
+    if (this.props)
+      for (let id2 in this.props)
+        result.push([+id2, this.props[id2]]);
+    return result;
+  }
+  /**
+  Balance the direct children of this tree, producing a copy of
+  which may have children grouped into subtrees with type
+  [`NodeType.none`](#common.NodeType^none).
+  */
+  balance(config = {}) {
+    return this.children.length <= 8 ? this : balanceRange(NodeType.none, this.children, this.positions, 0, this.children.length, 0, this.length, (children, positions, length) => new _Tree(this.type, children, positions, length, this.propValues), config.makeTree || ((children, positions, length) => new _Tree(NodeType.none, children, positions, length)));
+  }
+  /**
+  Build a tree from a postfix-ordered buffer of node information,
+  or a cursor over such a buffer.
+  */
+  static build(data) {
+    return buildTree(data);
+  }
+};
+Tree.empty = new Tree(NodeType.none, [], [], 0);
+var FlatBufferCursor = class _FlatBufferCursor {
+  constructor(buffer, index) {
+    this.buffer = buffer;
+    this.index = index;
+  }
+  get id() {
+    return this.buffer[this.index - 4];
+  }
+  get start() {
+    return this.buffer[this.index - 3];
+  }
+  get end() {
+    return this.buffer[this.index - 2];
+  }
+  get size() {
+    return this.buffer[this.index - 1];
+  }
+  get pos() {
+    return this.index;
+  }
+  next() {
+    this.index -= 4;
+  }
+  fork() {
+    return new _FlatBufferCursor(this.buffer, this.index);
+  }
+};
+var TreeBuffer = class _TreeBuffer {
+  /**
+  Create a tree buffer.
+  */
+  constructor(buffer, length, set) {
+    this.buffer = buffer;
+    this.length = length;
+    this.set = set;
+  }
+  /**
+  @internal
+  */
+  get type() {
+    return NodeType.none;
+  }
+  /**
+  @internal
+  */
+  toString() {
+    let result = [];
+    for (let index = 0; index < this.buffer.length; ) {
+      result.push(this.childString(index));
+      index = this.buffer[index + 3];
+    }
+    return result.join(",");
+  }
+  /**
+  @internal
+  */
+  childString(index) {
+    let id2 = this.buffer[index], endIndex = this.buffer[index + 3];
+    let type = this.set.types[id2], result = type.name;
+    if (/\W/.test(result) && !type.isError)
+      result = JSON.stringify(result);
+    index += 4;
+    if (endIndex == index)
+      return result;
+    let children = [];
+    while (index < endIndex) {
+      children.push(this.childString(index));
+      index = this.buffer[index + 3];
+    }
+    return result + "(" + children.join(",") + ")";
+  }
+  /**
+  @internal
+  */
+  findChild(startIndex, endIndex, dir, pos, side) {
+    let { buffer } = this, pick = -1;
+    for (let i2 = startIndex; i2 != endIndex; i2 = buffer[i2 + 3]) {
+      if (checkSide(side, pos, buffer[i2 + 1], buffer[i2 + 2])) {
+        pick = i2;
+        if (dir > 0)
+          break;
+      }
+    }
+    return pick;
+  }
+  /**
+  @internal
+  */
+  slice(startI, endI, from) {
+    let b = this.buffer;
+    let copy = new Uint16Array(endI - startI), len = 0;
+    for (let i2 = startI, j = 0; i2 < endI; ) {
+      copy[j++] = b[i2++];
+      copy[j++] = b[i2++] - from;
+      let to = copy[j++] = b[i2++] - from;
+      copy[j++] = b[i2++] - startI;
+      len = Math.max(len, to);
+    }
+    return new _TreeBuffer(copy, len, this.set);
+  }
+};
+function checkSide(side, pos, from, to) {
+  switch (side) {
+    case -2:
+      return from < pos;
+    case -1:
+      return to >= pos && from < pos;
+    case 0:
+      return from < pos && to > pos;
+    case 1:
+      return from <= pos && to > pos;
+    case 2:
+      return to > pos;
+    case 4:
+      return true;
+  }
+}
+function resolveNode(node, pos, side, overlays) {
+  var _a2;
+  while (node.from == node.to || (side < 1 ? node.from >= pos : node.from > pos) || (side > -1 ? node.to <= pos : node.to < pos)) {
+    let parent = !overlays && node instanceof TreeNode && node.index < 0 ? null : node.parent;
+    if (!parent)
+      return node;
+    node = parent;
+  }
+  let mode = overlays ? 0 : IterMode.IgnoreOverlays;
+  if (overlays)
+    for (let scan = node, parent = scan.parent; parent; scan = parent, parent = scan.parent) {
+      if (scan instanceof TreeNode && scan.index < 0 && ((_a2 = parent.enter(pos, side, mode)) === null || _a2 === void 0 ? void 0 : _a2.from) != scan.from)
+        node = parent;
+    }
+  for (; ; ) {
+    let inner = node.enter(pos, side, mode);
+    if (!inner)
+      return node;
+    node = inner;
+  }
+}
+var BaseNode = class {
+  cursor(mode = 0) {
+    return new TreeCursor(this, mode);
+  }
+  getChild(type, before = null, after = null) {
+    let r2 = getChildren(this, type, before, after);
+    return r2.length ? r2[0] : null;
+  }
+  getChildren(type, before = null, after = null) {
+    return getChildren(this, type, before, after);
+  }
+  resolve(pos, side = 0) {
+    return resolveNode(this, pos, side, false);
+  }
+  resolveInner(pos, side = 0) {
+    return resolveNode(this, pos, side, true);
+  }
+  matchContext(context) {
+    return matchNodeContext(this.parent, context);
+  }
+  enterUnfinishedNodesBefore(pos) {
+    let scan = this.childBefore(pos), node = this;
+    while (scan) {
+      let last = scan.lastChild;
+      if (!last || last.to != scan.to)
+        break;
+      if (last.type.isError && last.from == last.to) {
+        node = scan;
+        scan = last.prevSibling;
+      } else {
+        scan = last;
+      }
+    }
+    return node;
+  }
+  get node() {
+    return this;
+  }
+  get next() {
+    return this.parent;
+  }
+};
+var TreeNode = class _TreeNode extends BaseNode {
+  constructor(_tree, from, index, _parent) {
+    super();
+    this._tree = _tree;
+    this.from = from;
+    this.index = index;
+    this._parent = _parent;
+  }
+  get type() {
+    return this._tree.type;
+  }
+  get name() {
+    return this._tree.type.name;
+  }
+  get to() {
+    return this.from + this._tree.length;
+  }
+  nextChild(i2, dir, pos, side, mode = 0) {
+    for (let parent = this; ; ) {
+      for (let { children, positions } = parent._tree, e = dir > 0 ? children.length : -1; i2 != e; i2 += dir) {
+        let next = children[i2], start = positions[i2] + parent.from, mounted;
+        if (!(mode & IterMode.EnterBracketed && next instanceof Tree && (mounted = MountedTree.get(next)) && !mounted.overlay && mounted.bracketed && pos >= start && pos <= start + next.length) && !checkSide(side, pos, start, start + next.length))
+          continue;
+        if (next instanceof TreeBuffer) {
+          if (mode & IterMode.ExcludeBuffers)
+            continue;
+          let index = next.findChild(0, next.buffer.length, dir, pos - start, side);
+          if (index > -1)
+            return new BufferNode(new BufferContext(parent, next, i2, start), null, index);
+        } else if (mode & IterMode.IncludeAnonymous || (!next.type.isAnonymous || hasChild(next))) {
+          let mounted2;
+          if (!(mode & IterMode.IgnoreMounts) && (mounted2 = MountedTree.get(next)) && !mounted2.overlay)
+            return new _TreeNode(mounted2.tree, start, i2, parent);
+          let inner = new _TreeNode(next, start, i2, parent);
+          return mode & IterMode.IncludeAnonymous || !inner.type.isAnonymous ? inner : inner.nextChild(dir < 0 ? next.children.length - 1 : 0, dir, pos, side, mode);
+        }
+      }
+      if (mode & IterMode.IncludeAnonymous || !parent.type.isAnonymous)
+        return null;
+      if (parent.index >= 0)
+        i2 = parent.index + dir;
+      else
+        i2 = dir < 0 ? -1 : parent._parent._tree.children.length;
+      parent = parent._parent;
+      if (!parent)
+        return null;
+    }
+  }
+  get firstChild() {
+    return this.nextChild(
+      0,
+      1,
+      0,
+      4
+      /* Side.DontCare */
+    );
+  }
+  get lastChild() {
+    return this.nextChild(
+      this._tree.children.length - 1,
+      -1,
+      0,
+      4
+      /* Side.DontCare */
+    );
+  }
+  childAfter(pos) {
+    return this.nextChild(
+      0,
+      1,
+      pos,
+      2
+      /* Side.After */
+    );
+  }
+  childBefore(pos) {
+    return this.nextChild(
+      this._tree.children.length - 1,
+      -1,
+      pos,
+      -2
+      /* Side.Before */
+    );
+  }
+  prop(prop) {
+    return this._tree.prop(prop);
+  }
+  enter(pos, side, mode = 0) {
+    let mounted;
+    if (!(mode & IterMode.IgnoreOverlays) && (mounted = MountedTree.get(this._tree)) && mounted.overlay) {
+      let rPos = pos - this.from, enterBracketed = mode & IterMode.EnterBracketed && mounted.bracketed;
+      for (let { from, to } of mounted.overlay) {
+        if ((side > 0 || enterBracketed ? from <= rPos : from < rPos) && (side < 0 || enterBracketed ? to >= rPos : to > rPos))
+          return new _TreeNode(mounted.tree, mounted.overlay[0].from + this.from, -1, this);
+      }
+    }
+    return this.nextChild(0, 1, pos, side, mode);
+  }
+  nextSignificantParent() {
+    let val = this;
+    while (val.type.isAnonymous && val._parent)
+      val = val._parent;
+    return val;
+  }
+  get parent() {
+    return this._parent ? this._parent.nextSignificantParent() : null;
+  }
+  get nextSibling() {
+    return this._parent && this.index >= 0 ? this._parent.nextChild(
+      this.index + 1,
+      1,
+      0,
+      4
+      /* Side.DontCare */
+    ) : null;
+  }
+  get prevSibling() {
+    return this._parent && this.index >= 0 ? this._parent.nextChild(
+      this.index - 1,
+      -1,
+      0,
+      4
+      /* Side.DontCare */
+    ) : null;
+  }
+  get tree() {
+    return this._tree;
+  }
+  toTree() {
+    return this._tree;
+  }
+  /**
+  @internal
+  */
+  toString() {
+    return this._tree.toString();
+  }
+};
+function getChildren(node, type, before, after) {
+  let cur = node.cursor(), result = [];
+  if (!cur.firstChild())
+    return result;
+  if (before != null)
+    for (let found = false; !found; ) {
+      found = cur.type.is(before);
+      if (!cur.nextSibling())
+        return result;
+    }
+  for (; ; ) {
+    if (after != null && cur.type.is(after))
+      return result;
+    if (cur.type.is(type))
+      result.push(cur.node);
+    if (!cur.nextSibling())
+      return after == null ? result : [];
+  }
+}
+function matchNodeContext(node, context, i2 = context.length - 1) {
+  for (let p = node; i2 >= 0; p = p.parent) {
+    if (!p)
+      return false;
+    if (!p.type.isAnonymous) {
+      if (context[i2] && context[i2] != p.name)
+        return false;
+      i2--;
+    }
+  }
+  return true;
+}
+var BufferContext = class {
+  constructor(parent, buffer, index, start) {
+    this.parent = parent;
+    this.buffer = buffer;
+    this.index = index;
+    this.start = start;
+  }
+};
+var BufferNode = class _BufferNode extends BaseNode {
+  get name() {
+    return this.type.name;
+  }
+  get from() {
+    return this.context.start + this.context.buffer.buffer[this.index + 1];
+  }
+  get to() {
+    return this.context.start + this.context.buffer.buffer[this.index + 2];
+  }
+  constructor(context, _parent, index) {
+    super();
+    this.context = context;
+    this._parent = _parent;
+    this.index = index;
+    this.type = context.buffer.set.types[context.buffer.buffer[index]];
+  }
+  child(dir, pos, side) {
+    let { buffer } = this.context;
+    let index = buffer.findChild(this.index + 4, buffer.buffer[this.index + 3], dir, pos - this.context.start, side);
+    return index < 0 ? null : new _BufferNode(this.context, this, index);
+  }
+  get firstChild() {
+    return this.child(
+      1,
+      0,
+      4
+      /* Side.DontCare */
+    );
+  }
+  get lastChild() {
+    return this.child(
+      -1,
+      0,
+      4
+      /* Side.DontCare */
+    );
+  }
+  childAfter(pos) {
+    return this.child(
+      1,
+      pos,
+      2
+      /* Side.After */
+    );
+  }
+  childBefore(pos) {
+    return this.child(
+      -1,
+      pos,
+      -2
+      /* Side.Before */
+    );
+  }
+  prop(prop) {
+    return this.type.prop(prop);
+  }
+  enter(pos, side, mode = 0) {
+    if (mode & IterMode.ExcludeBuffers)
+      return null;
+    let { buffer } = this.context;
+    let index = buffer.findChild(this.index + 4, buffer.buffer[this.index + 3], side > 0 ? 1 : -1, pos - this.context.start, side);
+    return index < 0 ? null : new _BufferNode(this.context, this, index);
+  }
+  get parent() {
+    return this._parent || this.context.parent.nextSignificantParent();
+  }
+  externalSibling(dir) {
+    return this._parent ? null : this.context.parent.nextChild(
+      this.context.index + dir,
+      dir,
+      0,
+      4
+      /* Side.DontCare */
+    );
+  }
+  get nextSibling() {
+    let { buffer } = this.context;
+    let after = buffer.buffer[this.index + 3];
+    if (after < (this._parent ? buffer.buffer[this._parent.index + 3] : buffer.buffer.length))
+      return new _BufferNode(this.context, this._parent, after);
+    return this.externalSibling(1);
+  }
+  get prevSibling() {
+    let { buffer } = this.context;
+    let parentStart = this._parent ? this._parent.index + 4 : 0;
+    if (this.index == parentStart)
+      return this.externalSibling(-1);
+    return new _BufferNode(this.context, this._parent, buffer.findChild(
+      parentStart,
+      this.index,
+      -1,
+      0,
+      4
+      /* Side.DontCare */
+    ));
+  }
+  get tree() {
+    return null;
+  }
+  toTree() {
+    let children = [], positions = [];
+    let { buffer } = this.context;
+    let startI = this.index + 4, endI = buffer.buffer[this.index + 3];
+    if (endI > startI) {
+      let from = buffer.buffer[this.index + 1];
+      children.push(buffer.slice(startI, endI, from));
+      positions.push(0);
+    }
+    return new Tree(this.type, children, positions, this.to - this.from);
+  }
+  /**
+  @internal
+  */
+  toString() {
+    return this.context.buffer.childString(this.index);
+  }
+};
+function iterStack(heads) {
+  if (!heads.length)
+    return null;
+  let pick = 0, picked = heads[0];
+  for (let i2 = 1; i2 < heads.length; i2++) {
+    let node = heads[i2];
+    if (node.from > picked.from || node.to < picked.to) {
+      picked = node;
+      pick = i2;
+    }
+  }
+  let next = picked instanceof TreeNode && picked.index < 0 ? null : picked.parent;
+  let newHeads = heads.slice();
+  if (next)
+    newHeads[pick] = next;
+  else
+    newHeads.splice(pick, 1);
+  return new StackIterator(newHeads, picked);
+}
+var StackIterator = class {
+  constructor(heads, node) {
+    this.heads = heads;
+    this.node = node;
+  }
+  get next() {
+    return iterStack(this.heads);
+  }
+};
+function stackIterator(tree, pos, side) {
+  let inner = tree.resolveInner(pos, side), layers = null;
+  for (let scan = inner instanceof TreeNode ? inner : inner.context.parent; scan; scan = scan.parent) {
+    if (scan.index < 0) {
+      let parent = scan.parent;
+      (layers || (layers = [inner])).push(parent.resolve(pos, side));
+      scan = parent;
+    } else {
+      let mount = MountedTree.get(scan.tree);
+      if (mount && mount.overlay && mount.overlay[0].from <= pos && mount.overlay[mount.overlay.length - 1].to >= pos) {
+        let root = new TreeNode(mount.tree, mount.overlay[0].from + scan.from, -1, scan);
+        (layers || (layers = [inner])).push(resolveNode(root, pos, side, false));
+      }
+    }
+  }
+  return layers ? iterStack(layers) : inner;
+}
+var TreeCursor = class {
+  /**
+  Shorthand for `.type.name`.
+  */
+  get name() {
+    return this.type.name;
+  }
+  /**
+  @internal
+  */
+  constructor(node, mode = 0) {
+    this.buffer = null;
+    this.stack = [];
+    this.index = 0;
+    this.bufferNode = null;
+    this.mode = mode & ~IterMode.EnterBracketed;
+    if (node instanceof TreeNode) {
+      this.yieldNode(node);
+    } else {
+      this._tree = node.context.parent;
+      this.buffer = node.context;
+      for (let n = node._parent; n; n = n._parent)
+        this.stack.unshift(n.index);
+      this.bufferNode = node;
+      this.yieldBuf(node.index);
+    }
+  }
+  yieldNode(node) {
+    if (!node)
+      return false;
+    this._tree = node;
+    this.type = node.type;
+    this.from = node.from;
+    this.to = node.to;
+    return true;
+  }
+  yieldBuf(index, type) {
+    this.index = index;
+    let { start, buffer } = this.buffer;
+    this.type = type || buffer.set.types[buffer.buffer[index]];
+    this.from = start + buffer.buffer[index + 1];
+    this.to = start + buffer.buffer[index + 2];
+    return true;
+  }
+  /**
+  @internal
+  */
+  yield(node) {
+    if (!node)
+      return false;
+    if (node instanceof TreeNode) {
+      this.buffer = null;
+      return this.yieldNode(node);
+    }
+    this.buffer = node.context;
+    return this.yieldBuf(node.index, node.type);
+  }
+  /**
+  @internal
+  */
+  toString() {
+    return this.buffer ? this.buffer.buffer.childString(this.index) : this._tree.toString();
+  }
+  /**
+  @internal
+  */
+  enterChild(dir, pos, side) {
+    if (!this.buffer)
+      return this.yield(this._tree.nextChild(dir < 0 ? this._tree._tree.children.length - 1 : 0, dir, pos, side, this.mode));
+    let { buffer } = this.buffer;
+    let index = buffer.findChild(this.index + 4, buffer.buffer[this.index + 3], dir, pos - this.buffer.start, side);
+    if (index < 0)
+      return false;
+    this.stack.push(this.index);
+    return this.yieldBuf(index);
+  }
+  /**
+  Move the cursor to this node's first child. When this returns
+  false, the node has no child, and the cursor has not been moved.
+  */
+  firstChild() {
+    return this.enterChild(
+      1,
+      0,
+      4
+      /* Side.DontCare */
+    );
+  }
+  /**
+  Move the cursor to this node's last child.
+  */
+  lastChild() {
+    return this.enterChild(
+      -1,
+      0,
+      4
+      /* Side.DontCare */
+    );
+  }
+  /**
+  Move the cursor to the first child that ends after `pos`.
+  */
+  childAfter(pos) {
+    return this.enterChild(
+      1,
+      pos,
+      2
+      /* Side.After */
+    );
+  }
+  /**
+  Move to the last child that starts before `pos`.
+  */
+  childBefore(pos) {
+    return this.enterChild(
+      -1,
+      pos,
+      -2
+      /* Side.Before */
+    );
+  }
+  /**
+  Move the cursor to the child around `pos`. If side is -1 the
+  child may end at that position, when 1 it may start there. This
+  will also enter [overlaid](#common.MountedTree.overlay)
+  [mounted](#common.NodeProp^mounted) trees unless `overlays` is
+  set to false.
+  */
+  enter(pos, side, mode = this.mode) {
+    if (!this.buffer)
+      return this.yield(this._tree.enter(pos, side, mode));
+    return mode & IterMode.ExcludeBuffers ? false : this.enterChild(1, pos, side);
+  }
+  /**
+  Move to the node's parent node, if this isn't the top node.
+  */
+  parent() {
+    if (!this.buffer)
+      return this.yieldNode(this.mode & IterMode.IncludeAnonymous ? this._tree._parent : this._tree.parent);
+    if (this.stack.length)
+      return this.yieldBuf(this.stack.pop());
+    let parent = this.mode & IterMode.IncludeAnonymous ? this.buffer.parent : this.buffer.parent.nextSignificantParent();
+    this.buffer = null;
+    return this.yieldNode(parent);
+  }
+  /**
+  @internal
+  */
+  sibling(dir) {
+    if (!this.buffer)
+      return !this._tree._parent ? false : this.yield(this._tree.index < 0 ? null : this._tree._parent.nextChild(this._tree.index + dir, dir, 0, 4, this.mode));
+    let { buffer } = this.buffer, d = this.stack.length - 1;
+    if (dir < 0) {
+      let parentStart = d < 0 ? 0 : this.stack[d] + 4;
+      if (this.index != parentStart)
+        return this.yieldBuf(buffer.findChild(
+          parentStart,
+          this.index,
+          -1,
+          0,
+          4
+          /* Side.DontCare */
+        ));
+    } else {
+      let after = buffer.buffer[this.index + 3];
+      if (after < (d < 0 ? buffer.buffer.length : buffer.buffer[this.stack[d] + 3]))
+        return this.yieldBuf(after);
+    }
+    return d < 0 ? this.yield(this.buffer.parent.nextChild(this.buffer.index + dir, dir, 0, 4, this.mode)) : false;
+  }
+  /**
+  Move to this node's next sibling, if any.
+  */
+  nextSibling() {
+    return this.sibling(1);
+  }
+  /**
+  Move to this node's previous sibling, if any.
+  */
+  prevSibling() {
+    return this.sibling(-1);
+  }
+  atLastNode(dir) {
+    let index, parent, { buffer } = this;
+    if (buffer) {
+      if (dir > 0) {
+        if (this.index < buffer.buffer.buffer.length)
+          return false;
+      } else {
+        for (let i2 = 0; i2 < this.index; i2++)
+          if (buffer.buffer.buffer[i2 + 3] < this.index)
+            return false;
+      }
+      ({ index, parent } = buffer);
+    } else {
+      ({ index, _parent: parent } = this._tree);
+    }
+    for (; parent; { index, _parent: parent } = parent) {
+      if (index > -1)
+        for (let i2 = index + dir, e = dir < 0 ? -1 : parent._tree.children.length; i2 != e; i2 += dir) {
+          let child = parent._tree.children[i2];
+          if (this.mode & IterMode.IncludeAnonymous || child instanceof TreeBuffer || !child.type.isAnonymous || hasChild(child))
+            return false;
+        }
+    }
+    return true;
+  }
+  move(dir, enter) {
+    if (enter && this.enterChild(
+      dir,
+      0,
+      4
+      /* Side.DontCare */
+    ))
+      return true;
+    for (; ; ) {
+      if (this.sibling(dir))
+        return true;
+      if (this.atLastNode(dir) || !this.parent())
+        return false;
+    }
+  }
+  /**
+  Move to the next node in a
+  [pre-order](https://en.wikipedia.org/wiki/Tree_traversal#Pre-order,_NLR)
+  traversal, going from a node to its first child or, if the
+  current node is empty or `enter` is false, its next sibling or
+  the next sibling of the first parent node that has one.
+  */
+  next(enter = true) {
+    return this.move(1, enter);
+  }
+  /**
+  Move to the next node in a last-to-first pre-order traversal. A
+  node is followed by its last child or, if it has none, its
+  previous sibling or the previous sibling of the first parent
+  node that has one.
+  */
+  prev(enter = true) {
+    return this.move(-1, enter);
+  }
+  /**
+  Move the cursor to the innermost node that covers `pos`. If
+  `side` is -1, it will enter nodes that end at `pos`. If it is 1,
+  it will enter nodes that start at `pos`.
+  */
+  moveTo(pos, side = 0) {
+    while (this.from == this.to || (side < 1 ? this.from >= pos : this.from > pos) || (side > -1 ? this.to <= pos : this.to < pos))
+      if (!this.parent())
+        break;
+    while (this.enterChild(1, pos, side)) {
+    }
+    return this;
+  }
+  /**
+  Get a [syntax node](#common.SyntaxNode) at the cursor's current
+  position.
+  */
+  get node() {
+    if (!this.buffer)
+      return this._tree;
+    let cache2 = this.bufferNode, result = null, depth = 0;
+    if (cache2 && cache2.context == this.buffer) {
+      scan: for (let index = this.index, d = this.stack.length; d >= 0; ) {
+        for (let c = cache2; c; c = c._parent)
+          if (c.index == index) {
+            if (index == this.index)
+              return c;
+            result = c;
+            depth = d + 1;
+            break scan;
+          }
+        index = this.stack[--d];
+      }
+    }
+    for (let i2 = depth; i2 < this.stack.length; i2++)
+      result = new BufferNode(this.buffer, result, this.stack[i2]);
+    return this.bufferNode = new BufferNode(this.buffer, result, this.index);
+  }
+  /**
+  Get the [tree](#common.Tree) that represents the current node, if
+  any. Will return null when the node is in a [tree
+  buffer](#common.TreeBuffer).
+  */
+  get tree() {
+    return this.buffer ? null : this._tree._tree;
+  }
+  /**
+  Iterate over the current node and all its descendants, calling
+  `enter` when entering a node and `leave`, if given, when leaving
+  one. When `enter` returns `false`, any children of that node are
+  skipped, and `leave` isn't called for it.
+  */
+  iterate(enter, leave) {
+    for (let depth = 0; ; ) {
+      let mustLeave = false;
+      if (this.type.isAnonymous || enter(this) !== false) {
+        if (this.firstChild()) {
+          depth++;
+          continue;
+        }
+        if (!this.type.isAnonymous)
+          mustLeave = true;
+      }
+      for (; ; ) {
+        if (mustLeave && leave)
+          leave(this);
+        mustLeave = this.type.isAnonymous;
+        if (!depth)
+          return;
+        if (this.nextSibling())
+          break;
+        this.parent();
+        depth--;
+        mustLeave = true;
+      }
+    }
+  }
+  /**
+  Test whether the current node matches a given context—a sequence
+  of direct parent node names. Empty strings in the context array
+  are treated as wildcards.
+  */
+  matchContext(context) {
+    if (!this.buffer)
+      return matchNodeContext(this.node.parent, context);
+    let { buffer } = this.buffer, { types: types2 } = buffer.set;
+    for (let i2 = context.length - 1, d = this.stack.length - 1; i2 >= 0; d--) {
+      if (d < 0)
+        return matchNodeContext(this._tree, context, i2);
+      let type = types2[buffer.buffer[this.stack[d]]];
+      if (!type.isAnonymous) {
+        if (context[i2] && context[i2] != type.name)
+          return false;
+        i2--;
+      }
+    }
+    return true;
+  }
+};
+function hasChild(tree) {
+  return tree.children.some((ch) => ch instanceof TreeBuffer || !ch.type.isAnonymous || hasChild(ch));
+}
+function buildTree(data) {
+  var _a2;
+  let { buffer, nodeSet, maxBufferLength = DefaultBufferLength, reused = [], minRepeatType = nodeSet.types.length } = data;
+  let cursor = Array.isArray(buffer) ? new FlatBufferCursor(buffer, buffer.length) : buffer;
+  let types2 = nodeSet.types;
+  let contextHash = 0, lookAhead = 0;
+  function takeNode(parentStart, minPos, children2, positions2, inRepeat, depth) {
+    let { id: id2, start, end, size } = cursor;
+    let lookAheadAtStart = lookAhead, contextAtStart = contextHash;
+    if (size < 0) {
+      cursor.next();
+      if (size == -1) {
+        let node2 = reused[id2];
+        children2.push(node2);
+        positions2.push(start - parentStart);
+        return;
+      } else if (size == -3) {
+        contextHash = id2;
+        return;
+      } else if (size == -4) {
+        lookAhead = id2;
+        return;
+      } else {
+        throw new RangeError(`Unrecognized record size: ${size}`);
+      }
+    }
+    let type = types2[id2], node, buffer2;
+    let startPos = start - parentStart;
+    if (end - start <= maxBufferLength && (buffer2 = findBufferSize(cursor.pos - minPos, inRepeat))) {
+      let data2 = new Uint16Array(buffer2.size - buffer2.skip);
+      let endPos = cursor.pos - buffer2.size, index = data2.length;
+      while (cursor.pos > endPos)
+        index = copyToBuffer(buffer2.start, data2, index);
+      node = new TreeBuffer(data2, end - buffer2.start, nodeSet);
+      startPos = buffer2.start - parentStart;
+    } else {
+      let endPos = cursor.pos - size;
+      cursor.next();
+      let localChildren = [], localPositions = [];
+      let localInRepeat = id2 >= minRepeatType ? id2 : -1;
+      let lastGroup = 0, lastEnd = end;
+      while (cursor.pos > endPos) {
+        if (localInRepeat >= 0 && cursor.id == localInRepeat && cursor.size >= 0) {
+          if (cursor.end <= lastEnd - maxBufferLength) {
+            makeRepeatLeaf(localChildren, localPositions, start, lastGroup, cursor.end, lastEnd, localInRepeat, lookAheadAtStart, contextAtStart);
+            lastGroup = localChildren.length;
+            lastEnd = cursor.end;
+          }
+          cursor.next();
+        } else if (depth > 2500) {
+          takeFlatNode(start, endPos, localChildren, localPositions);
+        } else {
+          takeNode(start, endPos, localChildren, localPositions, localInRepeat, depth + 1);
+        }
+      }
+      if (localInRepeat >= 0 && lastGroup > 0 && lastGroup < localChildren.length)
+        makeRepeatLeaf(localChildren, localPositions, start, lastGroup, start, lastEnd, localInRepeat, lookAheadAtStart, contextAtStart);
+      localChildren.reverse();
+      localPositions.reverse();
+      if (localInRepeat > -1 && lastGroup > 0) {
+        let make = makeBalanced(type, contextAtStart);
+        node = balanceRange(type, localChildren, localPositions, 0, localChildren.length, 0, end - start, make, make);
+      } else {
+        node = makeTree(type, localChildren, localPositions, end - start, lookAheadAtStart - end, contextAtStart);
+      }
+    }
+    children2.push(node);
+    positions2.push(startPos);
+  }
+  function takeFlatNode(parentStart, minPos, children2, positions2) {
+    let nodes = [];
+    let nodeCount = 0, stopAt = -1;
+    while (cursor.pos > minPos) {
+      let { id: id2, start, end, size } = cursor;
+      if (size > 4) {
+        cursor.next();
+      } else if (stopAt > -1 && start < stopAt) {
+        break;
+      } else {
+        if (stopAt < 0)
+          stopAt = end - maxBufferLength;
+        nodes.push(id2, start, end);
+        nodeCount++;
+        cursor.next();
+      }
+    }
+    if (nodeCount) {
+      let buffer2 = new Uint16Array(nodeCount * 4);
+      let start = nodes[nodes.length - 2];
+      for (let i2 = nodes.length - 3, j = 0; i2 >= 0; i2 -= 3) {
+        buffer2[j++] = nodes[i2];
+        buffer2[j++] = nodes[i2 + 1] - start;
+        buffer2[j++] = nodes[i2 + 2] - start;
+        buffer2[j++] = j;
+      }
+      children2.push(new TreeBuffer(buffer2, nodes[2] - start, nodeSet));
+      positions2.push(start - parentStart);
+    }
+  }
+  function makeBalanced(type, contextHash2) {
+    return (children2, positions2, length2) => {
+      let lookAhead2 = 0, lastI = children2.length - 1, last, lookAheadProp;
+      if (lastI >= 0 && (last = children2[lastI]) instanceof Tree) {
+        if (!lastI && last.type == type && last.length == length2)
+          return last;
+        if (lookAheadProp = last.prop(NodeProp.lookAhead))
+          lookAhead2 = positions2[lastI] + last.length + lookAheadProp;
+      }
+      return makeTree(type, children2, positions2, length2, lookAhead2, contextHash2);
+    };
+  }
+  function makeRepeatLeaf(children2, positions2, base2, i2, from, to, type, lookAhead2, contextHash2) {
+    let localChildren = [], localPositions = [];
+    while (children2.length > i2) {
+      localChildren.push(children2.pop());
+      localPositions.push(positions2.pop() + base2 - from);
+    }
+    children2.push(makeTree(nodeSet.types[type], localChildren, localPositions, to - from, lookAhead2 - to, contextHash2));
+    positions2.push(from - base2);
+  }
+  function makeTree(type, children2, positions2, length2, lookAhead2, contextHash2, props) {
+    if (contextHash2) {
+      let pair2 = [NodeProp.contextHash, contextHash2];
+      props = props ? [pair2].concat(props) : [pair2];
+    }
+    if (lookAhead2 > 25) {
+      let pair2 = [NodeProp.lookAhead, lookAhead2];
+      props = props ? [pair2].concat(props) : [pair2];
+    }
+    return new Tree(type, children2, positions2, length2, props);
+  }
+  function findBufferSize(maxSize, inRepeat) {
+    let fork = cursor.fork();
+    let size = 0, start = 0, skip = 0, minStart = fork.end - maxBufferLength;
+    let result = { size: 0, start: 0, skip: 0 };
+    scan: for (let minPos = fork.pos - maxSize; fork.pos > minPos; ) {
+      let nodeSize2 = fork.size;
+      if (fork.id == inRepeat && nodeSize2 >= 0) {
+        result.size = size;
+        result.start = start;
+        result.skip = skip;
+        skip += 4;
+        size += 4;
+        fork.next();
+        continue;
+      }
+      let startPos = fork.pos - nodeSize2;
+      if (nodeSize2 < 0 || startPos < minPos || fork.start < minStart)
+        break;
+      let localSkipped = fork.id >= minRepeatType ? 4 : 0;
+      let nodeStart = fork.start;
+      fork.next();
+      while (fork.pos > startPos) {
+        if (fork.size < 0) {
+          if (fork.size == -3 || fork.size == -4)
+            localSkipped += 4;
+          else
+            break scan;
+        } else if (fork.id >= minRepeatType) {
+          localSkipped += 4;
+        }
+        fork.next();
+      }
+      start = nodeStart;
+      size += nodeSize2;
+      skip += localSkipped;
+    }
+    if (inRepeat < 0 || size == maxSize) {
+      result.size = size;
+      result.start = start;
+      result.skip = skip;
+    }
+    return result.size > 4 ? result : void 0;
+  }
+  function copyToBuffer(bufferStart, buffer2, index) {
+    let { id: id2, start, end, size } = cursor;
+    cursor.next();
+    if (size >= 0 && id2 < minRepeatType) {
+      let startIndex = index;
+      if (size > 4) {
+        let endPos = cursor.pos - (size - 4);
+        while (cursor.pos > endPos)
+          index = copyToBuffer(bufferStart, buffer2, index);
+      }
+      buffer2[--index] = startIndex;
+      buffer2[--index] = end - bufferStart;
+      buffer2[--index] = start - bufferStart;
+      buffer2[--index] = id2;
+    } else if (size == -3) {
+      contextHash = id2;
+    } else if (size == -4) {
+      lookAhead = id2;
+    }
+    return index;
+  }
+  let children = [], positions = [];
+  while (cursor.pos > 0)
+    takeNode(data.start || 0, data.bufferStart || 0, children, positions, -1, 0);
+  let length = (_a2 = data.length) !== null && _a2 !== void 0 ? _a2 : children.length ? positions[0] + children[0].length : 0;
+  return new Tree(types2[data.topID], children.reverse(), positions.reverse(), length);
+}
+var nodeSizeCache = /* @__PURE__ */ new WeakMap();
+function nodeSize(balanceType, node) {
+  if (!balanceType.isAnonymous || node instanceof TreeBuffer || node.type != balanceType)
+    return 1;
+  let size = nodeSizeCache.get(node);
+  if (size == null) {
+    size = 1;
+    for (let child of node.children) {
+      if (child.type != balanceType || !(child instanceof Tree)) {
+        size = 1;
+        break;
+      }
+      size += nodeSize(balanceType, child);
+    }
+    nodeSizeCache.set(node, size);
+  }
+  return size;
+}
+function balanceRange(balanceType, children, positions, from, to, start, length, mkTop, mkTree) {
+  let total = 0;
+  for (let i2 = from; i2 < to; i2++)
+    total += nodeSize(balanceType, children[i2]);
+  let maxChild = Math.ceil(
+    total * 1.5 / 8
+    /* Balance.BranchFactor */
+  );
+  let localChildren = [], localPositions = [];
+  function divide(children2, positions2, from2, to2, offset) {
+    for (let i2 = from2; i2 < to2; ) {
+      let groupFrom = i2, groupStart = positions2[i2], groupSize = nodeSize(balanceType, children2[i2]);
+      i2++;
+      for (; i2 < to2; i2++) {
+        let nextSize = nodeSize(balanceType, children2[i2]);
+        if (groupSize + nextSize >= maxChild)
+          break;
+        groupSize += nextSize;
+      }
+      if (i2 == groupFrom + 1) {
+        if (groupSize > maxChild) {
+          let only = children2[groupFrom];
+          divide(only.children, only.positions, 0, only.children.length, positions2[groupFrom] + offset);
+          continue;
+        }
+        localChildren.push(children2[groupFrom]);
+      } else {
+        let length2 = positions2[i2 - 1] + children2[i2 - 1].length - groupStart;
+        localChildren.push(balanceRange(balanceType, children2, positions2, groupFrom, i2, groupStart, length2, null, mkTree));
+      }
+      localPositions.push(groupStart + offset - start);
+    }
+  }
+  divide(children, positions, from, to, 0);
+  return (mkTop || mkTree)(localChildren, localPositions, length);
+}
+var NodeWeakMap = class {
+  constructor() {
+    this.map = /* @__PURE__ */ new WeakMap();
+  }
+  setBuffer(buffer, index, value) {
+    let inner = this.map.get(buffer);
+    if (!inner)
+      this.map.set(buffer, inner = /* @__PURE__ */ new Map());
+    inner.set(index, value);
+  }
+  getBuffer(buffer, index) {
+    let inner = this.map.get(buffer);
+    return inner && inner.get(index);
+  }
+  /**
+  Set the value for this syntax node.
+  */
+  set(node, value) {
+    if (node instanceof BufferNode)
+      this.setBuffer(node.context.buffer, node.index, value);
+    else if (node instanceof TreeNode)
+      this.map.set(node.tree, value);
+  }
+  /**
+  Retrieve value for this syntax node, if it exists in the map.
+  */
+  get(node) {
+    return node instanceof BufferNode ? this.getBuffer(node.context.buffer, node.index) : node instanceof TreeNode ? this.map.get(node.tree) : void 0;
+  }
+  /**
+  Set the value for the node that a cursor currently points to.
+  */
+  cursorSet(cursor, value) {
+    if (cursor.buffer)
+      this.setBuffer(cursor.buffer.buffer, cursor.index, value);
+    else
+      this.map.set(cursor.tree, value);
+  }
+  /**
+  Retrieve the value for the node that a cursor currently points
+  to.
+  */
+  cursorGet(cursor) {
+    return cursor.buffer ? this.getBuffer(cursor.buffer.buffer, cursor.index) : this.map.get(cursor.tree);
+  }
+};
+var TreeFragment = class _TreeFragment {
+  /**
+  Construct a tree fragment. You'll usually want to use
+  [`addTree`](#common.TreeFragment^addTree) and
+  [`applyChanges`](#common.TreeFragment^applyChanges) instead of
+  calling this directly.
+  */
+  constructor(from, to, tree, offset, openStart = false, openEnd = false) {
+    this.from = from;
+    this.to = to;
+    this.tree = tree;
+    this.offset = offset;
+    this.open = (openStart ? 1 : 0) | (openEnd ? 2 : 0);
+  }
+  /**
+  Whether the start of the fragment represents the start of a
+  parse, or the end of a change. (In the second case, it may not
+  be safe to reuse some nodes at the start, depending on the
+  parsing algorithm.)
+  */
+  get openStart() {
+    return (this.open & 1) > 0;
+  }
+  /**
+  Whether the end of the fragment represents the end of a
+  full-document parse, or the start of a change.
+  */
+  get openEnd() {
+    return (this.open & 2) > 0;
+  }
+  /**
+  Create a set of fragments from a freshly parsed tree, or update
+  an existing set of fragments by replacing the ones that overlap
+  with a tree with content from the new tree. When `partial` is
+  true, the parse is treated as incomplete, and the resulting
+  fragment has [`openEnd`](#common.TreeFragment.openEnd) set to
+  true.
+  */
+  static addTree(tree, fragments = [], partial = false) {
+    let result = [new _TreeFragment(0, tree.length, tree, 0, false, partial)];
+    for (let f of fragments)
+      if (f.to > tree.length)
+        result.push(f);
+    return result;
+  }
+  /**
+  Apply a set of edits to an array of fragments, removing or
+  splitting fragments as necessary to remove edited ranges, and
+  adjusting offsets for fragments that moved.
+  */
+  static applyChanges(fragments, changes, minGap = 128) {
+    if (!changes.length)
+      return fragments;
+    let result = [];
+    let fI = 1, nextF = fragments.length ? fragments[0] : null;
+    for (let cI = 0, pos = 0, off = 0; ; cI++) {
+      let nextC = cI < changes.length ? changes[cI] : null;
+      let nextPos = nextC ? nextC.fromA : 1e9;
+      if (nextPos - pos >= minGap)
+        while (nextF && nextF.from < nextPos) {
+          let cut = nextF;
+          if (pos >= cut.from || nextPos <= cut.to || off) {
+            let fFrom = Math.max(cut.from, pos) - off, fTo = Math.min(cut.to, nextPos) - off;
+            cut = fFrom >= fTo ? null : new _TreeFragment(fFrom, fTo, cut.tree, cut.offset + off, cI > 0, !!nextC);
+          }
+          if (cut)
+            result.push(cut);
+          if (nextF.to > nextPos)
+            break;
+          nextF = fI < fragments.length ? fragments[fI++] : null;
+        }
+      if (!nextC)
+        break;
+      pos = nextC.toA;
+      off = nextC.toA - nextC.toB;
+    }
+    return result;
+  }
+};
+var Parser = class {
+  /**
+  Start a parse, returning a [partial parse](#common.PartialParse)
+  object. [`fragments`](#common.TreeFragment) can be passed in to
+  make the parse incremental.
+  
+  By default, the entire input is parsed. You can pass `ranges`,
+  which should be a sorted array of non-empty, non-overlapping
+  ranges, to parse only those ranges. The tree returned in that
+  case will start at `ranges[0].from`.
+  */
+  startParse(input, fragments, ranges) {
+    if (typeof input == "string")
+      input = new StringInput(input);
+    ranges = !ranges ? [new Range2(0, input.length)] : ranges.length ? ranges.map((r2) => new Range2(r2.from, r2.to)) : [new Range2(0, 0)];
+    return this.createParse(input, fragments || [], ranges);
+  }
+  /**
+  Run a full parse, returning the resulting tree.
+  */
+  parse(input, fragments, ranges) {
+    let parse = this.startParse(input, fragments, ranges);
+    for (; ; ) {
+      let done = parse.advance();
+      if (done)
+        return done;
+    }
+  }
+};
+var StringInput = class {
+  constructor(string2) {
+    this.string = string2;
+  }
+  get length() {
+    return this.string.length;
+  }
+  chunk(from) {
+    return this.string.slice(from);
+  }
+  get lineChunks() {
+    return false;
+  }
+  read(from, to) {
+    return this.string.slice(from, to);
+  }
+};
+var stoppedInner = new NodeProp({ perNode: true });
+
+// node_modules/@lezer/highlight/dist/index.js
+var nextTagID = 0;
+var Tag = class _Tag {
+  /**
+  @internal
+  */
+  constructor(name2, set, base2, modified) {
+    this.name = name2;
+    this.set = set;
+    this.base = base2;
+    this.modified = modified;
+    this.id = nextTagID++;
+  }
+  toString() {
+    let { name: name2 } = this;
+    for (let mod of this.modified)
+      if (mod.name)
+        name2 = `${mod.name}(${name2})`;
+    return name2;
+  }
+  static define(nameOrParent, parent) {
+    let name2 = typeof nameOrParent == "string" ? nameOrParent : "?";
+    if (nameOrParent instanceof _Tag)
+      parent = nameOrParent;
+    if (parent === null || parent === void 0 ? void 0 : parent.base)
+      throw new Error("Can not derive from a modified tag");
+    let tag = new _Tag(name2, [], null, []);
+    tag.set.push(tag);
+    if (parent)
+      for (let t2 of parent.set)
+        tag.set.push(t2);
+    return tag;
+  }
+  /**
+  Define a tag _modifier_, which is a function that, given a tag,
+  will return a tag that is a subtag of the original. Applying the
+  same modifier to a twice tag will return the same value (`m1(t1)
+  == m1(t1)`) and applying multiple modifiers will, regardless or
+  order, produce the same tag (`m1(m2(t1)) == m2(m1(t1))`).
+  
+  When multiple modifiers are applied to a given base tag, each
+  smaller set of modifiers is registered as a parent, so that for
+  example `m1(m2(m3(t1)))` is a subtype of `m1(m2(t1))`,
+  `m1(m3(t1)`, and so on.
+  */
+  static defineModifier(name2) {
+    let mod = new Modifier(name2);
+    return (tag) => {
+      if (tag.modified.indexOf(mod) > -1)
+        return tag;
+      return Modifier.get(tag.base || tag, tag.modified.concat(mod).sort((a, b) => a.id - b.id));
+    };
+  }
+};
+var nextModifierID = 0;
+var Modifier = class _Modifier {
+  constructor(name2) {
+    this.name = name2;
+    this.instances = [];
+    this.id = nextModifierID++;
+  }
+  static get(base2, mods) {
+    if (!mods.length)
+      return base2;
+    let exists = mods[0].instances.find((t2) => t2.base == base2 && sameArray2(mods, t2.modified));
+    if (exists)
+      return exists;
+    let set = [], tag = new Tag(base2.name, set, base2, mods);
+    for (let m of mods)
+      m.instances.push(tag);
+    let configs = powerSet(mods);
+    for (let parent of base2.set)
+      if (!parent.modified.length)
+        for (let config of configs)
+          set.push(_Modifier.get(parent, config));
+    return tag;
+  }
+};
+function sameArray2(a, b) {
+  return a.length == b.length && a.every((x, i2) => x == b[i2]);
+}
+function powerSet(array) {
+  let sets = [[]];
+  for (let i2 = 0; i2 < array.length; i2++) {
+    for (let j = 0, e = sets.length; j < e; j++) {
+      sets.push(sets[j].concat(array[i2]));
+    }
+  }
+  return sets.sort((a, b) => b.length - a.length);
+}
+function styleTags(spec) {
+  let byName = /* @__PURE__ */ Object.create(null);
+  for (let prop in spec) {
+    let tags2 = spec[prop];
+    if (!Array.isArray(tags2))
+      tags2 = [tags2];
+    for (let part of prop.split(" "))
+      if (part) {
+        let pieces = [], mode = 2, rest = part;
+        for (let pos = 0; ; ) {
+          if (rest == "..." && pos > 0 && pos + 3 == part.length) {
+            mode = 1;
+            break;
+          }
+          let m = /^"(?:[^"\\]|\\.)*?"|[^\/!]+/.exec(rest);
+          if (!m)
+            throw new RangeError("Invalid path: " + part);
+          pieces.push(m[0] == "*" ? "" : m[0][0] == '"' ? JSON.parse(m[0]) : m[0]);
+          pos += m[0].length;
+          if (pos == part.length)
+            break;
+          let next = part[pos++];
+          if (pos == part.length && next == "!") {
+            mode = 0;
+            break;
+          }
+          if (next != "/")
+            throw new RangeError("Invalid path: " + part);
+          rest = part.slice(pos);
+        }
+        let last = pieces.length - 1, inner = pieces[last];
+        if (!inner)
+          throw new RangeError("Invalid path: " + part);
+        let rule = new Rule(tags2, mode, last > 0 ? pieces.slice(0, last) : null);
+        byName[inner] = rule.sort(byName[inner]);
+      }
+  }
+  return ruleNodeProp.add(byName);
+}
+var ruleNodeProp = new NodeProp({
+  combine(a, b) {
+    let cur, root, take;
+    while (a || b) {
+      if (!a || b && a.depth >= b.depth) {
+        take = b;
+        b = b.next;
+      } else {
+        take = a;
+        a = a.next;
+      }
+      if (cur && cur.mode == take.mode && !take.context && !cur.context)
+        continue;
+      let copy = new Rule(take.tags, take.mode, take.context);
+      if (cur)
+        cur.next = copy;
+      else
+        root = copy;
+      cur = copy;
+    }
+    return root;
+  }
+});
+var Rule = class {
+  constructor(tags2, mode, context, next) {
+    this.tags = tags2;
+    this.mode = mode;
+    this.context = context;
+    this.next = next;
+  }
+  get opaque() {
+    return this.mode == 0;
+  }
+  get inherit() {
+    return this.mode == 1;
+  }
+  sort(other) {
+    if (!other || other.depth < this.depth) {
+      this.next = other;
+      return this;
+    }
+    other.next = this.sort(other.next);
+    return other;
+  }
+  get depth() {
+    return this.context ? this.context.length : 0;
+  }
+};
+Rule.empty = new Rule([], 2, null);
+function tagHighlighter(tags2, options) {
+  let map = /* @__PURE__ */ Object.create(null);
+  for (let style of tags2) {
+    if (!Array.isArray(style.tag))
+      map[style.tag.id] = style.class;
+    else
+      for (let tag of style.tag)
+        map[tag.id] = style.class;
+  }
+  let { scope, all = null } = options || {};
+  return {
+    style: (tags3) => {
+      let cls = all;
+      for (let tag of tags3) {
+        for (let sub of tag.set) {
+          let tagClass = map[sub.id];
+          if (tagClass) {
+            cls = cls ? cls + " " + tagClass : tagClass;
+            break;
+          }
+        }
+      }
+      return cls;
+    },
+    scope
+  };
+}
+var t = Tag.define;
+var comment = t();
+var name = t();
+var typeName = t(name);
+var propertyName = t(name);
+var literal = t();
+var string = t(literal);
+var number = t(literal);
+var content = t();
+var heading = t(content);
+var keyword = t();
+var operator = t();
+var punctuation = t();
+var bracket = t(punctuation);
+var meta = t();
+var tags = {
+  /**
+  A comment.
+  */
+  comment,
+  /**
+  A line [comment](#highlight.tags.comment).
+  */
+  lineComment: t(comment),
+  /**
+  A block [comment](#highlight.tags.comment).
+  */
+  blockComment: t(comment),
+  /**
+  A documentation [comment](#highlight.tags.comment).
+  */
+  docComment: t(comment),
+  /**
+  Any kind of identifier.
+  */
+  name,
+  /**
+  The [name](#highlight.tags.name) of a variable.
+  */
+  variableName: t(name),
+  /**
+  A type [name](#highlight.tags.name).
+  */
+  typeName,
+  /**
+  A tag name (subtag of [`typeName`](#highlight.tags.typeName)).
+  */
+  tagName: t(typeName),
+  /**
+  A property or field [name](#highlight.tags.name).
+  */
+  propertyName,
+  /**
+  An attribute name (subtag of [`propertyName`](#highlight.tags.propertyName)).
+  */
+  attributeName: t(propertyName),
+  /**
+  The [name](#highlight.tags.name) of a class.
+  */
+  className: t(name),
+  /**
+  A label [name](#highlight.tags.name).
+  */
+  labelName: t(name),
+  /**
+  A namespace [name](#highlight.tags.name).
+  */
+  namespace: t(name),
+  /**
+  The [name](#highlight.tags.name) of a macro.
+  */
+  macroName: t(name),
+  /**
+  A literal value.
+  */
+  literal,
+  /**
+  A string [literal](#highlight.tags.literal).
+  */
+  string,
+  /**
+  A documentation [string](#highlight.tags.string).
+  */
+  docString: t(string),
+  /**
+  A character literal (subtag of [string](#highlight.tags.string)).
+  */
+  character: t(string),
+  /**
+  An attribute value (subtag of [string](#highlight.tags.string)).
+  */
+  attributeValue: t(string),
+  /**
+  A number [literal](#highlight.tags.literal).
+  */
+  number,
+  /**
+  An integer [number](#highlight.tags.number) literal.
+  */
+  integer: t(number),
+  /**
+  A floating-point [number](#highlight.tags.number) literal.
+  */
+  float: t(number),
+  /**
+  A boolean [literal](#highlight.tags.literal).
+  */
+  bool: t(literal),
+  /**
+  Regular expression [literal](#highlight.tags.literal).
+  */
+  regexp: t(literal),
+  /**
+  An escape [literal](#highlight.tags.literal), for example a
+  backslash escape in a string.
+  */
+  escape: t(literal),
+  /**
+  A color [literal](#highlight.tags.literal).
+  */
+  color: t(literal),
+  /**
+  A URL [literal](#highlight.tags.literal).
+  */
+  url: t(literal),
+  /**
+  A language keyword.
+  */
+  keyword,
+  /**
+  The [keyword](#highlight.tags.keyword) for the self or this
+  object.
+  */
+  self: t(keyword),
+  /**
+  The [keyword](#highlight.tags.keyword) for null.
+  */
+  null: t(keyword),
+  /**
+  A [keyword](#highlight.tags.keyword) denoting some atomic value.
+  */
+  atom: t(keyword),
+  /**
+  A [keyword](#highlight.tags.keyword) that represents a unit.
+  */
+  unit: t(keyword),
+  /**
+  A modifier [keyword](#highlight.tags.keyword).
+  */
+  modifier: t(keyword),
+  /**
+  A [keyword](#highlight.tags.keyword) that acts as an operator.
+  */
+  operatorKeyword: t(keyword),
+  /**
+  A control-flow related [keyword](#highlight.tags.keyword).
+  */
+  controlKeyword: t(keyword),
+  /**
+  A [keyword](#highlight.tags.keyword) that defines something.
+  */
+  definitionKeyword: t(keyword),
+  /**
+  A [keyword](#highlight.tags.keyword) related to defining or
+  interfacing with modules.
+  */
+  moduleKeyword: t(keyword),
+  /**
+  An operator.
+  */
+  operator,
+  /**
+  An [operator](#highlight.tags.operator) that dereferences something.
+  */
+  derefOperator: t(operator),
+  /**
+  Arithmetic-related [operator](#highlight.tags.operator).
+  */
+  arithmeticOperator: t(operator),
+  /**
+  Logical [operator](#highlight.tags.operator).
+  */
+  logicOperator: t(operator),
+  /**
+  Bit [operator](#highlight.tags.operator).
+  */
+  bitwiseOperator: t(operator),
+  /**
+  Comparison [operator](#highlight.tags.operator).
+  */
+  compareOperator: t(operator),
+  /**
+  [Operator](#highlight.tags.operator) that updates its operand.
+  */
+  updateOperator: t(operator),
+  /**
+  [Operator](#highlight.tags.operator) that defines something.
+  */
+  definitionOperator: t(operator),
+  /**
+  Type-related [operator](#highlight.tags.operator).
+  */
+  typeOperator: t(operator),
+  /**
+  Control-flow [operator](#highlight.tags.operator).
+  */
+  controlOperator: t(operator),
+  /**
+  Program or markup punctuation.
+  */
+  punctuation,
+  /**
+  [Punctuation](#highlight.tags.punctuation) that separates
+  things.
+  */
+  separator: t(punctuation),
+  /**
+  Bracket-style [punctuation](#highlight.tags.punctuation).
+  */
+  bracket,
+  /**
+  Angle [brackets](#highlight.tags.bracket) (usually `<` and `>`
+  tokens).
+  */
+  angleBracket: t(bracket),
+  /**
+  Square [brackets](#highlight.tags.bracket) (usually `[` and `]`
+  tokens).
+  */
+  squareBracket: t(bracket),
+  /**
+  Parentheses (usually `(` and `)` tokens). Subtag of
+  [bracket](#highlight.tags.bracket).
+  */
+  paren: t(bracket),
+  /**
+  Braces (usually `{` and `}` tokens). Subtag of
+  [bracket](#highlight.tags.bracket).
+  */
+  brace: t(bracket),
+  /**
+  Content, for example plain text in XML or markup documents.
+  */
+  content,
+  /**
+  [Content](#highlight.tags.content) that represents a heading.
+  */
+  heading,
+  /**
+  A level 1 [heading](#highlight.tags.heading).
+  */
+  heading1: t(heading),
+  /**
+  A level 2 [heading](#highlight.tags.heading).
+  */
+  heading2: t(heading),
+  /**
+  A level 3 [heading](#highlight.tags.heading).
+  */
+  heading3: t(heading),
+  /**
+  A level 4 [heading](#highlight.tags.heading).
+  */
+  heading4: t(heading),
+  /**
+  A level 5 [heading](#highlight.tags.heading).
+  */
+  heading5: t(heading),
+  /**
+  A level 6 [heading](#highlight.tags.heading).
+  */
+  heading6: t(heading),
+  /**
+  A prose [content](#highlight.tags.content) separator (such as a horizontal rule).
+  */
+  contentSeparator: t(content),
+  /**
+  [Content](#highlight.tags.content) that represents a list.
+  */
+  list: t(content),
+  /**
+  [Content](#highlight.tags.content) that represents a quote.
+  */
+  quote: t(content),
+  /**
+  [Content](#highlight.tags.content) that is emphasized.
+  */
+  emphasis: t(content),
+  /**
+  [Content](#highlight.tags.content) that is styled strong.
+  */
+  strong: t(content),
+  /**
+  [Content](#highlight.tags.content) that is part of a link.
+  */
+  link: t(content),
+  /**
+  [Content](#highlight.tags.content) that is styled as code or
+  monospace.
+  */
+  monospace: t(content),
+  /**
+  [Content](#highlight.tags.content) that has a strike-through
+  style.
+  */
+  strikethrough: t(content),
+  /**
+  Inserted text in a change-tracking format.
+  */
+  inserted: t(),
+  /**
+  Deleted text.
+  */
+  deleted: t(),
+  /**
+  Changed text.
+  */
+  changed: t(),
+  /**
+  An invalid or unsyntactic element.
+  */
+  invalid: t(),
+  /**
+  Metadata or meta-instruction.
+  */
+  meta,
+  /**
+  [Metadata](#highlight.tags.meta) that applies to the entire
+  document.
+  */
+  documentMeta: t(meta),
+  /**
+  [Metadata](#highlight.tags.meta) that annotates or adds
+  attributes to a given syntactic element.
+  */
+  annotation: t(meta),
+  /**
+  Processing instruction or preprocessor directive. Subtag of
+  [meta](#highlight.tags.meta).
+  */
+  processingInstruction: t(meta),
+  /**
+  [Modifier](#highlight.Tag^defineModifier) that indicates that a
+  given element is being defined. Expected to be used with the
+  various [name](#highlight.tags.name) tags.
+  */
+  definition: Tag.defineModifier("definition"),
+  /**
+  [Modifier](#highlight.Tag^defineModifier) that indicates that
+  something is constant. Mostly expected to be used with
+  [variable names](#highlight.tags.variableName).
+  */
+  constant: Tag.defineModifier("constant"),
+  /**
+  [Modifier](#highlight.Tag^defineModifier) used to indicate that
+  a [variable](#highlight.tags.variableName) or [property
+  name](#highlight.tags.propertyName) is being called or defined
+  as a function.
+  */
+  function: Tag.defineModifier("function"),
+  /**
+  [Modifier](#highlight.Tag^defineModifier) that can be applied to
+  [names](#highlight.tags.name) to indicate that they belong to
+  the language's standard environment.
+  */
+  standard: Tag.defineModifier("standard"),
+  /**
+  [Modifier](#highlight.Tag^defineModifier) that indicates a given
+  [names](#highlight.tags.name) is local to some scope.
+  */
+  local: Tag.defineModifier("local"),
+  /**
+  A generic variant [modifier](#highlight.Tag^defineModifier) that
+  can be used to tag language-specific alternative variants of
+  some common tag. It is recommended for themes to define special
+  forms of at least the [string](#highlight.tags.string) and
+  [variable name](#highlight.tags.variableName) tags, since those
+  come up a lot.
+  */
+  special: Tag.defineModifier("special")
+};
+for (let name2 in tags) {
+  let val = tags[name2];
+  if (val instanceof Tag)
+    val.name = name2;
+}
+var classHighlighter = tagHighlighter([
+  { tag: tags.link, class: "tok-link" },
+  { tag: tags.heading, class: "tok-heading" },
+  { tag: tags.emphasis, class: "tok-emphasis" },
+  { tag: tags.strong, class: "tok-strong" },
+  { tag: tags.keyword, class: "tok-keyword" },
+  { tag: tags.atom, class: "tok-atom" },
+  { tag: tags.bool, class: "tok-bool" },
+  { tag: tags.url, class: "tok-url" },
+  { tag: tags.labelName, class: "tok-labelName" },
+  { tag: tags.inserted, class: "tok-inserted" },
+  { tag: tags.deleted, class: "tok-deleted" },
+  { tag: tags.literal, class: "tok-literal" },
+  { tag: tags.string, class: "tok-string" },
+  { tag: tags.number, class: "tok-number" },
+  { tag: [tags.regexp, tags.escape, tags.special(tags.string)], class: "tok-string2" },
+  { tag: tags.variableName, class: "tok-variableName" },
+  { tag: tags.local(tags.variableName), class: "tok-variableName tok-local" },
+  { tag: tags.definition(tags.variableName), class: "tok-variableName tok-definition" },
+  { tag: tags.special(tags.variableName), class: "tok-variableName2" },
+  { tag: tags.definition(tags.propertyName), class: "tok-propertyName tok-definition" },
+  { tag: tags.typeName, class: "tok-typeName" },
+  { tag: tags.namespace, class: "tok-namespace" },
+  { tag: tags.className, class: "tok-className" },
+  { tag: tags.macroName, class: "tok-macroName" },
+  { tag: tags.propertyName, class: "tok-propertyName" },
+  { tag: tags.operator, class: "tok-operator" },
+  { tag: tags.comment, class: "tok-comment" },
+  { tag: tags.meta, class: "tok-meta" },
+  { tag: tags.invalid, class: "tok-invalid" },
+  { tag: tags.punctuation, class: "tok-punctuation" }
+]);
+
+// node_modules/@codemirror/language/dist/index.js
+var _a;
+var languageDataProp = /* @__PURE__ */ new NodeProp();
+function defineLanguageFacet(baseData) {
+  return Facet.define({
+    combine: baseData ? (values) => values.concat(baseData) : void 0
+  });
+}
+var sublanguageProp = /* @__PURE__ */ new NodeProp();
+var Language = class {
+  /**
+  Construct a language object. If you need to invoke this
+  directly, first define a data facet with
+  [`defineLanguageFacet`](https://codemirror.net/6/docs/ref/#language.defineLanguageFacet), and then
+  configure your parser to [attach](https://codemirror.net/6/docs/ref/#language.languageDataProp) it
+  to the language's outer syntax node.
+  */
+  constructor(data, parser3, extraExtensions = [], name2 = "") {
+    this.data = data;
+    this.name = name2;
+    if (!EditorState.prototype.hasOwnProperty("tree"))
+      Object.defineProperty(EditorState.prototype, "tree", { get() {
+        return syntaxTree(this);
+      } });
+    this.parser = parser3;
+    this.extension = [
+      language.of(this),
+      EditorState.languageData.of((state, pos, side) => {
+        let top2 = topNodeAt(state, pos, side), data2 = top2.type.prop(languageDataProp);
+        if (!data2)
+          return [];
+        let base2 = state.facet(data2), sub = top2.type.prop(sublanguageProp);
+        if (sub) {
+          let innerNode = top2.resolve(pos - top2.from, side);
+          for (let sublang of sub)
+            if (sublang.test(innerNode, state)) {
+              let data3 = state.facet(sublang.facet);
+              return sublang.type == "replace" ? data3 : data3.concat(base2);
+            }
+        }
+        return base2;
+      })
+    ].concat(extraExtensions);
+  }
+  /**
+  Query whether this language is active at the given position.
+  */
+  isActiveAt(state, pos, side = -1) {
+    return topNodeAt(state, pos, side).type.prop(languageDataProp) == this.data;
+  }
+  /**
+  Find the document regions that were parsed using this language.
+  The returned regions will _include_ any nested languages rooted
+  in this language, when those exist.
+  */
+  findRegions(state) {
+    let lang = state.facet(language);
+    if ((lang === null || lang === void 0 ? void 0 : lang.data) == this.data)
+      return [{ from: 0, to: state.doc.length }];
+    if (!lang || !lang.allowsNesting)
+      return [];
+    let result = [];
+    let explore = (tree, from) => {
+      if (tree.prop(languageDataProp) == this.data) {
+        result.push({ from, to: from + tree.length });
+        return;
+      }
+      let mount = tree.prop(NodeProp.mounted);
+      if (mount) {
+        if (mount.tree.prop(languageDataProp) == this.data) {
+          if (mount.overlay)
+            for (let r2 of mount.overlay)
+              result.push({ from: r2.from + from, to: r2.to + from });
+          else
+            result.push({ from, to: from + tree.length });
+          return;
+        } else if (mount.overlay) {
+          let size = result.length;
+          explore(mount.tree, mount.overlay[0].from + from);
+          if (result.length > size)
+            return;
+        }
+      }
+      for (let i2 = 0; i2 < tree.children.length; i2++) {
+        let ch = tree.children[i2];
+        if (ch instanceof Tree)
+          explore(ch, tree.positions[i2] + from);
+      }
+    };
+    explore(syntaxTree(state), 0);
+    return result;
+  }
+  /**
+  Indicates whether this language allows nested languages. The
+  default implementation returns true.
+  */
+  get allowsNesting() {
+    return true;
+  }
+};
+Language.setState = /* @__PURE__ */ StateEffect.define();
+function topNodeAt(state, pos, side) {
+  let topLang = state.facet(language), tree = syntaxTree(state).topNode;
+  if (!topLang || topLang.allowsNesting) {
+    for (let node = tree; node; node = node.enter(pos, side, IterMode.ExcludeBuffers | IterMode.EnterBracketed))
+      if (node.type.isTop)
+        tree = node;
+  }
+  return tree;
+}
+var LRLanguage = class _LRLanguage extends Language {
+  constructor(data, parser3, name2) {
+    super(data, parser3, [], name2);
+    this.parser = parser3;
+  }
+  /**
+  Define a language from a parser.
+  */
+  static define(spec) {
+    let data = defineLanguageFacet(spec.languageData);
+    return new _LRLanguage(data, spec.parser.configure({
+      props: [languageDataProp.add((type) => type.isTop ? data : void 0)]
+    }), spec.name);
+  }
+  /**
+  Create a new instance of this language with a reconfigured
+  version of its parser and optionally a new name.
+  */
+  configure(options, name2) {
+    return new _LRLanguage(this.data, this.parser.configure(options), name2 || this.name);
+  }
+  get allowsNesting() {
+    return this.parser.hasWrappers();
+  }
+};
+function syntaxTree(state) {
+  let field = state.field(Language.state, false);
+  return field ? field.tree : Tree.empty;
+}
+var DocInput = class {
+  /**
+  Create an input object for the given document.
+  */
+  constructor(doc2) {
+    this.doc = doc2;
+    this.cursorPos = 0;
+    this.string = "";
+    this.cursor = doc2.iter();
+  }
+  get length() {
+    return this.doc.length;
+  }
+  syncTo(pos) {
+    this.string = this.cursor.next(pos - this.cursorPos).value;
+    this.cursorPos = pos + this.string.length;
+    return this.cursorPos - this.string.length;
+  }
+  chunk(pos) {
+    this.syncTo(pos);
+    return this.string;
+  }
+  get lineChunks() {
+    return true;
+  }
+  read(from, to) {
+    let stringStart2 = this.cursorPos - this.string.length;
+    if (from < stringStart2 || to >= this.cursorPos)
+      return this.doc.sliceString(from, to);
+    else
+      return this.string.slice(from - stringStart2, to - stringStart2);
+  }
+};
+var currentContext = null;
+var ParseContext = class _ParseContext {
+  constructor(parser3, state, fragments = [], tree, treeLen, viewport, skipped, scheduleOn) {
+    this.parser = parser3;
+    this.state = state;
+    this.fragments = fragments;
+    this.tree = tree;
+    this.treeLen = treeLen;
+    this.viewport = viewport;
+    this.skipped = skipped;
+    this.scheduleOn = scheduleOn;
+    this.parse = null;
+    this.tempSkipped = [];
+  }
+  /**
+  @internal
+  */
+  static create(parser3, state, viewport) {
+    return new _ParseContext(parser3, state, [], Tree.empty, 0, viewport, [], null);
+  }
+  startParse() {
+    return this.parser.startParse(new DocInput(this.state.doc), this.fragments);
+  }
+  /**
+  @internal
+  */
+  work(until, upto) {
+    if (upto != null && upto >= this.state.doc.length)
+      upto = void 0;
+    if (this.tree != Tree.empty && this.isDone(upto !== null && upto !== void 0 ? upto : this.state.doc.length)) {
+      this.takeTree();
+      return true;
+    }
+    return this.withContext(() => {
+      var _a2;
+      if (typeof until == "number") {
+        let endTime = Date.now() + until;
+        until = () => Date.now() > endTime;
+      }
+      if (!this.parse)
+        this.parse = this.startParse();
+      if (upto != null && (this.parse.stoppedAt == null || this.parse.stoppedAt > upto) && upto < this.state.doc.length)
+        this.parse.stopAt(upto);
+      for (; ; ) {
+        let done = this.parse.advance();
+        if (done) {
+          this.fragments = this.withoutTempSkipped(TreeFragment.addTree(done, this.fragments, this.parse.stoppedAt != null));
+          this.treeLen = (_a2 = this.parse.stoppedAt) !== null && _a2 !== void 0 ? _a2 : this.state.doc.length;
+          this.tree = done;
+          this.parse = null;
+          if (this.treeLen < (upto !== null && upto !== void 0 ? upto : this.state.doc.length))
+            this.parse = this.startParse();
+          else
+            return true;
+        }
+        if (until())
+          return false;
+      }
+    });
+  }
+  /**
+  @internal
+  */
+  takeTree() {
+    let pos, tree;
+    if (this.parse && (pos = this.parse.parsedPos) >= this.treeLen) {
+      if (this.parse.stoppedAt == null || this.parse.stoppedAt > pos)
+        this.parse.stopAt(pos);
+      this.withContext(() => {
+        while (!(tree = this.parse.advance())) {
+        }
+      });
+      this.treeLen = pos;
+      this.tree = tree;
+      this.fragments = this.withoutTempSkipped(TreeFragment.addTree(this.tree, this.fragments, true));
+      this.parse = null;
+    }
+  }
+  withContext(f) {
+    let prev = currentContext;
+    currentContext = this;
+    try {
+      return f();
+    } finally {
+      currentContext = prev;
+    }
+  }
+  withoutTempSkipped(fragments) {
+    for (let r2; r2 = this.tempSkipped.pop(); )
+      fragments = cutFragments(fragments, r2.from, r2.to);
+    return fragments;
+  }
+  /**
+  @internal
+  */
+  changes(changes, newState) {
+    let { fragments, tree, treeLen, viewport, skipped } = this;
+    this.takeTree();
+    if (!changes.empty) {
+      let ranges = [];
+      changes.iterChangedRanges((fromA, toA, fromB, toB) => ranges.push({ fromA, toA, fromB, toB }));
+      fragments = TreeFragment.applyChanges(fragments, ranges);
+      tree = Tree.empty;
+      treeLen = 0;
+      viewport = { from: changes.mapPos(viewport.from, -1), to: changes.mapPos(viewport.to, 1) };
+      if (this.skipped.length) {
+        skipped = [];
+        for (let r2 of this.skipped) {
+          let from = changes.mapPos(r2.from, 1), to = changes.mapPos(r2.to, -1);
+          if (from < to)
+            skipped.push({ from, to });
+        }
+      }
+    }
+    return new _ParseContext(this.parser, newState, fragments, tree, treeLen, viewport, skipped, this.scheduleOn);
+  }
+  /**
+  @internal
+  */
+  updateViewport(viewport) {
+    if (this.viewport.from == viewport.from && this.viewport.to == viewport.to)
+      return false;
+    this.viewport = viewport;
+    let startLen = this.skipped.length;
+    for (let i2 = 0; i2 < this.skipped.length; i2++) {
+      let { from, to } = this.skipped[i2];
+      if (from < viewport.to && to > viewport.from) {
+        this.fragments = cutFragments(this.fragments, from, to);
+        this.skipped.splice(i2--, 1);
+      }
+    }
+    if (this.skipped.length >= startLen)
+      return false;
+    this.reset();
+    return true;
+  }
+  /**
+  @internal
+  */
+  reset() {
+    if (this.parse) {
+      this.takeTree();
+      this.parse = null;
+    }
+  }
+  /**
+  Notify the parse scheduler that the given region was skipped
+  because it wasn't in view, and the parse should be restarted
+  when it comes into view.
+  */
+  skipUntilInView(from, to) {
+    this.skipped.push({ from, to });
+  }
+  /**
+  Returns a parser intended to be used as placeholder when
+  asynchronously loading a nested parser. It'll skip its input and
+  mark it as not-really-parsed, so that the next update will parse
+  it again.
+  
+  When `until` is given, a reparse will be scheduled when that
+  promise resolves.
+  */
+  static getSkippingParser(until) {
+    return new class extends Parser {
+      createParse(input, fragments, ranges) {
+        let from = ranges[0].from, to = ranges[ranges.length - 1].to;
+        let parser3 = {
+          parsedPos: from,
+          advance() {
+            let cx = currentContext;
+            if (cx) {
+              for (let r2 of ranges)
+                cx.tempSkipped.push(r2);
+              if (until)
+                cx.scheduleOn = cx.scheduleOn ? Promise.all([cx.scheduleOn, until]) : until;
+            }
+            this.parsedPos = to;
+            return new Tree(NodeType.none, [], [], to - from);
+          },
+          stoppedAt: null,
+          stopAt() {
+          }
+        };
+        return parser3;
+      }
+    }();
+  }
+  /**
+  @internal
+  */
+  isDone(upto) {
+    upto = Math.min(upto, this.state.doc.length);
+    let frags = this.fragments;
+    return this.treeLen >= upto && frags.length && frags[0].from == 0 && frags[0].to >= upto;
+  }
+  /**
+  Get the context for the current parse, or `null` if no editor
+  parse is in progress.
+  */
+  static get() {
+    return currentContext;
+  }
+};
+function cutFragments(fragments, from, to) {
+  return TreeFragment.applyChanges(fragments, [{ fromA: from, toA: to, fromB: from, toB: to }]);
+}
+var LanguageState = class _LanguageState {
+  constructor(context) {
+    this.context = context;
+    this.tree = context.tree;
+  }
+  apply(tr) {
+    if (!tr.docChanged && this.tree == this.context.tree)
+      return this;
+    let newCx = this.context.changes(tr.changes, tr.state);
+    let upto = this.context.treeLen == tr.startState.doc.length ? void 0 : Math.max(tr.changes.mapPos(this.context.treeLen), newCx.viewport.to);
+    if (!newCx.work(20, upto))
+      newCx.takeTree();
+    return new _LanguageState(newCx);
+  }
+  static init(state) {
+    let vpTo = Math.min(3e3, state.doc.length);
+    let parseState = ParseContext.create(state.facet(language).parser, state, { from: 0, to: vpTo });
+    if (!parseState.work(20, vpTo))
+      parseState.takeTree();
+    return new _LanguageState(parseState);
+  }
+};
+Language.state = /* @__PURE__ */ StateField.define({
+  create: LanguageState.init,
+  update(value, tr) {
+    for (let e of tr.effects)
+      if (e.is(Language.setState))
+        return e.value;
+    if (tr.startState.facet(language) != tr.state.facet(language))
+      return LanguageState.init(tr.state);
+    return value.apply(tr);
+  }
+});
+var requestIdle = (callback) => {
+  let timeout = setTimeout(
+    () => callback(),
+    500
+    /* Work.MaxPause */
+  );
+  return () => clearTimeout(timeout);
+};
+if (typeof requestIdleCallback != "undefined")
+  requestIdle = (callback) => {
+    let idle = -1, timeout = setTimeout(
+      () => {
+        idle = requestIdleCallback(callback, {
+          timeout: 500 - 100
+          /* Work.MinPause */
+        });
+      },
+      100
+      /* Work.MinPause */
+    );
+    return () => idle < 0 ? clearTimeout(timeout) : cancelIdleCallback(idle);
+  };
+var isInputPending = typeof navigator != "undefined" && ((_a = navigator.scheduling) === null || _a === void 0 ? void 0 : _a.isInputPending) ? () => navigator.scheduling.isInputPending() : null;
+var parseWorker = /* @__PURE__ */ ViewPlugin.fromClass(class ParseWorker {
+  constructor(view) {
+    this.view = view;
+    this.working = null;
+    this.workScheduled = 0;
+    this.chunkEnd = -1;
+    this.chunkBudget = -1;
+    this.work = this.work.bind(this);
+    this.scheduleWork();
+  }
+  update(update) {
+    let cx = this.view.state.field(Language.state).context;
+    if (cx.updateViewport(update.view.viewport) || this.view.viewport.to > cx.treeLen)
+      this.scheduleWork();
+    if (update.docChanged || update.selectionSet) {
+      if (this.view.hasFocus)
+        this.chunkBudget += 50;
+      this.scheduleWork();
+    }
+    this.checkAsyncSchedule(cx);
+  }
+  scheduleWork() {
+    if (this.working)
+      return;
+    let { state } = this.view, field = state.field(Language.state);
+    if (field.tree != field.context.tree || !field.context.isDone(state.doc.length))
+      this.working = requestIdle(this.work);
+  }
+  work(deadline) {
+    this.working = null;
+    let now = Date.now();
+    if (this.chunkEnd < now && (this.chunkEnd < 0 || this.view.hasFocus)) {
+      this.chunkEnd = now + 3e4;
+      this.chunkBudget = 3e3;
+    }
+    if (this.chunkBudget <= 0)
+      return;
+    let { state, viewport: { to: vpTo } } = this.view, field = state.field(Language.state);
+    if (field.tree == field.context.tree && field.context.isDone(
+      vpTo + 1e5
+      /* Work.MaxParseAhead */
+    ))
+      return;
+    let endTime = Date.now() + Math.min(this.chunkBudget, 100, deadline && !isInputPending ? Math.max(25, deadline.timeRemaining() - 5) : 1e9);
+    let viewportFirst = field.context.treeLen < vpTo && state.doc.length > vpTo + 1e3;
+    let done = field.context.work(() => {
+      return isInputPending && isInputPending() || Date.now() > endTime;
+    }, vpTo + (viewportFirst ? 0 : 1e5));
+    this.chunkBudget -= Date.now() - now;
+    if (done || this.chunkBudget <= 0) {
+      field.context.takeTree();
+      this.view.dispatch({ effects: Language.setState.of(new LanguageState(field.context)) });
+    }
+    if (this.chunkBudget > 0 && !(done && !viewportFirst))
+      this.scheduleWork();
+    this.checkAsyncSchedule(field.context);
+  }
+  checkAsyncSchedule(cx) {
+    if (cx.scheduleOn) {
+      this.workScheduled++;
+      cx.scheduleOn.then(() => this.scheduleWork()).catch((err) => logException(this.view.state, err)).then(() => this.workScheduled--);
+      cx.scheduleOn = null;
+    }
+  }
+  destroy() {
+    if (this.working)
+      this.working();
+  }
+  isWorking() {
+    return !!(this.working || this.workScheduled > 0);
+  }
+}, {
+  eventHandlers: { focus() {
+    this.scheduleWork();
+  } }
+});
+var language = /* @__PURE__ */ Facet.define({
+  combine(languages) {
+    return languages.length ? languages[0] : null;
+  },
+  enables: (language2) => [
+    Language.state,
+    parseWorker,
+    EditorView.contentAttributes.compute([language2], (state) => {
+      let lang = state.facet(language2);
+      return lang && lang.name ? { "data-language": lang.name } : {};
+    })
+  ]
+});
+var LanguageSupport = class {
+  /**
+  Create a language support object.
+  */
+  constructor(language2, support = []) {
+    this.language = language2;
+    this.support = support;
+    this.extension = [language2, support];
+  }
+};
+var indentUnit = /* @__PURE__ */ Facet.define({
+  combine: (values) => {
+    if (!values.length)
+      return "  ";
+    let unit = values[0];
+    if (!unit || /\S/.test(unit) || Array.from(unit).some((e) => e != unit[0]))
+      throw new Error("Invalid indent unit: " + JSON.stringify(values[0]));
+    return unit;
+  }
+});
+function getIndentUnit(state) {
+  let unit = state.facet(indentUnit);
+  return unit.charCodeAt(0) == 9 ? state.tabSize * unit.length : unit.length;
+}
+function indentString(state, cols) {
+  let result = "", ts = state.tabSize, ch = state.facet(indentUnit)[0];
+  if (ch == "	") {
+    while (cols >= ts) {
+      result += "	";
+      cols -= ts;
+    }
+    ch = " ";
+  }
+  for (let i2 = 0; i2 < cols; i2++)
+    result += ch;
+  return result;
+}
+var indentNodeProp = /* @__PURE__ */ new NodeProp();
+function bracketedAligned(context) {
+  let tree = context.node;
+  let openToken = tree.childAfter(tree.from), last = tree.lastChild;
+  if (!openToken)
+    return null;
+  let sim = context.options.simulateBreak;
+  let openLine = context.state.doc.lineAt(openToken.from);
+  let lineEnd = sim == null || sim <= openLine.from ? openLine.to : Math.min(openLine.to, sim);
+  for (let pos = openToken.to; ; ) {
+    let next = tree.childAfter(pos);
+    if (!next || next == last)
+      return null;
+    if (!next.type.isSkipped) {
+      if (next.from >= lineEnd)
+        return null;
+      let space2 = /^ */.exec(openLine.text.slice(openToken.to - openLine.from))[0].length;
+      return { from: openToken.from, to: openToken.to + space2 };
+    }
+    pos = next.to;
+  }
+}
+function delimitedIndent({ closing, align = true, units = 1 }) {
+  return (context) => delimitedStrategy(context, align, units, closing);
+}
+function delimitedStrategy(context, align, units, closing, closedAt) {
+  let after = context.textAfter, space2 = after.match(/^\s*/)[0].length;
+  let closed = closing && after.slice(space2, space2 + closing.length) == closing || closedAt == context.pos + space2;
+  let aligned = align ? bracketedAligned(context) : null;
+  if (aligned)
+    return closed ? context.column(aligned.from) : context.column(aligned.to);
+  return context.baseIndent + (closed ? 0 : context.unit * units);
+}
+var foldNodeProp = /* @__PURE__ */ new NodeProp();
+function foldInside(node) {
+  let first = node.firstChild, last = node.lastChild;
+  return first && first.to < last.from ? { from: first.to, to: last.type.isError ? node.to : last.from } : null;
+}
+var HighlightStyle = class _HighlightStyle {
+  constructor(specs, options) {
+    this.specs = specs;
+    let modSpec;
+    function def(spec) {
+      let cls = StyleModule.newName();
+      (modSpec || (modSpec = /* @__PURE__ */ Object.create(null)))["." + cls] = spec;
+      return cls;
+    }
+    const all = typeof options.all == "string" ? options.all : options.all ? def(options.all) : void 0;
+    const scopeOpt = options.scope;
+    this.scope = scopeOpt instanceof Language ? (type) => type.prop(languageDataProp) == scopeOpt.data : scopeOpt ? (type) => type == scopeOpt : void 0;
+    this.style = tagHighlighter(specs.map((style) => ({
+      tag: style.tag,
+      class: style.class || def(Object.assign({}, style, { tag: null }))
+    })), {
+      all
+    }).style;
+    this.module = modSpec ? new StyleModule(modSpec) : null;
+    this.themeType = options.themeType;
+  }
+  /**
+  Create a highlighter style that associates the given styles to
+  the given tags. The specs must be objects that hold a style tag
+  or array of tags in their `tag` property, and either a single
+  `class` property providing a static CSS class (for highlighter
+  that rely on external styling), or a
+  [`style-mod`](https://code.haverbeke.berlin/marijn/style-mod#documentation)-style
+  set of CSS properties (which define the styling for those tags).
+  
+  The CSS rules created for a highlighter will be emitted in the
+  order of the spec's properties. That means that for elements that
+  have multiple tags associated with them, styles defined further
+  down in the list will have a higher CSS precedence than styles
+  defined earlier.
+  */
+  static define(specs, options) {
+    return new _HighlightStyle(specs, options || {});
+  }
+};
+var defaultHighlightStyle = /* @__PURE__ */ HighlightStyle.define([
+  {
+    tag: tags.meta,
+    color: "#404740"
+  },
+  {
+    tag: tags.link,
+    textDecoration: "underline"
+  },
+  {
+    tag: tags.heading,
+    textDecoration: "underline",
+    fontWeight: "bold"
+  },
+  {
+    tag: tags.emphasis,
+    fontStyle: "italic"
+  },
+  {
+    tag: tags.strong,
+    fontWeight: "bold"
+  },
+  {
+    tag: tags.strikethrough,
+    textDecoration: "line-through"
+  },
+  {
+    tag: tags.keyword,
+    color: "#708"
+  },
+  {
+    tag: [tags.atom, tags.bool, tags.url, tags.contentSeparator, tags.labelName],
+    color: "#219"
+  },
+  {
+    tag: [tags.literal, tags.inserted],
+    color: "#164"
+  },
+  {
+    tag: [tags.string, tags.deleted],
+    color: "#a11"
+  },
+  {
+    tag: [tags.regexp, tags.escape, /* @__PURE__ */ tags.special(tags.string)],
+    color: "#e40"
+  },
+  {
+    tag: /* @__PURE__ */ tags.definition(tags.variableName),
+    color: "#00f"
+  },
+  {
+    tag: /* @__PURE__ */ tags.local(tags.variableName),
+    color: "#30a"
+  },
+  {
+    tag: [tags.typeName, tags.namespace],
+    color: "#085"
+  },
+  {
+    tag: tags.className,
+    color: "#167"
+  },
+  {
+    tag: [/* @__PURE__ */ tags.special(tags.variableName), tags.macroName],
+    color: "#256"
+  },
+  {
+    tag: /* @__PURE__ */ tags.definition(tags.propertyName),
+    color: "#00c"
+  },
+  {
+    tag: tags.comment,
+    color: "#940"
+  },
+  {
+    tag: tags.invalid,
+    color: "#f00"
+  }
+]);
+var baseTheme2 = /* @__PURE__ */ EditorView.baseTheme({
+  "&.cm-focused .cm-matchingBracket": { backgroundColor: "#328c8252" },
+  "&.cm-focused .cm-nonmatchingBracket": { backgroundColor: "#bb555544" }
+});
+var DefaultScanDist = 1e4;
+var DefaultBrackets = "()[]{}";
+var bracketMatchingConfig = /* @__PURE__ */ Facet.define({
+  combine(configs) {
+    return combineConfig(configs, {
+      afterCursor: true,
+      brackets: DefaultBrackets,
+      maxScanDistance: DefaultScanDist,
+      renderMatch: defaultRenderMatch
+    });
+  }
+});
+var matchingMark = /* @__PURE__ */ Decoration.mark({ class: "cm-matchingBracket" });
+var nonmatchingMark = /* @__PURE__ */ Decoration.mark({ class: "cm-nonmatchingBracket" });
+function defaultRenderMatch(match) {
+  let decorations2 = [];
+  let mark = match.matched ? matchingMark : nonmatchingMark;
+  decorations2.push(mark.range(match.start.from, match.start.to));
+  if (match.end)
+    decorations2.push(mark.range(match.end.from, match.end.to));
+  return decorations2;
+}
+function bracketDeco(state) {
+  let decorations2 = [];
+  let config = state.facet(bracketMatchingConfig);
+  for (let range of state.selection.ranges) {
+    if (!range.empty)
+      continue;
+    let match = matchBrackets(state, range.head, -1, config) || range.head > 0 && matchBrackets(state, range.head - 1, 1, config) || config.afterCursor && (matchBrackets(state, range.head, 1, config) || range.head < state.doc.length && matchBrackets(state, range.head + 1, -1, config));
+    if (match)
+      decorations2 = decorations2.concat(config.renderMatch(match, state));
+  }
+  return Decoration.set(decorations2, true);
+}
+var bracketMatcher = /* @__PURE__ */ ViewPlugin.fromClass(class {
+  constructor(view) {
+    this.paused = false;
+    this.decorations = bracketDeco(view.state);
+  }
+  update(update) {
+    if (update.docChanged || update.selectionSet || this.paused) {
+      if (update.view.composing) {
+        this.decorations = this.decorations.map(update.changes);
+        this.paused = true;
+      } else {
+        this.decorations = bracketDeco(update.state);
+        this.paused = false;
+      }
+    }
+  }
+}, {
+  decorations: (v) => v.decorations
+});
+var bracketMatchingUnique = [
+  bracketMatcher,
+  baseTheme2
+];
+function bracketMatching(config = {}) {
+  return [bracketMatchingConfig.of(config), bracketMatchingUnique];
+}
+var bracketMatchingHandle = /* @__PURE__ */ new NodeProp();
+function matchingNodes(node, dir, brackets) {
+  let byProp = node.prop(dir < 0 ? NodeProp.openedBy : NodeProp.closedBy);
+  if (byProp)
+    return byProp;
+  if (node.name.length == 1) {
+    let index = brackets.indexOf(node.name);
+    if (index > -1 && index % 2 == (dir < 0 ? 1 : 0))
+      return [brackets[index + dir]];
+  }
+  return null;
+}
+function findHandle(node) {
+  let hasHandle = node.type.prop(bracketMatchingHandle);
+  return hasHandle ? hasHandle(node.node) : node;
+}
+function matchBrackets(state, pos, dir, config = {}) {
+  let maxScanDistance = config.maxScanDistance || DefaultScanDist, brackets = config.brackets || DefaultBrackets;
+  let tree = syntaxTree(state), node = tree.resolveInner(pos, dir);
+  for (let cur = node; cur; cur = cur.parent) {
+    let matches = matchingNodes(cur.type, dir, brackets);
+    if (matches && cur.from < cur.to) {
+      let handle = findHandle(cur);
+      if (handle && (dir > 0 ? pos >= handle.from && pos < handle.to : pos > handle.from && pos <= handle.to))
+        return matchMarkedBrackets(state, pos, dir, cur, handle, matches, brackets);
+    }
+  }
+  return matchPlainBrackets(state, pos, dir, tree, node.type, maxScanDistance, brackets);
+}
+function matchMarkedBrackets(_state, _pos, dir, token, handle, matching, brackets) {
+  let parent = token.parent, firstToken = { from: handle.from, to: handle.to };
+  let depth = 0, cursor = parent === null || parent === void 0 ? void 0 : parent.cursor();
+  if (cursor && (dir < 0 ? cursor.childBefore(token.from) : cursor.childAfter(token.to)))
+    do {
+      if (dir < 0 ? cursor.to <= token.from : cursor.from >= token.to) {
+        if (depth == 0 && matching.indexOf(cursor.type.name) > -1 && cursor.from < cursor.to) {
+          let endHandle = findHandle(cursor);
+          return { start: firstToken, end: endHandle ? { from: endHandle.from, to: endHandle.to } : void 0, matched: true };
+        } else if (matchingNodes(cursor.type, dir, brackets)) {
+          depth++;
+        } else if (matchingNodes(cursor.type, -dir, brackets)) {
+          if (depth == 0) {
+            let endHandle = findHandle(cursor);
+            return {
+              start: firstToken,
+              end: endHandle && endHandle.from < endHandle.to ? { from: endHandle.from, to: endHandle.to } : void 0,
+              matched: false
+            };
+          }
+          depth--;
+        }
+      }
+    } while (dir < 0 ? cursor.prevSibling() : cursor.nextSibling());
+  return { start: firstToken, matched: false };
+}
+function matchPlainBrackets(state, pos, dir, tree, tokenType, maxScanDistance, brackets) {
+  if (dir < 0 ? !pos : pos == state.doc.length)
+    return null;
+  let startCh = dir < 0 ? state.sliceDoc(pos - 1, pos) : state.sliceDoc(pos, pos + 1);
+  let bracket2 = brackets.indexOf(startCh);
+  if (bracket2 < 0 || bracket2 % 2 == 0 != dir > 0)
+    return null;
+  let startToken = { from: dir < 0 ? pos - 1 : pos, to: dir > 0 ? pos + 1 : pos };
+  let iter = state.doc.iterRange(pos, dir > 0 ? state.doc.length : 0), depth = 0;
+  for (let distance = 0; !iter.next().done && distance <= maxScanDistance; ) {
+    let text = iter.value;
+    if (dir < 0)
+      distance += text.length;
+    let basePos = pos + distance * dir;
+    for (let pos2 = dir > 0 ? 0 : text.length - 1, end = dir > 0 ? text.length : -1; pos2 != end; pos2 += dir) {
+      let found = brackets.indexOf(text[pos2]);
+      if (found < 0 || tree.resolveInner(basePos + pos2, 1).type != tokenType)
+        continue;
+      if (found % 2 == 0 == dir > 0) {
+        depth++;
+      } else if (depth == 1) {
+        return { start: startToken, end: { from: basePos + pos2, to: basePos + pos2 + 1 }, matched: found >> 1 == bracket2 >> 1 };
+      } else {
+        depth--;
+      }
+    }
+    if (dir > 0)
+      distance += text.length;
+  }
+  return iter.done ? { start: startToken, matched: false } : null;
+}
+var noTokens = /* @__PURE__ */ Object.create(null);
+var typeArray = [NodeType.none];
+var warned = [];
+var byTag = /* @__PURE__ */ Object.create(null);
+var defaultTable = /* @__PURE__ */ Object.create(null);
+for (let [legacyName, name2] of [
+  ["variable", "variableName"],
+  ["variable-2", "variableName.special"],
+  ["string-2", "string.special"],
+  ["def", "variableName.definition"],
+  ["tag", "tagName"],
+  ["attribute", "attributeName"],
+  ["type", "typeName"],
+  ["builtin", "variableName.standard"],
+  ["qualifier", "modifier"],
+  ["error", "invalid"],
+  ["header", "heading"],
+  ["property", "propertyName"]
+])
+  defaultTable[legacyName] = /* @__PURE__ */ createTokenType(noTokens, name2);
+function warnForPart(part, msg) {
+  if (warned.indexOf(part) > -1)
+    return;
+  warned.push(part);
+  console.warn(msg);
+}
+function createTokenType(extra, tagStr) {
+  let tags$1 = [];
+  for (let name3 of tagStr.split(" ")) {
+    let found = [];
+    for (let part of name3.split(".")) {
+      let value = extra[part] || tags[part];
+      if (!value) {
+        warnForPart(part, `Unknown highlighting tag ${part}`);
+      } else if (typeof value == "function") {
+        if (!found.length)
+          warnForPart(part, `Modifier ${part} used at start of tag`);
+        else
+          found = found.map(value);
+      } else {
+        if (found.length)
+          warnForPart(part, `Tag ${part} used as modifier`);
+        else
+          found = Array.isArray(value) ? value : [value];
+      }
+    }
+    for (let tag of found)
+      tags$1.push(tag);
+  }
+  if (!tags$1.length)
+    return 0;
+  let name2 = tagStr.replace(/ /g, "_"), key = name2 + " " + tags$1.map((t2) => t2.id);
+  let known = byTag[key];
+  if (known)
+    return known.id;
+  let type = byTag[key] = NodeType.define({
+    id: typeArray.length,
+    name: name2,
+    props: [styleTags({ [name2]: tags$1 })]
+  });
+  typeArray.push(type);
+  return type.id;
+}
+var marks = {
+  rtl: /* @__PURE__ */ Decoration.mark({ class: "cm-iso", inclusive: true, attributes: { dir: "rtl" }, bidiIsolate: Direction.RTL }),
+  ltr: /* @__PURE__ */ Decoration.mark({ class: "cm-iso", inclusive: true, attributes: { dir: "ltr" }, bidiIsolate: Direction.LTR }),
+  auto: /* @__PURE__ */ Decoration.mark({ class: "cm-iso", inclusive: true, attributes: { dir: "auto" }, bidiIsolate: null })
+};
+
+// node_modules/@codemirror/commands/dist/index.js
+var fromHistory = /* @__PURE__ */ Annotation.define();
+var invertedEffects = /* @__PURE__ */ Facet.define();
+var HistEvent = class _HistEvent {
+  constructor(changes, effects, mapped, startSelection, selectionsAfter) {
+    this.changes = changes;
+    this.effects = effects;
+    this.mapped = mapped;
+    this.startSelection = startSelection;
+    this.selectionsAfter = selectionsAfter;
+  }
+  setSelAfter(after) {
+    return new _HistEvent(this.changes, this.effects, this.mapped, this.startSelection, after);
+  }
+  toJSON() {
+    var _a2, _b, _c;
+    return {
+      changes: (_a2 = this.changes) === null || _a2 === void 0 ? void 0 : _a2.toJSON(),
+      mapped: (_b = this.mapped) === null || _b === void 0 ? void 0 : _b.toJSON(),
+      startSelection: (_c = this.startSelection) === null || _c === void 0 ? void 0 : _c.toJSON(),
+      selectionsAfter: this.selectionsAfter.map((s) => s.toJSON())
+    };
+  }
+  static fromJSON(json) {
+    return new _HistEvent(json.changes && ChangeSet.fromJSON(json.changes), [], json.mapped && ChangeDesc.fromJSON(json.mapped), json.startSelection && EditorSelection.fromJSON(json.startSelection), json.selectionsAfter.map(EditorSelection.fromJSON));
+  }
+  // This does not check `addToHistory` and such, it assumes the
+  // transaction needs to be converted to an item. Returns null when
+  // there are no changes or effects in the transaction.
+  static fromTransaction(tr, selection) {
+    let effects = none2;
+    for (let invert of tr.startState.facet(invertedEffects)) {
+      let result = invert(tr);
+      if (result.length)
+        effects = effects.concat(result);
+    }
+    if (!effects.length && tr.changes.empty)
+      return null;
+    return new _HistEvent(tr.changes.invert(tr.startState.doc), effects, void 0, selection || tr.startState.selection, none2);
+  }
+  static selection(selections) {
+    return new _HistEvent(void 0, none2, void 0, void 0, selections);
+  }
+};
+function updateBranch(branch, to, maxLen, newEvent) {
+  let start = to + 1 > maxLen + 20 ? to - maxLen - 1 : 0;
+  let newBranch = branch.slice(start, to);
+  newBranch.push(newEvent);
+  return newBranch;
+}
+function isAdjacent(a, b) {
+  let ranges = [], isAdjacent2 = false;
+  a.iterChangedRanges((f, t2) => ranges.push(f, t2));
+  b.iterChangedRanges((_f, _t, f, t2) => {
+    for (let i2 = 0; i2 < ranges.length; ) {
+      let from = ranges[i2++], to = ranges[i2++];
+      if (t2 >= from && f <= to)
+        isAdjacent2 = true;
+    }
+  });
+  return isAdjacent2;
+}
+function eqSelectionShape(a, b) {
+  return a.ranges.length == b.ranges.length && a.ranges.filter((r2, i2) => r2.empty != b.ranges[i2].empty).length === 0;
+}
+function conc(a, b) {
+  return !a.length ? b : !b.length ? a : a.concat(b);
+}
+var none2 = [];
+var MaxSelectionsPerEvent = 200;
+function addSelection(branch, selection) {
+  if (!branch.length) {
+    return [HistEvent.selection([selection])];
+  } else {
+    let lastEvent = branch[branch.length - 1];
+    let sels = lastEvent.selectionsAfter.slice(Math.max(0, lastEvent.selectionsAfter.length - MaxSelectionsPerEvent));
+    if (sels.length && sels[sels.length - 1].eq(selection))
+      return branch;
+    sels.push(selection);
+    return updateBranch(branch, branch.length - 1, 1e9, lastEvent.setSelAfter(sels));
+  }
+}
+function popSelection(branch) {
+  let last = branch[branch.length - 1];
+  let newBranch = branch.slice();
+  newBranch[branch.length - 1] = last.setSelAfter(last.selectionsAfter.slice(0, last.selectionsAfter.length - 1));
+  return newBranch;
+}
+function addMappingToBranch(branch, mapping) {
+  if (!branch.length)
+    return branch;
+  let length = branch.length, selections = none2;
+  while (length) {
+    let event = mapEvent(branch[length - 1], mapping, selections);
+    if (event.changes && !event.changes.empty || event.effects.length) {
+      let result = branch.slice(0, length);
+      result[length - 1] = event;
+      return result;
+    } else {
+      mapping = event.mapped;
+      length--;
+      selections = event.selectionsAfter;
+    }
+  }
+  return selections.length ? [HistEvent.selection(selections)] : none2;
+}
+function mapEvent(event, mapping, extraSelections) {
+  let selections = conc(event.selectionsAfter.length ? event.selectionsAfter.map((s) => s.map(mapping)) : none2, extraSelections);
+  if (!event.changes)
+    return HistEvent.selection(selections);
+  let mappedChanges = event.changes.map(mapping), before = mapping.mapDesc(event.changes, true);
+  let fullMapping = event.mapped ? event.mapped.composeDesc(before) : before;
+  return new HistEvent(mappedChanges, StateEffect.mapEffects(event.effects, mapping), fullMapping, event.startSelection.map(before), selections);
+}
+var joinableUserEvent = /^(input\.type|delete)($|\.)/;
+var HistoryState = class _HistoryState {
+  constructor(done, undone, prevTime = 0, prevUserEvent = void 0) {
+    this.done = done;
+    this.undone = undone;
+    this.prevTime = prevTime;
+    this.prevUserEvent = prevUserEvent;
+  }
+  isolate() {
+    return this.prevTime ? new _HistoryState(this.done, this.undone) : this;
+  }
+  addChanges(event, time, userEvent, config, tr) {
+    let done = this.done, lastEvent = done[done.length - 1];
+    if (lastEvent && lastEvent.changes && !lastEvent.changes.empty && event.changes && (!userEvent || joinableUserEvent.test(userEvent)) && (!lastEvent.selectionsAfter.length && time - this.prevTime < config.newGroupDelay && config.joinToEvent(tr, isAdjacent(lastEvent.changes, event.changes)) || // For compose (but not compose.start) events, always join with previous event
+    userEvent == "input.type.compose")) {
+      done = updateBranch(done, done.length - 1, config.minDepth, new HistEvent(event.changes.compose(lastEvent.changes), conc(StateEffect.mapEffects(event.effects, lastEvent.changes), lastEvent.effects), lastEvent.mapped, lastEvent.startSelection, none2));
+    } else {
+      done = updateBranch(done, done.length, config.minDepth, event);
+    }
+    return new _HistoryState(done, none2, time, userEvent);
+  }
+  addSelection(selection, time, userEvent, newGroupDelay) {
+    let last = this.done.length ? this.done[this.done.length - 1].selectionsAfter : none2;
+    if (last.length > 0 && time - this.prevTime < newGroupDelay && userEvent == this.prevUserEvent && userEvent && /^select($|\.)/.test(userEvent) && eqSelectionShape(last[last.length - 1], selection))
+      return this;
+    return new _HistoryState(addSelection(this.done, selection), this.undone, time, userEvent);
+  }
+  addMapping(mapping) {
+    return new _HistoryState(addMappingToBranch(this.done, mapping), addMappingToBranch(this.undone, mapping), this.prevTime, this.prevUserEvent);
+  }
+  pop(side, state, onlySelection) {
+    let branch = side == 0 ? this.done : this.undone;
+    if (branch.length == 0)
+      return null;
+    let event = branch[branch.length - 1], selection = event.selectionsAfter[0] || (event.startSelection ? event.startSelection.map(event.changes.invertedDesc, 1) : state.selection);
+    if (onlySelection && event.selectionsAfter.length) {
+      return state.update({
+        selection: event.selectionsAfter[event.selectionsAfter.length - 1],
+        annotations: fromHistory.of({ side, rest: popSelection(branch), selection }),
+        userEvent: side == 0 ? "select.undo" : "select.redo",
+        scrollIntoView: true
+      });
+    } else if (!event.changes) {
+      return null;
+    } else {
+      let rest = branch.length == 1 ? none2 : branch.slice(0, branch.length - 1);
+      if (event.mapped)
+        rest = addMappingToBranch(rest, event.mapped);
+      return state.update({
+        changes: event.changes,
+        selection: event.startSelection,
+        effects: event.effects,
+        annotations: fromHistory.of({ side, rest, selection }),
+        filter: false,
+        userEvent: side == 0 ? "undo" : "redo",
+        scrollIntoView: true
+      });
+    }
+  }
+};
+HistoryState.empty = /* @__PURE__ */ new HistoryState(none2, none2);
+var segmenter = typeof Intl != "undefined" && Intl.Segmenter ? /* @__PURE__ */ new Intl.Segmenter(void 0, { granularity: "word" }) : null;
+function changeBySelectedLine(state, f) {
+  let atLine = -1;
+  return state.changeByRange((range) => {
+    let changes = [];
+    for (let pos = range.from; pos <= range.to; ) {
+      let line = state.doc.lineAt(pos);
+      if (line.number > atLine && (range.empty || range.to > line.from)) {
+        f(line, changes, range);
+        atLine = line.number;
+      }
+      pos = line.to + 1;
+    }
+    let changeSet = state.changes(changes);
+    return {
+      changes,
+      range: EditorSelection.range(changeSet.mapPos(range.anchor, 1), changeSet.mapPos(range.head, 1))
+    };
+  });
+}
+var indentMore = ({ state, dispatch }) => {
+  if (state.readOnly)
+    return false;
+  dispatch(state.update(changeBySelectedLine(state, (line, changes) => {
+    changes.push({ from: line.from, insert: state.facet(indentUnit) });
+  }), { userEvent: "input.indent" }));
+  return true;
+};
+var indentLess = ({ state, dispatch }) => {
+  if (state.readOnly)
+    return false;
+  dispatch(state.update(changeBySelectedLine(state, (line, changes) => {
+    let space2 = /^\s*/.exec(line.text)[0];
+    if (!space2)
+      return;
+    let col = countColumn(space2, state.tabSize), keep = 0;
+    let insert2 = indentString(state, Math.max(0, col - getIndentUnit(state)));
+    while (keep < space2.length && keep < insert2.length && space2.charCodeAt(keep) == insert2.charCodeAt(keep))
+      keep++;
+    changes.push({ from: line.from + keep, to: line.from + space2.length, insert: insert2.slice(keep) });
+  }), { userEvent: "delete.dedent" }));
+  return true;
+};
+var indentWithTab = { key: "Tab", run: indentMore, shift: indentLess };
+
+// node_modules/@lezer/lr/dist/index.js
+var Stack = class _Stack {
+  /**
+  @internal
+  */
+  constructor(p, stack, state, reducePos, pos, score, buffer, bufferBase, curContext, lookAhead = 0, parent) {
+    this.p = p;
+    this.stack = stack;
+    this.state = state;
+    this.reducePos = reducePos;
+    this.pos = pos;
+    this.score = score;
+    this.buffer = buffer;
+    this.bufferBase = bufferBase;
+    this.curContext = curContext;
+    this.lookAhead = lookAhead;
+    this.parent = parent;
+  }
+  /**
+  @internal
+  */
+  toString() {
+    return `[${this.stack.filter((_, i2) => i2 % 3 == 0).concat(this.state)}]@${this.pos}${this.score ? "!" + this.score : ""}`;
+  }
+  // Start an empty stack
+  /**
+  @internal
+  */
+  static start(p, state, pos = 0) {
+    let cx = p.parser.context;
+    return new _Stack(p, [], state, pos, pos, 0, [], 0, cx ? new StackContext(cx, cx.start) : null, 0, null);
+  }
+  /**
+  The stack's current [context](#lr.ContextTracker) value, if
+  any. Its type will depend on the context tracker's type
+  parameter, or it will be `null` if there is no context
+  tracker.
+  */
+  get context() {
+    return this.curContext ? this.curContext.context : null;
+  }
+  // Push a state onto the stack, tracking its start position as well
+  // as the buffer base at that point.
+  /**
+  @internal
+  */
+  pushState(state, start) {
+    this.stack.push(this.state, start, this.bufferBase + this.buffer.length);
+    this.state = state;
+  }
+  // Apply a reduce action
+  /**
+  @internal
+  */
+  reduce(action) {
+    var _a2;
+    let depth = action >> 19, type = action & 65535;
+    let { parser: parser3 } = this.p;
+    let lookaheadRecord = this.reducePos < this.pos - 25 && this.setLookAhead(this.pos);
+    let dPrec = parser3.dynamicPrecedence(type);
+    if (dPrec)
+      this.score += dPrec;
+    if (depth == 0) {
+      if (type < parser3.minRepeatTerm && this.reducePos < this.pos)
+        this.reducePos = this.pos;
+      this.pushState(parser3.getGoto(this.state, type, true), this.reducePos);
+      if (type < parser3.minRepeatTerm)
+        this.storeNode(type, this.reducePos, this.reducePos, lookaheadRecord ? 8 : 4, true);
+      this.reduceContext(type, this.reducePos);
+      return;
+    }
+    let base2 = this.stack.length - (depth - 1) * 3 - (action & 262144 ? 6 : 0);
+    let start = base2 ? this.stack[base2 - 2] : this.p.ranges[0].from;
+    if (type < parser3.minRepeatTerm && start == this.reducePos && this.reducePos < this.pos)
+      this.reducePos = this.pos;
+    let size = this.reducePos - start;
+    if (size >= 2e3 && !((_a2 = this.p.parser.nodeSet.types[type]) === null || _a2 === void 0 ? void 0 : _a2.isAnonymous)) {
+      if (start == this.p.lastBigReductionStart) {
+        this.p.bigReductionCount++;
+        this.p.lastBigReductionSize = size;
+      } else if (this.p.lastBigReductionSize < size) {
+        this.p.bigReductionCount = 1;
+        this.p.lastBigReductionStart = start;
+        this.p.lastBigReductionSize = size;
+      }
+    }
+    let bufferBase = base2 ? this.stack[base2 - 1] : 0, count = this.bufferBase + this.buffer.length - bufferBase;
+    if (type < parser3.minRepeatTerm || action & 131072) {
+      let pos = parser3.stateFlag(
+        this.state,
+        1
+        /* StateFlag.Skipped */
+      ) ? this.pos : this.reducePos;
+      this.storeNode(type, start, pos, count + 4, true);
+    }
+    if (action & 262144) {
+      this.state = this.stack[base2];
+    } else {
+      let baseStateID = this.stack[base2 - 3];
+      this.state = parser3.getGoto(baseStateID, type, true);
+    }
+    while (this.stack.length > base2)
+      this.stack.pop();
+    this.reduceContext(type, start);
+  }
+  // Shift a value into the buffer
+  /**
+  @internal
+  */
+  storeNode(term, start, end, size = 4, mustSink = false) {
+    if (term == 0 && (!this.stack.length || this.stack[this.stack.length - 1] < this.buffer.length + this.bufferBase)) {
+      let top2 = this.buffer.length;
+      if (top2 > 0 && this.buffer[top2 - 4] == 0 && this.buffer[top2 - 1] > -1) {
+        if (start == end)
+          return;
+        if (this.buffer[top2 - 2] >= start) {
+          this.buffer[top2 - 2] = end;
+          return;
+        }
+      }
+    }
+    if (!mustSink || this.pos == end) {
+      this.buffer.push(term, start, end, size);
+    } else {
+      let index = this.buffer.length;
+      if (index > 0 && (this.buffer[index - 4] != 0 || this.buffer[index - 1] < 0)) {
+        let mustMove = false;
+        for (let scan = index; scan > 0 && this.buffer[scan - 2] > end; scan -= 4) {
+          if (this.buffer[scan - 1] >= 0) {
+            mustMove = true;
+            break;
+          }
+        }
+        if (mustMove)
+          while (index > 0 && this.buffer[index - 2] > end) {
+            this.buffer[index] = this.buffer[index - 4];
+            this.buffer[index + 1] = this.buffer[index - 3];
+            this.buffer[index + 2] = this.buffer[index - 2];
+            this.buffer[index + 3] = this.buffer[index - 1];
+            index -= 4;
+            if (size > 4)
+              size -= 4;
+          }
+      }
+      this.buffer[index] = term;
+      this.buffer[index + 1] = start;
+      this.buffer[index + 2] = end;
+      this.buffer[index + 3] = size;
+    }
+  }
+  // Apply a shift action
+  /**
+  @internal
+  */
+  shift(action, type, start, end) {
+    if (action & 131072) {
+      this.pushState(action & 65535, this.pos);
+    } else if ((action & 262144) == 0) {
+      let nextState = action, { parser: parser3 } = this.p;
+      this.pos = end;
+      let skipped = parser3.stateFlag(
+        nextState,
+        1
+        /* StateFlag.Skipped */
+      );
+      if (!skipped && (end > start || type <= parser3.maxNode))
+        this.reducePos = end;
+      this.pushState(nextState, skipped ? start : Math.min(start, this.reducePos));
+      this.shiftContext(type, start);
+      if (type <= parser3.maxNode)
+        this.buffer.push(type, start, end, 4);
+    } else {
+      this.pos = end;
+      this.shiftContext(type, start);
+      if (type <= this.p.parser.maxNode)
+        this.buffer.push(type, start, end, 4);
+    }
+  }
+  // Apply an action
+  /**
+  @internal
+  */
+  apply(action, next, nextStart, nextEnd) {
+    if (action & 65536)
+      this.reduce(action);
+    else
+      this.shift(action, next, nextStart, nextEnd);
+  }
+  // Add a prebuilt (reused) node into the buffer.
+  /**
+  @internal
+  */
+  useNode(value, next) {
+    let index = this.p.reused.length - 1;
+    if (index < 0 || this.p.reused[index] != value) {
+      this.p.reused.push(value);
+      index++;
+    }
+    let start = this.pos;
+    this.reducePos = this.pos = start + value.length;
+    this.pushState(next, start);
+    this.buffer.push(
+      index,
+      start,
+      this.reducePos,
+      -1
+      /* size == -1 means this is a reused value */
+    );
+    if (this.curContext)
+      this.updateContext(this.curContext.tracker.reuse(this.curContext.context, value, this, this.p.stream.reset(this.pos - value.length)));
+  }
+  // Split the stack. Due to the buffer sharing and the fact
+  // that `this.stack` tends to stay quite shallow, this isn't very
+  // expensive.
+  /**
+  @internal
+  */
+  split() {
+    let parent = this;
+    let off = parent.buffer.length;
+    if (off && parent.buffer[off - 4] == 0)
+      off -= 4;
+    while (off > 0 && parent.buffer[off - 2] > parent.reducePos)
+      off -= 4;
+    let buffer = parent.buffer.slice(off), base2 = parent.bufferBase + off;
+    while (parent && base2 == parent.bufferBase)
+      parent = parent.parent;
+    return new _Stack(this.p, this.stack.slice(), this.state, this.reducePos, this.pos, this.score, buffer, base2, this.curContext, this.lookAhead, parent);
+  }
+  // Try to recover from an error by 'deleting' (ignoring) one token.
+  /**
+  @internal
+  */
+  recoverByDelete(next, nextEnd) {
+    let isNode = next <= this.p.parser.maxNode;
+    if (isNode)
+      this.storeNode(next, this.pos, nextEnd, 4);
+    this.storeNode(0, this.pos, nextEnd, isNode ? 8 : 4);
+    this.pos = this.reducePos = nextEnd;
+    this.score -= 190;
+  }
+  /**
+  Check if the given term would be able to be shifted (optionally
+  after some reductions) on this stack. This can be useful for
+  external tokenizers that want to make sure they only provide a
+  given token when it applies.
+  */
+  canShift(term) {
+    for (let sim = new SimulatedStack(this); ; ) {
+      let action = this.p.parser.stateSlot(
+        sim.state,
+        4
+        /* ParseState.DefaultReduce */
+      ) || this.p.parser.hasAction(sim.state, term);
+      if (action == 0)
+        return false;
+      if ((action & 65536) == 0)
+        return true;
+      sim.reduce(action);
+    }
+  }
+  // Apply up to Recover.MaxNext recovery actions that conceptually
+  // inserts some missing token or rule.
+  /**
+  @internal
+  */
+  recoverByInsert(next) {
+    if (this.stack.length >= 300)
+      return [];
+    let nextStates = this.p.parser.nextStates(this.state);
+    if (nextStates.length > 4 << 1 || this.stack.length >= 120) {
+      let best = [];
+      for (let i2 = 0, s; i2 < nextStates.length; i2 += 2) {
+        if ((s = nextStates[i2 + 1]) != this.state && this.p.parser.hasAction(s, next))
+          best.push(nextStates[i2], s);
+      }
+      if (this.stack.length < 120)
+        for (let i2 = 0; best.length < 4 << 1 && i2 < nextStates.length; i2 += 2) {
+          let s = nextStates[i2 + 1];
+          if (!best.some((v, i3) => i3 & 1 && v == s))
+            best.push(nextStates[i2], s);
+        }
+      nextStates = best;
+    }
+    let result = [];
+    for (let i2 = 0; i2 < nextStates.length && result.length < 4; i2 += 2) {
+      let s = nextStates[i2 + 1];
+      if (s == this.state)
+        continue;
+      let stack = this.split();
+      stack.pushState(s, this.pos);
+      stack.storeNode(0, stack.pos, stack.pos, 4, true);
+      stack.shiftContext(nextStates[i2], this.pos);
+      stack.reducePos = this.pos;
+      stack.score -= 200;
+      result.push(stack);
+    }
+    return result;
+  }
+  // Force a reduce, if possible. Return false if that can't
+  // be done.
+  /**
+  @internal
+  */
+  forceReduce() {
+    let { parser: parser3 } = this.p;
+    let reduce = parser3.stateSlot(
+      this.state,
+      5
+      /* ParseState.ForcedReduce */
+    );
+    if ((reduce & 65536) == 0)
+      return false;
+    if (!parser3.validAction(this.state, reduce)) {
+      let depth = reduce >> 19, term = reduce & 65535;
+      let target = this.stack.length - depth * 3;
+      if (target < 0 || parser3.getGoto(this.stack[target], term, false) < 0) {
+        let backup = this.findForcedReduction();
+        if (backup == null)
+          return false;
+        reduce = backup;
+      }
+      this.storeNode(0, this.pos, this.pos, 4, true);
+      this.score -= 100;
+    }
+    this.reducePos = this.pos;
+    this.reduce(reduce);
+    return true;
+  }
+  /**
+  Try to scan through the automaton to find some kind of reduction
+  that can be applied. Used when the regular ForcedReduce field
+  isn't a valid action. @internal
+  */
+  findForcedReduction() {
+    let { parser: parser3 } = this.p, seen = [];
+    let explore = (state, depth) => {
+      if (seen.includes(state))
+        return;
+      seen.push(state);
+      return parser3.allActions(state, (action) => {
+        if (action & (262144 | 131072)) ;
+        else if (action & 65536) {
+          let rDepth = (action >> 19) - depth;
+          if (rDepth > 1) {
+            let term = action & 65535, target = this.stack.length - rDepth * 3;
+            if (target >= 0 && parser3.getGoto(this.stack[target], term, false) >= 0)
+              return rDepth << 19 | 65536 | term;
+          }
+        } else {
+          let found = explore(action, depth + 1);
+          if (found != null)
+            return found;
+        }
+      });
+    };
+    return explore(this.state, 0);
+  }
+  /**
+  @internal
+  */
+  forceAll() {
+    while (!this.p.parser.stateFlag(
+      this.state,
+      2
+      /* StateFlag.Accepting */
+    )) {
+      if (!this.forceReduce()) {
+        this.storeNode(0, this.pos, this.pos, 4, true);
+        break;
+      }
+    }
+    return this;
+  }
+  /**
+  Check whether this state has no further actions (assumed to be a direct descendant of the
+  top state, since any other states must be able to continue
+  somehow). @internal
+  */
+  get deadEnd() {
+    if (this.stack.length != 3)
+      return false;
+    let { parser: parser3 } = this.p;
+    return parser3.data[parser3.stateSlot(
+      this.state,
+      1
+      /* ParseState.Actions */
+    )] == 65535 && !parser3.stateSlot(
+      this.state,
+      4
+      /* ParseState.DefaultReduce */
+    );
+  }
+  /**
+  Restart the stack (put it back in its start state). Only safe
+  when this.stack.length == 3 (state is directly below the top
+  state). @internal
+  */
+  restart() {
+    this.storeNode(0, this.pos, this.pos, 4, true);
+    this.state = this.stack[0];
+    this.stack.length = 0;
+  }
+  /**
+  @internal
+  */
+  sameState(other) {
+    if (this.state != other.state || this.stack.length != other.stack.length)
+      return false;
+    for (let i2 = 0; i2 < this.stack.length; i2 += 3)
+      if (this.stack[i2] != other.stack[i2])
+        return false;
+    return true;
+  }
+  /**
+  Get the parser used by this stack.
+  */
+  get parser() {
+    return this.p.parser;
+  }
+  /**
+  Test whether a given dialect (by numeric ID, as exported from
+  the terms file) is enabled.
+  */
+  dialectEnabled(dialectID) {
+    return this.p.parser.dialect.flags[dialectID];
+  }
+  shiftContext(term, start) {
+    if (this.curContext)
+      this.updateContext(this.curContext.tracker.shift(this.curContext.context, term, this, this.p.stream.reset(start)));
+  }
+  reduceContext(term, start) {
+    if (this.curContext)
+      this.updateContext(this.curContext.tracker.reduce(this.curContext.context, term, this, this.p.stream.reset(start)));
+  }
+  /**
+  @internal
+  */
+  emitContext() {
+    let last = this.buffer.length - 1;
+    if (last < 0 || this.buffer[last] != -3)
+      this.buffer.push(this.curContext.hash, this.pos, this.pos, -3);
+  }
+  /**
+  @internal
+  */
+  emitLookAhead() {
+    let last = this.buffer.length - 1;
+    if (last < 0 || this.buffer[last] != -4)
+      this.buffer.push(this.lookAhead, this.pos, this.pos, -4);
+  }
+  updateContext(context) {
+    if (context != this.curContext.context) {
+      let newCx = new StackContext(this.curContext.tracker, context);
+      if (newCx.hash != this.curContext.hash)
+        this.emitContext();
+      this.curContext = newCx;
+    }
+  }
+  /**
+  @internal
+  */
+  setLookAhead(lookAhead) {
+    if (lookAhead <= this.lookAhead)
+      return false;
+    this.emitLookAhead();
+    this.lookAhead = lookAhead;
+    return true;
+  }
+  /**
+  @internal
+  */
+  close() {
+    if (this.curContext && this.curContext.tracker.strict)
+      this.emitContext();
+    if (this.lookAhead > 0)
+      this.emitLookAhead();
+  }
+};
+var StackContext = class {
+  constructor(tracker, context) {
+    this.tracker = tracker;
+    this.context = context;
+    this.hash = tracker.strict ? tracker.hash(context) : 0;
+  }
+};
+var SimulatedStack = class {
+  constructor(start) {
+    this.start = start;
+    this.state = start.state;
+    this.stack = start.stack;
+    this.base = this.stack.length;
+  }
+  reduce(action) {
+    let term = action & 65535, depth = action >> 19;
+    if (depth == 0) {
+      if (this.stack == this.start.stack)
+        this.stack = this.stack.slice();
+      this.stack.push(this.state, 0, 0);
+      this.base += 3;
+    } else {
+      this.base -= (depth - 1) * 3;
+    }
+    let goto = this.start.p.parser.getGoto(this.stack[this.base - 3], term, true);
+    this.state = goto;
+  }
+};
+var StackBufferCursor = class _StackBufferCursor {
+  constructor(stack, pos, index) {
+    this.stack = stack;
+    this.pos = pos;
+    this.index = index;
+    this.buffer = stack.buffer;
+    if (this.index == 0)
+      this.maybeNext();
+  }
+  static create(stack, pos = stack.bufferBase + stack.buffer.length) {
+    return new _StackBufferCursor(stack, pos, pos - stack.bufferBase);
+  }
+  maybeNext() {
+    let next = this.stack.parent;
+    if (next != null) {
+      this.index = this.stack.bufferBase - next.bufferBase;
+      this.stack = next;
+      this.buffer = next.buffer;
+    }
+  }
+  get id() {
+    return this.buffer[this.index - 4];
+  }
+  get start() {
+    return this.buffer[this.index - 3];
+  }
+  get end() {
+    return this.buffer[this.index - 2];
+  }
+  get size() {
+    return this.buffer[this.index - 1];
+  }
+  next() {
+    this.index -= 4;
+    this.pos -= 4;
+    if (this.index == 0)
+      this.maybeNext();
+  }
+  fork() {
+    return new _StackBufferCursor(this.stack, this.pos, this.index);
+  }
+};
+function decodeArray(input, Type = Uint16Array) {
+  if (typeof input != "string")
+    return input;
+  let array = null;
+  for (let pos = 0, out = 0; pos < input.length; ) {
+    let value = 0;
+    for (; ; ) {
+      let next = input.charCodeAt(pos++), stop = false;
+      if (next == 126) {
+        value = 65535;
+        break;
+      }
+      if (next >= 92)
+        next--;
+      if (next >= 34)
+        next--;
+      let digit = next - 32;
+      if (digit >= 46) {
+        digit -= 46;
+        stop = true;
+      }
+      value += digit;
+      if (stop)
+        break;
+      value *= 46;
+    }
+    if (array)
+      array[out++] = value;
+    else
+      array = new Type(value);
+  }
+  return array;
+}
+var CachedToken = class {
+  constructor() {
+    this.start = -1;
+    this.value = -1;
+    this.end = -1;
+    this.extended = -1;
+    this.lookAhead = 0;
+    this.mask = 0;
+    this.context = 0;
+  }
+};
+var nullToken = new CachedToken();
+var InputStream = class {
+  /**
+  @internal
+  */
+  constructor(input, ranges) {
+    this.input = input;
+    this.ranges = ranges;
+    this.chunk = "";
+    this.chunkOff = 0;
+    this.chunk2 = "";
+    this.chunk2Pos = 0;
+    this.next = -1;
+    this.token = nullToken;
+    this.rangeIndex = 0;
+    this.pos = this.chunkPos = ranges[0].from;
+    this.range = ranges[0];
+    this.end = ranges[ranges.length - 1].to;
+    this.readNext();
+  }
+  /**
+  @internal
+  */
+  resolveOffset(offset, assoc) {
+    let range = this.range, index = this.rangeIndex;
+    let pos = this.pos + offset;
+    while (pos < range.from) {
+      if (!index)
+        return null;
+      let next = this.ranges[--index];
+      pos -= range.from - next.to;
+      range = next;
+    }
+    while (assoc < 0 ? pos > range.to : pos >= range.to) {
+      if (index == this.ranges.length - 1)
+        return null;
+      let next = this.ranges[++index];
+      pos += next.from - range.to;
+      range = next;
+    }
+    return pos;
+  }
+  /**
+  @internal
+  */
+  clipPos(pos) {
+    if (pos >= this.range.from && pos < this.range.to)
+      return pos;
+    for (let range of this.ranges)
+      if (range.to > pos)
+        return Math.max(pos, range.from);
+    return this.end;
+  }
+  /**
+  Look at a code unit near the stream position. `.peek(0)` equals
+  `.next`, `.peek(-1)` gives you the previous character, and so
+  on.
+  
+  Note that looking around during tokenizing creates dependencies
+  on potentially far-away content, which may reduce the
+  effectiveness incremental parsing—when looking forward—or even
+  cause invalid reparses when looking backward more than 25 code
+  units, since the library does not track lookbehind.
+  */
+  peek(offset) {
+    let idx = this.chunkOff + offset, pos, result;
+    if (idx >= 0 && idx < this.chunk.length) {
+      pos = this.pos + offset;
+      result = this.chunk.charCodeAt(idx);
+    } else {
+      let resolved = this.resolveOffset(offset, 1);
+      if (resolved == null)
+        return -1;
+      pos = resolved;
+      if (pos >= this.chunk2Pos && pos < this.chunk2Pos + this.chunk2.length) {
+        result = this.chunk2.charCodeAt(pos - this.chunk2Pos);
+      } else {
+        let i2 = this.rangeIndex, range = this.range;
+        while (range.to <= pos)
+          range = this.ranges[++i2];
+        this.chunk2 = this.input.chunk(this.chunk2Pos = pos);
+        if (pos + this.chunk2.length > range.to)
+          this.chunk2 = this.chunk2.slice(0, range.to - pos);
+        result = this.chunk2.charCodeAt(0);
+      }
+    }
+    if (pos >= this.token.lookAhead)
+      this.token.lookAhead = pos + 1;
+    return result;
+  }
+  /**
+  Accept a token. By default, the end of the token is set to the
+  current stream position, but you can pass an offset (relative to
+  the stream position) to change that.
+  */
+  acceptToken(token, endOffset = 0) {
+    let end = endOffset ? this.resolveOffset(endOffset, -1) : this.pos;
+    if (end == null || end < this.token.start)
+      throw new RangeError("Token end out of bounds");
+    this.token.value = token;
+    this.token.end = end;
+  }
+  /**
+  Accept a token ending at a specific given position.
+  */
+  acceptTokenTo(token, endPos) {
+    this.token.value = token;
+    this.token.end = endPos;
+  }
+  getChunk() {
+    if (this.pos >= this.chunk2Pos && this.pos < this.chunk2Pos + this.chunk2.length) {
+      let { chunk, chunkPos } = this;
+      this.chunk = this.chunk2;
+      this.chunkPos = this.chunk2Pos;
+      this.chunk2 = chunk;
+      this.chunk2Pos = chunkPos;
+      this.chunkOff = this.pos - this.chunkPos;
+    } else {
+      this.chunk2 = this.chunk;
+      this.chunk2Pos = this.chunkPos;
+      let nextChunk = this.input.chunk(this.pos);
+      let end = this.pos + nextChunk.length;
+      this.chunk = end > this.range.to ? nextChunk.slice(0, this.range.to - this.pos) : nextChunk;
+      this.chunkPos = this.pos;
+      this.chunkOff = 0;
+    }
+  }
+  readNext() {
+    if (this.chunkOff >= this.chunk.length) {
+      this.getChunk();
+      if (this.chunkOff == this.chunk.length)
+        return this.next = -1;
+    }
+    return this.next = this.chunk.charCodeAt(this.chunkOff);
+  }
+  /**
+  Move the stream forward N (defaults to 1) code units. Returns
+  the new value of [`next`](#lr.InputStream.next).
+  */
+  advance(n = 1) {
+    this.chunkOff += n;
+    while (this.pos + n >= this.range.to) {
+      if (this.rangeIndex == this.ranges.length - 1)
+        return this.setDone();
+      n -= this.range.to - this.pos;
+      this.range = this.ranges[++this.rangeIndex];
+      this.pos = this.range.from;
+    }
+    this.pos += n;
+    if (this.pos >= this.token.lookAhead)
+      this.token.lookAhead = this.pos + 1;
+    return this.readNext();
+  }
+  setDone() {
+    this.pos = this.chunkPos = this.end;
+    this.range = this.ranges[this.rangeIndex = this.ranges.length - 1];
+    this.chunk = "";
+    return this.next = -1;
+  }
+  /**
+  @internal
+  */
+  reset(pos, token) {
+    if (token) {
+      this.token = token;
+      token.start = pos;
+      token.lookAhead = pos + 1;
+      token.value = token.extended = -1;
+    } else {
+      this.token = nullToken;
+    }
+    if (this.pos != pos) {
+      this.pos = pos;
+      if (pos == this.end) {
+        this.setDone();
+        return this;
+      }
+      while (pos < this.range.from)
+        this.range = this.ranges[--this.rangeIndex];
+      while (pos >= this.range.to)
+        this.range = this.ranges[++this.rangeIndex];
+      if (pos >= this.chunkPos && pos < this.chunkPos + this.chunk.length) {
+        this.chunkOff = pos - this.chunkPos;
+      } else {
+        this.chunk = "";
+        this.chunkOff = 0;
+      }
+      this.readNext();
+    }
+    return this;
+  }
+  /**
+  @internal
+  */
+  read(from, to) {
+    if (from >= this.chunkPos && to <= this.chunkPos + this.chunk.length)
+      return this.chunk.slice(from - this.chunkPos, to - this.chunkPos);
+    if (from >= this.chunk2Pos && to <= this.chunk2Pos + this.chunk2.length)
+      return this.chunk2.slice(from - this.chunk2Pos, to - this.chunk2Pos);
+    if (from >= this.range.from && to <= this.range.to)
+      return this.input.read(from, to);
+    let result = "";
+    for (let r2 of this.ranges) {
+      if (r2.from >= to)
+        break;
+      if (r2.to > from)
+        result += this.input.read(Math.max(r2.from, from), Math.min(r2.to, to));
+    }
+    return result;
+  }
+};
+var TokenGroup = class {
+  constructor(data, id2) {
+    this.data = data;
+    this.id = id2;
+  }
+  token(input, stack) {
+    let { parser: parser3 } = stack.p;
+    readToken(this.data, input, stack, this.id, parser3.data, parser3.tokenPrecTable);
+  }
+};
+TokenGroup.prototype.contextual = TokenGroup.prototype.fallback = TokenGroup.prototype.extend = false;
+var LocalTokenGroup = class {
+  constructor(data, precTable, elseToken) {
+    this.precTable = precTable;
+    this.elseToken = elseToken;
+    this.data = typeof data == "string" ? decodeArray(data) : data;
+  }
+  token(input, stack) {
+    let start = input.pos, skipped = 0;
+    for (; ; ) {
+      let atEof = input.next < 0, nextPos = input.resolveOffset(1, 1);
+      readToken(this.data, input, stack, 0, this.data, this.precTable);
+      if (input.token.value > -1)
+        break;
+      if (this.elseToken == null)
+        return;
+      if (!atEof)
+        skipped++;
+      if (nextPos == null)
+        break;
+      input.reset(nextPos, input.token);
+    }
+    if (skipped) {
+      input.reset(start, input.token);
+      input.acceptToken(this.elseToken, skipped);
+    }
+  }
+};
+LocalTokenGroup.prototype.contextual = TokenGroup.prototype.fallback = TokenGroup.prototype.extend = false;
+var ExternalTokenizer = class {
+  /**
+  Create a tokenizer. The first argument is the function that,
+  given an input stream, scans for the types of tokens it
+  recognizes at the stream's position, and calls
+  [`acceptToken`](#lr.InputStream.acceptToken) when it finds
+  one.
+  */
+  constructor(token, options = {}) {
+    this.token = token;
+    this.contextual = !!options.contextual;
+    this.fallback = !!options.fallback;
+    this.extend = !!options.extend;
+  }
+};
+function readToken(data, input, stack, group, precTable, precOffset) {
+  let state = 0, groupMask = 1 << group, { dialect } = stack.p.parser;
+  scan: for (; ; ) {
+    if ((groupMask & data[state]) == 0)
+      break;
+    let accEnd = data[state + 1];
+    for (let i2 = state + 3; i2 < accEnd; i2 += 2)
+      if ((data[i2 + 1] & groupMask) > 0) {
+        let term = data[i2];
+        if (dialect.allows(term) && (input.token.value == -1 || input.token.value == term || overrides(term, input.token.value, precTable, precOffset))) {
+          input.acceptToken(term);
+          break;
+        }
+      }
+    let next = input.next, low = 0, high = data[state + 2];
+    if (input.next < 0 && high > low && data[accEnd + high * 3 - 3] == 65535) {
+      state = data[accEnd + high * 3 - 1];
+      continue scan;
+    }
+    for (; low < high; ) {
+      let mid = low + high >> 1;
+      let index = accEnd + mid + (mid << 1);
+      let from = data[index], to = data[index + 1] || 65536;
+      if (next < from)
+        high = mid;
+      else if (next >= to)
+        low = mid + 1;
+      else {
+        state = data[index + 2];
+        input.advance();
+        continue scan;
+      }
+    }
+    break;
+  }
+}
+function findOffset(data, start, term) {
+  for (let i2 = start, next; (next = data[i2]) != 65535; i2++)
+    if (next == term)
+      return i2 - start;
+  return -1;
+}
+function overrides(token, prev, tableData, tableOffset) {
+  let iPrev = findOffset(tableData, tableOffset, prev);
+  return iPrev < 0 || findOffset(tableData, tableOffset, token) < iPrev;
+}
+var verbose = typeof process != "undefined" && process.env && /\bparse\b/.test(process.env.LOG);
+var stackIDs = null;
+function cutAt(tree, pos, side) {
+  let cursor = tree.cursor(IterMode.IncludeAnonymous);
+  cursor.moveTo(pos);
+  for (; ; ) {
+    if (!(side < 0 ? cursor.childBefore(pos) : cursor.childAfter(pos)))
+      for (; ; ) {
+        if ((side < 0 ? cursor.to < pos : cursor.from > pos) && !cursor.type.isError)
+          return side < 0 ? Math.max(0, Math.min(
+            cursor.to - 1,
+            pos - 25
+            /* Lookahead.Margin */
+          )) : Math.min(tree.length, Math.max(
+            cursor.from + 1,
+            pos + 25
+            /* Lookahead.Margin */
+          ));
+        if (side < 0 ? cursor.prevSibling() : cursor.nextSibling())
+          break;
+        if (!cursor.parent())
+          return side < 0 ? 0 : tree.length;
+      }
+  }
+}
+var FragmentCursor = class {
+  constructor(fragments, nodeSet) {
+    this.fragments = fragments;
+    this.nodeSet = nodeSet;
+    this.i = 0;
+    this.fragment = null;
+    this.safeFrom = -1;
+    this.safeTo = -1;
+    this.trees = [];
+    this.start = [];
+    this.index = [];
+    this.nextFragment();
+  }
+  nextFragment() {
+    let fr = this.fragment = this.i == this.fragments.length ? null : this.fragments[this.i++];
+    if (fr) {
+      this.safeFrom = fr.openStart ? cutAt(fr.tree, fr.from + fr.offset, 1) - fr.offset : fr.from;
+      this.safeTo = fr.openEnd ? cutAt(fr.tree, fr.to + fr.offset, -1) - fr.offset : fr.to;
+      while (this.trees.length) {
+        this.trees.pop();
+        this.start.pop();
+        this.index.pop();
+      }
+      this.trees.push(fr.tree);
+      this.start.push(-fr.offset);
+      this.index.push(0);
+      this.nextStart = this.safeFrom;
+    } else {
+      this.nextStart = 1e9;
+    }
+  }
+  // `pos` must be >= any previously given `pos` for this cursor
+  nodeAt(pos) {
+    if (pos < this.nextStart)
+      return null;
+    while (this.fragment && this.safeTo <= pos)
+      this.nextFragment();
+    if (!this.fragment)
+      return null;
+    for (; ; ) {
+      let last = this.trees.length - 1;
+      if (last < 0) {
+        this.nextFragment();
+        return null;
+      }
+      let top2 = this.trees[last], index = this.index[last];
+      if (index == top2.children.length) {
+        this.trees.pop();
+        this.start.pop();
+        this.index.pop();
+        continue;
+      }
+      let next = top2.children[index];
+      let start = this.start[last] + top2.positions[index];
+      if (start > pos) {
+        this.nextStart = start;
+        return null;
+      }
+      if (next instanceof Tree) {
+        if (start == pos) {
+          if (start < this.safeFrom)
+            return null;
+          let end = start + next.length;
+          if (end <= this.safeTo) {
+            let lookAhead = next.prop(NodeProp.lookAhead);
+            if (!lookAhead || end + lookAhead < this.fragment.to)
+              return next;
+          }
+        }
+        this.index[last]++;
+        if (start + next.length >= Math.max(this.safeFrom, pos)) {
+          this.trees.push(next);
+          this.start.push(start);
+          this.index.push(0);
+        }
+      } else {
+        this.index[last]++;
+        this.nextStart = start + next.length;
+      }
+    }
+  }
+};
+var TokenCache = class {
+  constructor(parser3, stream) {
+    this.stream = stream;
+    this.tokens = [];
+    this.mainToken = null;
+    this.actions = [];
+    this.tokens = parser3.tokenizers.map((_) => new CachedToken());
+  }
+  getActions(stack) {
+    let actionIndex = 0;
+    let main = null;
+    let { parser: parser3 } = stack.p, { tokenizers } = parser3;
+    let mask = parser3.stateSlot(
+      stack.state,
+      3
+      /* ParseState.TokenizerMask */
+    );
+    let context = stack.curContext ? stack.curContext.hash : 0;
+    let lookAhead = 0;
+    for (let i2 = 0; i2 < tokenizers.length; i2++) {
+      if ((1 << i2 & mask) == 0)
+        continue;
+      let tokenizer = tokenizers[i2], token = this.tokens[i2];
+      if (main && !tokenizer.fallback)
+        continue;
+      if (tokenizer.contextual || token.start != stack.pos || token.mask != mask || token.context != context) {
+        this.updateCachedToken(token, tokenizer, stack);
+        token.mask = mask;
+        token.context = context;
+      }
+      if (token.lookAhead > token.end + 25)
+        lookAhead = Math.max(token.lookAhead, lookAhead);
+      if (token.value != 0) {
+        let startIndex = actionIndex;
+        if (token.extended > -1)
+          actionIndex = this.addActions(stack, token.extended, token.end, actionIndex);
+        actionIndex = this.addActions(stack, token.value, token.end, actionIndex);
+        if (!tokenizer.extend) {
+          main = token;
+          if (actionIndex > startIndex)
+            break;
+        }
+      }
+    }
+    while (this.actions.length > actionIndex)
+      this.actions.pop();
+    if (lookAhead)
+      stack.setLookAhead(lookAhead);
+    if (!main && stack.pos == this.stream.end) {
+      main = new CachedToken();
+      main.value = stack.p.parser.eofTerm;
+      main.start = main.end = stack.pos;
+      actionIndex = this.addActions(stack, main.value, main.end, actionIndex);
+    }
+    this.mainToken = main;
+    return this.actions;
+  }
+  getMainToken(stack) {
+    if (this.mainToken)
+      return this.mainToken;
+    let main = new CachedToken(), { pos, p } = stack;
+    main.start = pos;
+    main.end = Math.min(pos + 1, p.stream.end);
+    main.value = pos == p.stream.end ? p.parser.eofTerm : 0;
+    return main;
+  }
+  updateCachedToken(token, tokenizer, stack) {
+    let start = this.stream.clipPos(stack.pos);
+    tokenizer.token(this.stream.reset(start, token), stack);
+    if (token.value > -1) {
+      let { parser: parser3 } = stack.p;
+      for (let i2 = 0; i2 < parser3.specialized.length; i2++)
+        if (parser3.specialized[i2] == token.value) {
+          let result = parser3.specializers[i2](this.stream.read(token.start, token.end), stack);
+          if (result >= 0 && stack.p.parser.dialect.allows(result >> 1)) {
+            if ((result & 1) == 0)
+              token.value = result >> 1;
+            else
+              token.extended = result >> 1;
+            break;
+          }
+        }
+    } else {
+      token.value = 0;
+      token.end = this.stream.clipPos(start + 1);
+    }
+  }
+  putAction(action, token, end, index) {
+    for (let i2 = 0; i2 < index; i2 += 3)
+      if (this.actions[i2] == action)
+        return index;
+    this.actions[index++] = action;
+    this.actions[index++] = token;
+    this.actions[index++] = end;
+    return index;
+  }
+  addActions(stack, token, end, index) {
+    let { state } = stack, { parser: parser3 } = stack.p, { data } = parser3;
+    for (let set = 0; set < 2; set++) {
+      for (let i2 = parser3.stateSlot(
+        state,
+        set ? 2 : 1
+        /* ParseState.Actions */
+      ); ; i2 += 3) {
+        if (data[i2] == 65535) {
+          if (data[i2 + 1] == 1) {
+            i2 = pair(data, i2 + 2);
+          } else {
+            if (index == 0 && data[i2 + 1] == 2)
+              index = this.putAction(pair(data, i2 + 2), token, end, index);
+            break;
+          }
+        }
+        if (data[i2] == token)
+          index = this.putAction(pair(data, i2 + 1), token, end, index);
+      }
+    }
+    return index;
+  }
+};
+var Parse = class {
+  constructor(parser3, input, fragments, ranges) {
+    this.parser = parser3;
+    this.input = input;
+    this.ranges = ranges;
+    this.recovering = 0;
+    this.nextStackID = 9812;
+    this.minStackPos = 0;
+    this.reused = [];
+    this.stoppedAt = null;
+    this.lastBigReductionStart = -1;
+    this.lastBigReductionSize = 0;
+    this.bigReductionCount = 0;
+    this.stream = new InputStream(input, ranges);
+    this.tokens = new TokenCache(parser3, this.stream);
+    this.topTerm = parser3.top[1];
+    let { from } = ranges[0];
+    this.stacks = [Stack.start(this, parser3.top[0], from)];
+    this.fragments = fragments.length && this.stream.end - from > parser3.bufferLength * 4 ? new FragmentCursor(fragments, parser3.nodeSet) : null;
+  }
+  get parsedPos() {
+    return this.minStackPos;
+  }
+  // Move the parser forward. This will process all parse stacks at
+  // `this.pos` and try to advance them to a further position. If no
+  // stack for such a position is found, it'll start error-recovery.
+  //
+  // When the parse is finished, this will return a syntax tree. When
+  // not, it returns `null`.
+  advance() {
+    let stacks = this.stacks, pos = this.minStackPos;
+    let newStacks = this.stacks = [];
+    let stopped, stoppedTokens;
+    if (this.bigReductionCount > 300 && stacks.length == 1) {
+      let [s] = stacks;
+      while (s.forceReduce() && s.stack.length && s.stack[s.stack.length - 2] >= this.lastBigReductionStart) {
+      }
+      this.bigReductionCount = this.lastBigReductionSize = 0;
+    }
+    for (let i2 = 0; i2 < stacks.length; i2++) {
+      let stack = stacks[i2];
+      for (; ; ) {
+        this.tokens.mainToken = null;
+        if (stack.pos > pos) {
+          newStacks.push(stack);
+        } else if (this.advanceStack(stack, newStacks, stacks)) {
+          continue;
+        } else {
+          if (!stopped) {
+            stopped = [];
+            stoppedTokens = [];
+          }
+          stopped.push(stack);
+          let tok = this.tokens.getMainToken(stack);
+          stoppedTokens.push(tok.value, tok.end);
+        }
+        break;
+      }
+    }
+    if (!newStacks.length) {
+      let finished = stopped && findFinished(stopped);
+      if (finished) {
+        if (verbose)
+          console.log("Finish with " + this.stackID(finished));
+        return this.stackToTree(finished);
+      }
+      if (this.parser.strict) {
+        if (verbose && stopped)
+          console.log("Stuck with token " + (this.tokens.mainToken ? this.parser.getName(this.tokens.mainToken.value) : "none"));
+        throw new SyntaxError("No parse at " + pos);
+      }
+      if (!this.recovering)
+        this.recovering = 5;
+    }
+    if (this.recovering && stopped) {
+      let finished = this.stoppedAt != null && stopped[0].pos > this.stoppedAt ? stopped[0] : this.runRecovery(stopped, stoppedTokens, newStacks);
+      if (finished) {
+        if (verbose)
+          console.log("Force-finish " + this.stackID(finished));
+        return this.stackToTree(finished.forceAll());
+      }
+    }
+    if (this.recovering) {
+      let maxRemaining = this.recovering == 1 ? 1 : this.recovering * 3;
+      if (newStacks.length > maxRemaining) {
+        newStacks.sort((a, b) => b.score - a.score);
+        while (newStacks.length > maxRemaining)
+          newStacks.pop();
+      }
+      if (newStacks.some((s) => s.reducePos > pos))
+        this.recovering--;
+    } else if (newStacks.length > 1) {
+      outer: for (let i2 = 0; i2 < newStacks.length - 1; i2++) {
+        let stack = newStacks[i2];
+        for (let j = i2 + 1; j < newStacks.length; j++) {
+          let other = newStacks[j];
+          if (stack.sameState(other) || stack.buffer.length > 500 && other.buffer.length > 500) {
+            if ((stack.score - other.score || stack.buffer.length - other.buffer.length) > 0) {
+              newStacks.splice(j--, 1);
+            } else {
+              newStacks.splice(i2--, 1);
+              continue outer;
+            }
+          }
+        }
+      }
+      if (newStacks.length > 12) {
+        newStacks.sort((a, b) => b.score - a.score);
+        newStacks.splice(
+          12,
+          newStacks.length - 12
+          /* Rec.MaxStackCount */
+        );
+      }
+    }
+    this.minStackPos = newStacks[0].pos;
+    for (let i2 = 1; i2 < newStacks.length; i2++)
+      if (newStacks[i2].pos < this.minStackPos)
+        this.minStackPos = newStacks[i2].pos;
+    return null;
+  }
+  stopAt(pos) {
+    if (this.stoppedAt != null && this.stoppedAt < pos)
+      throw new RangeError("Can't move stoppedAt forward");
+    this.stoppedAt = pos;
+  }
+  // Returns an updated version of the given stack, or null if the
+  // stack can't advance normally. When `split` and `stacks` are
+  // given, stacks split off by ambiguous operations will be pushed to
+  // `split`, or added to `stacks` if they move `pos` forward.
+  advanceStack(stack, stacks, split) {
+    let start = stack.pos, { parser: parser3 } = this;
+    let base2 = verbose ? this.stackID(stack) + " -> " : "";
+    if (this.stoppedAt != null && start > this.stoppedAt)
+      return stack.forceReduce() ? stack : null;
+    if (this.fragments) {
+      let strictCx = stack.curContext && stack.curContext.tracker.strict, cxHash = strictCx ? stack.curContext.hash : 0;
+      for (let cached = this.fragments.nodeAt(start); cached; ) {
+        let match = this.parser.nodeSet.types[cached.type.id] == cached.type ? parser3.getGoto(stack.state, cached.type.id) : -1;
+        if (match > -1 && cached.length && (!strictCx || (cached.prop(NodeProp.contextHash) || 0) == cxHash)) {
+          stack.useNode(cached, match);
+          if (verbose)
+            console.log(base2 + this.stackID(stack) + ` (via reuse of ${parser3.getName(cached.type.id)})`);
+          return true;
+        }
+        if (!(cached instanceof Tree) || cached.children.length == 0 || cached.positions[0] > 0)
+          break;
+        let inner = cached.children[0];
+        if (inner instanceof Tree && cached.positions[0] == 0)
+          cached = inner;
+        else
+          break;
+      }
+    }
+    let defaultReduce = parser3.stateSlot(
+      stack.state,
+      4
+      /* ParseState.DefaultReduce */
+    );
+    if (defaultReduce > 0) {
+      stack.reduce(defaultReduce);
+      if (verbose)
+        console.log(base2 + this.stackID(stack) + ` (via always-reduce ${parser3.getName(
+          defaultReduce & 65535
+          /* Action.ValueMask */
+        )})`);
+      return true;
+    }
+    if (stack.stack.length >= 8400) {
+      while (stack.stack.length > 6e3 && stack.forceReduce()) {
+      }
+    }
+    let actions = this.tokens.getActions(stack);
+    for (let i2 = 0; i2 < actions.length; ) {
+      let action = actions[i2++], term = actions[i2++], end = actions[i2++];
+      let last = i2 == actions.length || !split;
+      let localStack = last ? stack : stack.split();
+      let main = this.tokens.mainToken;
+      localStack.apply(action, term, main ? main.start : localStack.pos, end);
+      if (verbose)
+        console.log(base2 + this.stackID(localStack) + ` (via ${(action & 65536) == 0 ? "shift" : `reduce of ${parser3.getName(
+          action & 65535
+          /* Action.ValueMask */
+        )}`} for ${parser3.getName(term)} @ ${start}${localStack == stack ? "" : ", split"})`);
+      if (last)
+        return true;
+      else if (localStack.pos > start)
+        stacks.push(localStack);
+      else
+        split.push(localStack);
+    }
+    return false;
+  }
+  // Advance a given stack forward as far as it will go. Returns the
+  // (possibly updated) stack if it got stuck, or null if it moved
+  // forward and was given to `pushStackDedup`.
+  advanceFully(stack, newStacks) {
+    let pos = stack.pos;
+    for (; ; ) {
+      if (!this.advanceStack(stack, null, null))
+        return false;
+      if (stack.pos > pos) {
+        pushStackDedup(stack, newStacks);
+        return true;
+      }
+    }
+  }
+  runRecovery(stacks, tokens, newStacks) {
+    let finished = null, restarted = false;
+    for (let i2 = 0; i2 < stacks.length; i2++) {
+      let stack = stacks[i2], token = tokens[i2 << 1], tokenEnd = tokens[(i2 << 1) + 1];
+      let base2 = verbose ? this.stackID(stack) + " -> " : "";
+      if (stack.deadEnd) {
+        if (restarted)
+          continue;
+        restarted = true;
+        stack.restart();
+        if (verbose)
+          console.log(base2 + this.stackID(stack) + " (restarted)");
+        let done = this.advanceFully(stack, newStacks);
+        if (done)
+          continue;
+      }
+      let force = stack.split(), forceBase = base2;
+      for (let j = 0; j < 10 && force.forceReduce(); j++) {
+        if (verbose)
+          console.log(forceBase + this.stackID(force) + " (via force-reduce)");
+        let done = this.advanceFully(force, newStacks);
+        if (done)
+          break;
+        if (verbose)
+          forceBase = this.stackID(force) + " -> ";
+      }
+      for (let insert2 of stack.recoverByInsert(token)) {
+        if (verbose)
+          console.log(base2 + this.stackID(insert2) + " (via recover-insert)");
+        this.advanceFully(insert2, newStacks);
+      }
+      if (this.stream.end > stack.pos) {
+        if (tokenEnd == stack.pos) {
+          tokenEnd++;
+          token = 0;
+        }
+        stack.recoverByDelete(token, tokenEnd);
+        if (verbose)
+          console.log(base2 + this.stackID(stack) + ` (via recover-delete ${this.parser.getName(token)})`);
+        pushStackDedup(stack, newStacks);
+      } else if (!finished || finished.score < force.score) {
+        finished = force;
+      }
+    }
+    return finished;
+  }
+  // Convert the stack's buffer to a syntax tree.
+  stackToTree(stack) {
+    stack.close();
+    return Tree.build({
+      buffer: StackBufferCursor.create(stack),
+      nodeSet: this.parser.nodeSet,
+      topID: this.topTerm,
+      maxBufferLength: this.parser.bufferLength,
+      reused: this.reused,
+      start: this.ranges[0].from,
+      length: stack.pos - this.ranges[0].from,
+      minRepeatType: this.parser.minRepeatTerm
+    });
+  }
+  stackID(stack) {
+    let id2 = (stackIDs || (stackIDs = /* @__PURE__ */ new WeakMap())).get(stack);
+    if (!id2)
+      stackIDs.set(stack, id2 = String.fromCodePoint(this.nextStackID++));
+    return id2 + stack;
+  }
+};
+function pushStackDedup(stack, newStacks) {
+  for (let i2 = 0; i2 < newStacks.length; i2++) {
+    let other = newStacks[i2];
+    if (other.pos == stack.pos && other.sameState(stack)) {
+      if (newStacks[i2].score < stack.score)
+        newStacks[i2] = stack;
+      return;
+    }
+  }
+  newStacks.push(stack);
+}
+var Dialect = class {
+  constructor(source, flags, disabled) {
+    this.source = source;
+    this.flags = flags;
+    this.disabled = disabled;
+  }
+  allows(term) {
+    return !this.disabled || this.disabled[term] == 0;
+  }
+};
+var id = (x) => x;
+var ContextTracker = class {
+  /**
+  Define a context tracker.
+  */
+  constructor(spec) {
+    this.start = spec.start;
+    this.shift = spec.shift || id;
+    this.reduce = spec.reduce || id;
+    this.reuse = spec.reuse || id;
+    this.hash = spec.hash || (() => 0);
+    this.strict = spec.strict !== false;
+  }
+};
+var LRParser = class _LRParser extends Parser {
+  /**
+  @internal
+  */
+  constructor(spec) {
+    super();
+    this.wrappers = [];
+    if (spec.version != 14)
+      throw new RangeError(`Parser version (${spec.version}) doesn't match runtime version (${14})`);
+    let nodeNames = spec.nodeNames.split(" ");
+    this.minRepeatTerm = nodeNames.length;
+    for (let i2 = 0; i2 < spec.repeatNodeCount; i2++)
+      nodeNames.push("");
+    let topTerms = Object.keys(spec.topRules).map((r2) => spec.topRules[r2][1]);
+    let nodeProps = [];
+    for (let i2 = 0; i2 < nodeNames.length; i2++)
+      nodeProps.push([]);
+    function setProp(nodeID, prop, value) {
+      nodeProps[nodeID].push([prop, prop.deserialize(String(value))]);
+    }
+    if (spec.nodeProps)
+      for (let propSpec of spec.nodeProps) {
+        let prop = propSpec[0];
+        if (typeof prop == "string")
+          prop = NodeProp[prop];
+        for (let i2 = 1; i2 < propSpec.length; ) {
+          let next = propSpec[i2++];
+          if (next >= 0) {
+            setProp(next, prop, propSpec[i2++]);
+          } else {
+            let value = propSpec[i2 + -next];
+            for (let j = -next; j > 0; j--)
+              setProp(propSpec[i2++], prop, value);
+            i2++;
+          }
+        }
+      }
+    this.nodeSet = new NodeSet(nodeNames.map((name2, i2) => NodeType.define({
+      name: i2 >= this.minRepeatTerm ? void 0 : name2,
+      id: i2,
+      props: nodeProps[i2],
+      top: topTerms.indexOf(i2) > -1,
+      error: i2 == 0,
+      skipped: spec.skippedNodes && spec.skippedNodes.indexOf(i2) > -1
+    })));
+    if (spec.propSources)
+      this.nodeSet = this.nodeSet.extend(...spec.propSources);
+    this.strict = false;
+    this.bufferLength = DefaultBufferLength;
+    let tokenArray = decodeArray(spec.tokenData);
+    this.context = spec.context;
+    this.specializerSpecs = spec.specialized || [];
+    this.specialized = new Uint16Array(this.specializerSpecs.length);
+    for (let i2 = 0; i2 < this.specializerSpecs.length; i2++)
+      this.specialized[i2] = this.specializerSpecs[i2].term;
+    this.specializers = this.specializerSpecs.map(getSpecializer);
+    this.states = decodeArray(spec.states, Uint32Array);
+    this.data = decodeArray(spec.stateData);
+    this.goto = decodeArray(spec.goto);
+    this.maxTerm = spec.maxTerm;
+    this.tokenizers = spec.tokenizers.map((value) => typeof value == "number" ? new TokenGroup(tokenArray, value) : value);
+    this.topRules = spec.topRules;
+    this.dialects = spec.dialects || {};
+    this.dynamicPrecedences = spec.dynamicPrecedences || null;
+    this.tokenPrecTable = spec.tokenPrec;
+    this.termNames = spec.termNames || null;
+    this.maxNode = this.nodeSet.types.length - 1;
+    this.dialect = this.parseDialect();
+    this.top = this.topRules[Object.keys(this.topRules)[0]];
+  }
+  createParse(input, fragments, ranges) {
+    let parse = new Parse(this, input, fragments, ranges);
+    for (let w of this.wrappers)
+      parse = w(parse, input, fragments, ranges);
+    return parse;
+  }
+  /**
+  Get a goto table entry @internal
+  */
+  getGoto(state, term, loose = false) {
+    let table = this.goto;
+    if (term >= table[0])
+      return -1;
+    for (let pos = table[term + 1]; ; ) {
+      let groupTag = table[pos++], last = groupTag & 1;
+      let target = table[pos++];
+      if (last && loose)
+        return target;
+      for (let end = pos + (groupTag >> 1); pos < end; pos++)
+        if (table[pos] == state)
+          return target;
+      if (last)
+        return -1;
+    }
+  }
+  /**
+  Check if this state has an action for a given terminal @internal
+  */
+  hasAction(state, terminal) {
+    let data = this.data;
+    for (let set = 0; set < 2; set++) {
+      for (let i2 = this.stateSlot(
+        state,
+        set ? 2 : 1
+        /* ParseState.Actions */
+      ), next; ; i2 += 3) {
+        if ((next = data[i2]) == 65535) {
+          if (data[i2 + 1] == 1)
+            next = data[i2 = pair(data, i2 + 2)];
+          else if (data[i2 + 1] == 2)
+            return pair(data, i2 + 2);
+          else
+            break;
+        }
+        if (next == terminal || next == 0)
+          return pair(data, i2 + 1);
+      }
+    }
+    return 0;
+  }
+  /**
+  @internal
+  */
+  stateSlot(state, slot) {
+    return this.states[state * 6 + slot];
+  }
+  /**
+  @internal
+  */
+  stateFlag(state, flag) {
+    return (this.stateSlot(
+      state,
+      0
+      /* ParseState.Flags */
+    ) & flag) > 0;
+  }
+  /**
+  @internal
+  */
+  validAction(state, action) {
+    return !!this.allActions(state, (a) => a == action ? true : null);
+  }
+  /**
+  @internal
+  */
+  allActions(state, action) {
+    let deflt = this.stateSlot(
+      state,
+      4
+      /* ParseState.DefaultReduce */
+    );
+    let result = deflt ? action(deflt) : void 0;
+    for (let i2 = this.stateSlot(
+      state,
+      1
+      /* ParseState.Actions */
+    ); result == null; i2 += 3) {
+      if (this.data[i2] == 65535) {
+        if (this.data[i2 + 1] == 1)
+          i2 = pair(this.data, i2 + 2);
+        else
+          break;
+      }
+      result = action(pair(this.data, i2 + 1));
+    }
+    return result;
+  }
+  /**
+  Get the states that can follow this one through shift actions or
+  goto jumps. @internal
+  */
+  nextStates(state) {
+    let result = [];
+    for (let i2 = this.stateSlot(
+      state,
+      1
+      /* ParseState.Actions */
+    ); ; i2 += 3) {
+      if (this.data[i2] == 65535) {
+        if (this.data[i2 + 1] == 1)
+          i2 = pair(this.data, i2 + 2);
+        else
+          break;
+      }
+      if ((this.data[i2 + 2] & 65536 >> 16) == 0) {
+        let value = this.data[i2 + 1];
+        if (!result.some((v, i3) => i3 & 1 && v == value))
+          result.push(this.data[i2], value);
+      }
+    }
+    return result;
+  }
+  /**
+  Configure the parser. Returns a new parser instance that has the
+  given settings modified. Settings not provided in `config` are
+  kept from the original parser.
+  */
+  configure(config) {
+    let copy = Object.assign(Object.create(_LRParser.prototype), this);
+    if (config.props)
+      copy.nodeSet = this.nodeSet.extend(...config.props);
+    if (config.top) {
+      let info = this.topRules[config.top];
+      if (!info)
+        throw new RangeError(`Invalid top rule name ${config.top}`);
+      copy.top = info;
+    }
+    if (config.tokenizers)
+      copy.tokenizers = this.tokenizers.map((t2) => {
+        let found = config.tokenizers.find((r2) => r2.from == t2);
+        return found ? found.to : t2;
+      });
+    if (config.specializers) {
+      copy.specializers = this.specializers.slice();
+      copy.specializerSpecs = this.specializerSpecs.map((s, i2) => {
+        let found = config.specializers.find((r2) => r2.from == s.external);
+        if (!found)
+          return s;
+        let spec = Object.assign(Object.assign({}, s), { external: found.to });
+        copy.specializers[i2] = getSpecializer(spec);
+        return spec;
+      });
+    }
+    if (config.contextTracker)
+      copy.context = config.contextTracker;
+    if (config.dialect)
+      copy.dialect = this.parseDialect(config.dialect);
+    if (config.strict != null)
+      copy.strict = config.strict;
+    if (config.wrap)
+      copy.wrappers = copy.wrappers.concat(config.wrap);
+    if (config.bufferLength != null)
+      copy.bufferLength = config.bufferLength;
+    return copy;
+  }
+  /**
+  Tells you whether any [parse wrappers](#lr.ParserConfig.wrap)
+  are registered for this parser.
+  */
+  hasWrappers() {
+    return this.wrappers.length > 0;
+  }
+  /**
+  Returns the name associated with a given term. This will only
+  work for all terms when the parser was generated with the
+  `--names` option. By default, only the names of tagged terms are
+  stored.
+  */
+  getName(term) {
+    return this.termNames ? this.termNames[term] : String(term <= this.maxNode && this.nodeSet.types[term].name || term);
+  }
+  /**
+  The eof term id is always allocated directly after the node
+  types. @internal
+  */
+  get eofTerm() {
+    return this.maxNode + 1;
+  }
+  /**
+  The type of top node produced by the parser.
+  */
+  get topNode() {
+    return this.nodeSet.types[this.top[1]];
+  }
+  /**
+  @internal
+  */
+  dynamicPrecedence(term) {
+    let prec2 = this.dynamicPrecedences;
+    return prec2 == null ? 0 : prec2[term] || 0;
+  }
+  /**
+  @internal
+  */
+  parseDialect(dialect) {
+    let values = Object.keys(this.dialects), flags = values.map(() => false);
+    if (dialect)
+      for (let part of dialect.split(" ")) {
+        let id2 = values.indexOf(part);
+        if (id2 >= 0)
+          flags[id2] = true;
+      }
+    let disabled = null;
+    for (let i2 = 0; i2 < values.length; i2++)
+      if (!flags[i2]) {
+        for (let j = this.dialects[values[i2]], id2; (id2 = this.data[j++]) != 65535; )
+          (disabled || (disabled = new Uint8Array(this.maxTerm + 1)))[id2] = 1;
+      }
+    return new Dialect(dialect, flags, disabled);
+  }
+  /**
+  Used by the output of the parser generator. Not available to
+  user code. @hide
+  */
+  static deserialize(spec) {
+    return new _LRParser(spec);
+  }
+};
+function pair(data, off) {
+  return data[off] | data[off + 1] << 16;
+}
+function findFinished(stacks) {
+  let best = null;
+  for (let stack of stacks) {
+    let stopped = stack.p.stoppedAt;
+    if ((stack.pos == stack.p.stream.end || stopped != null && stack.pos > stopped) && stack.p.parser.stateFlag(
+      stack.state,
+      2
+      /* StateFlag.Accepting */
+    ) && (!best || best.score < stack.score))
+      best = stack;
+  }
+  return best;
+}
+function getSpecializer(spec) {
+  if (spec.external) {
+    let mask = spec.extend ? 1 : 0;
+    return (value, stack) => spec.external(value, stack) << 1 | mask;
+  }
+  return spec.get;
+}
+
+// node_modules/lezer-r/dist/index.es.js
+var rHighlight = styleTags({
+  "repeat while for if else return break next in": tags.controlKeyword,
+  "Logical!": tags.bool,
+  function: tags.definitionKeyword,
+  "FunctionCall/Identifier FunctionCall/String": tags.function(tags.variableName),
+  "NamedArg!": tags.function(tags.attributeName),
+  Comment: tags.lineComment,
+  "Numeric Integer Complex Inf": tags.number,
+  "SpecialConstant!": tags.literal,
+  String: tags.string,
+  "ArithOp MatrixOp": tags.arithmeticOperator,
+  BitOp: tags.bitwiseOperator,
+  CompareOp: tags.compareOperator,
+  "ExtractionOp NamespaceOp": tags.operator,
+  AssignmentOperator: tags.definitionOperator,
+  "...": tags.punctuation,
+  "( )": tags.paren,
+  "[ ]": tags.squareBracket,
+  "{ }": tags.brace,
+  $: tags.derefOperator,
+  ", ;": tags.separator
+});
+var spec_Identifier = { __proto__: null, TRUE: 12, T: 14, FALSE: 18, F: 20, NULL: 30, NA: 34, Inf: 38, NaN: 42, function: 46, "...": 50, return: 60, break: 64, next: 68, if: 80, else: 82, repeat: 86, while: 90, for: 94, in: 96 };
+var parser = LRParser.deserialize({
+  version: 14,
+  states: "7dOYQPOOOOQO'#Dx'#DxOOQO'#Dw'#DwO$aQPO'#DwOOQO'#Dy'#DyO(]QPO'#DvOOQO'#Dv'#DvOOQO'#Cx'#CxO*UQPO'#CwO,YQPO'#DmO/rQPO'#DaO1kQPO'#D`OOQO'#Dz'#DzOOQO'#Du'#DuQYQPOOOOQO'#Ca'#CaOOQO'#Cd'#CdOOQO'#Cj'#CjOOQO'#Cl'#ClOOQO'#Cn'#CnOOQO'#Cp'#CpO1|QPO'#CrO2RQPO'#DTO!bQPO'#DWO2WQPO'#DYO2]QPO'#D[O3oQPO'#DROOQO,59l,59lO3yQPO'#DoOOQO'#Do'#DoO*UQPO,59cOOQO'#DP'#DPOOQO,59c,59cO5fQPO'#CyO5kQPO'#C{O7XQPO'#C}O8uQPO,59yO:ZQQO,59yOOQO'#Dd'#DdOOQO'#De'#DeOOQO'#Df'#DfOOQO'#Dg'#DgOOQO'#Dh'#DhOOQO'#Di'#DiOOQO'#Dj'#DjOOQO'#Dk'#DkOOQO'#Dl'#DlOYQPO,59}OYQPO,59}OYQPO,59}OYQPO,59}OYQPO,59}OYQPO,59}OYQPO,59}OYQPO,59}OYQPO,59}OOQO'#Db'#DbOYQPO,59zOOQO-E7k-E7kO:bQPO'#CtO!bQPO,59^OYQPO,59oOOQO,59r,59rOYQPO,59tOYQPO,59vO:mQPO'#DwO:tQPO'#DvO:{QPO'#ESO;VQPO'#ESO;aQPO,59mO;fQPO'#ESOOQO-E7m-E7mOOQO1G.}1G.}O;nQPO,59eO;uQPO,59gO;zQPO,59iO<PQPO'#EUO<ZQPO1G/eO<`QQO'#DwO>kQQO'#DvO@gQQO'#EUO@qQQO1G/eO@vQQO'#DaODcQPO1G/iODmQPO1G/iOH`QPO1G/iOHgQPO1G/iOLSQPO1G/iOL^QPO1G/iO! aQPO1G/iO!!WQPO1G/iO!$tQPO1G/iO!(dQPO1G/fO!*]QPO'#D}OYQPO'#D}O!*hQPO,59`O!*`QPO'#D}OOQO1G.x1G.xO!*mQPO1G/ZO!*tQPO1G/`O!*{QPO1G/bOOQO,59n,59nO!+SQPO'#DpO!+ZQPO,5:nO!+cQPO,5:nOOQO1G/X1G/XO!+mQPO1G/POOQO1G/P1G/POOQO1G/R1G/ROOQO1G/T1G/TOYQPO'#DqO!+tQPO,5:pOOQO7+%P7+%PO!+|QQO,5:pOOQO,59b,59bO!,UQPO'#DnO!,^QPO,5:iO!,fQPO,5:iOOQO1G.z1G.zO!bQPO7+$uO!bQPO7+$zOYQPO7+$|O!,pQPO,5:[O!,zQPO,5:[OOQO,5:[,5:[OOQO-E7n-E7nO!-UQPO1G0YOOQO7+$k7+$kO!-^QPO,5:]OOQO-E7o-E7oO!-hQQO,5:]O!/fQQO1G/iO!/pQQO1G/iO!1qQQO1G/iO!1xQQO1G/iO!3sQQO1G/iO!3}QQO1G/iO!5`QQO1G/iO!6VQQO1G/iO!6|QQO1G/iO!7TQQO1G/fO!7[QPO,5:YOYQPO,5:YOOQO,5:Y,5:YOOQO-E7l-E7lO!7gQPO1G0TO!9iQPO<<HaOOQO<<Hf<<HfO!;bQPO<<HhO!;iQPO1G/vO!;sQPO1G/tO!bQPOAN={O!bQPOAN>SO!;}QQO<<HaOOQOG23gG23gOOQOG23nG23nO8|QPO,59}O8|QPO,59}O8|QPO,59}O8|QPO,59}O8|QPO,59}O8|QPO,59}O8|QPO,59}O8|QPO,59}O8|QPO,59}O8|QPO,59zO8|QPO'#DqO!bQPO7+$uO1kQPO'#D`O!<UQPO1G/ZOYQPO,59oO!<]QPO'#DT",
+  stateData: "!<h~O!hOSPOS~ORTOSQOU_OV_OX`OY`OZQO[RO]QO_aOabOccOedOgeOxfO{gO}hO!PiO!uVO~O!pjO!w!kX!z!kX#Q!kX#R!kX#S!kX#T!kX#U!kX#V!kX#W!kX#X!kX#Y!kX#Z!kX#[!kX#]!kX#^!kX#_!kX#`!kX#a!kX#b!kX#c!kX#d!kX#e!kX#f!kX#g!kX#h!kX!s!kX!o!kX~OR!kXS!kXU!kXV!kXX!kXY!kXZ!kX[!kX]!kX_!kXa!kXc!kXe!kXg!kXx!kX{!kX}!kX!P!kX!f!kX!u!kXn!kXp!kXr!kX!t!kX!y!kX!Q!kX~P!gO!p!jX!w!jX!z!jX!|!TX!}!TX#O!TX#P!TX#Q!jX#R!jX#S!jX#T!jX#U!jX#V!jX#W!jX#X!jX#Y!jX#Z!jX#[!jX#]!jX#^!jX#_!jX#`!jX#a!jX#b!jX#c!jX#d!jX#e!jX#f!jX#g!jX#h!jX!s!jX!o!jX~OR!jXS!jXU!jXV!jXX!jXY!jXZ!jX[!jX]!jX_!jXa!jXc!jXe!jXg!jXx!jX{!jX}!jX!P!jX!f!jX!r!TX!u!jXn!jXp!jXr!jX!t!jX!y!jX!Q!jX~P&VOnqOprOrsO!toO~PYO!pjO!wtO!zuO#QvO#RvO#SwO#TwO#UxO#VyO#WyO#XyO#YzO#ZzO#[{O#]{O#^{O#_{O#`{O#a|O#b|O#c|O#d|O#e}O#f}O#g!OO#h!OO~OR!aXS!aXU!aXV!aXX!aXY!aXZ!aX[!aX]!aX_!aXa!aXc!aXe!aXg!aXx!aX{!aX}!aX!P!aX!f!aX!u!aX~P*fO!p!nX!r!TX!w!nX!z!nX!|!TX!}!TX#O!TX#P!TX#Q!nX#R!nX#S!nX#T!nX#U!nX#V!nX#W!nX#X!nX#Y!nX#Z!nX#[!nX#]!nX#^!nX#_!nX#`!nX#a!nX#b!nX#c!nX#d!nX#e!nX#f!nX#g!nX#h!nX!s!nX~OR!nXS!nXU!nXV!nXX!nXY!nXZ!nX[!nX]!nX_!nXa!nXc!nXe!nXg!nXx!nX{!nX}!nX!P!nX!f!nX!u!nXn!nXp!nXr!nX!t!nX!o!nX!y!nX!Q!nX~P-lO!r!YO!|!YO!}!YO#O!YO#P!YO~O!p!]O~O!p!_O~O!p!aO~O!p!bO~OR!dOSQOU_OV_OX`OY`OZQO[!cO]QO_aOabOccOedOgeOxfO{gO}hO!PiO!uVO~Oi!hO!o!vP~P2bOR!cXS!cXU!cXV!cXX!cXY!cXZ!cX[!cX]!cX_!cXa!cXc!cXe!cXg!cXn!cXp!cXr!cXx!cX{!cX}!cX!P!cX!t!cX!u!cX~P*fO!p!kO~O!p!lORoXSoXUoXVoXXoXYoXZoX[oX]oX_oXaoXcoXeoXgoXnoXpoXroXxoX{oX}oX!PoX!toX!uoX~O!p!mORqXSqXUqXVqXXqXYqXZqX[qX]qX_qXaqXcqXeqXgqXnqXpqXrqXxqX{qX}qX!PqX!tqX!uqX~O!y!xP~PYOR!qOSQOU_OV_OX`OY`OZQO[!pO]QO_aOabOccOedOgeOx$qO{gO}hO!PiO!uVO~O!{!xP~P8|OR#POi#SO!o!qP~O!r#XO~P!gO!r#XO~P&VO!s#YO!o!vX~P*fO!s#YO!o!vX~PYO!o#]O~O!s#YO!o!vX~O!o#_O~PYO!o#`O~O!o#aO~O!s#bO!y!xX~P*fO!y#dO~O!pjO!s!kX!w!kX!z!kX!{!kX#Q!kX#R!kX#S!kX#T!kX#U!kX#V!kX#W!kX#X!kX#Y!kX#Z!kX#[!kX#]!kX#^!kX#_!kX#`!kX#a!kX#b!kX#c!kX#d!kX#e!kX#f!kX#g!kX#h!kX~O!r!TX!|!TX!}!TX#O!TX#P!TX~O!p!jX!s!jX!w!jX!z!jX!{!jX#Q!jX#R!jX#S!jX#T!jX#U!jX#V!jX#W!jX#X!jX#Y!jX#Z!jX#[!jX#]!jX#^!jX#_!jX#`!jX#a!jX#b!jX#c!jX#d!jX#e!jX#f!jX#g!jX#h!jX~P>YO!s$lO!{!xX~P*fO!{#dO~O!{!nX~P-lO!pjOR!ViS!ViU!ViV!ViX!ViY!ViZ!Vi[!Vi]!Vi_!Via!Vic!Vie!Vig!Vix!Vi{!Vi}!Vi!P!Vi!f!Vi!u!Vi!w!Vi!z!Vi#S!Vi#T!Vi#U!Vi#V!Vi#W!Vi#X!Vi#Y!Vi#Z!Vi#[!Vi#]!Vi#^!Vi#_!Vi#`!Vi#a!Vi#b!Vi#c!Vi#d!Vi#e!Vi#f!Vi#g!Vi#h!Vin!Vip!Vir!Vi!t!Vi!o!Vi!s!Vi!y!Vi!Q!Vi~O#Q!Vi#R!Vi~P@}O#QvO#RvO~P@}O!pjO#QvO#RvO#SwO#TwOR!ViS!ViU!ViV!ViX!ViY!ViZ!Vi[!Vi]!Vi_!Via!Vic!Vie!Vig!Vix!Vi{!Vi}!Vi!P!Vi!f!Vi!u!Vi!w!Vi!z!Vi#V!Vi#W!Vi#X!Vi#Y!Vi#Z!Vi#[!Vi#]!Vi#^!Vi#_!Vi#`!Vi#a!Vi#b!Vi#c!Vi#d!Vi#e!Vi#f!Vi#g!Vi#h!Vin!Vip!Vir!Vi!t!Vi!o!Vi!s!Vi!y!Vi!Q!Vi~O#U!Vi~PDwO#UxO~PDwO!pjO#QvO#RvO#SwO#TwO#UxO#VyO#WyO#XyO#a|O#b|O#c|O#d|OR!ViS!ViU!ViV!ViX!ViY!ViZ!Vi[!Vi]!Vi_!Via!Vic!Vie!Vig!Vix!Vi{!Vi}!Vi!P!Vi!f!Vi!u!Vi!w!Vi!z!Vi#[!Vi#]!Vi#^!Vi#_!Vi#`!Vi#e!Vi#f!Vi#g!Vi#h!Vin!Vip!Vir!Vi!t!Vi!o!Vi!s!Vi!y!Vi!Q!Vi~O#Y!Vi#Z!Vi~PHnO#YzO#ZzO~PHnO!pjO#QvO#RvO#SwO#TwO#UxO#VyO#WyO#XyOR!ViS!ViU!ViV!ViX!ViY!ViZ!Vi[!Vi]!Vi_!Via!Vic!Vie!Vig!Vix!Vi{!Vi}!Vi!P!Vi!f!Vi!u!Vi!w!Vi!z!Vi#e!Vi#f!Vi#g!Vi#h!Vin!Vip!Vir!Vi!t!Vi!o!Vi!s!Vi!y!Vi!Q!Vi~O#Y!Vi#Z!Vi#[!Vi#]!Vi#^!Vi#_!Vi#`!Vi#a!Vi#b!Vi#c!Vi#d!Vi~PLhO#YzO#ZzO#[{O#]{O#^{O#_{O#`{O#a|O#b|O#c|O#d|O~PLhO!pjO#QvO#RvO#SwO#TwO#UxO#VyO#WyO#XyO#YzO#ZzO#[{O#]{O#^{O#_{O#`{O#a|O#b|O#c|O#d|O#e}O#f}O!w!Vi!z!Vi#g!Vi#h!Vi!s!Vi~OR!ViS!ViU!ViV!ViX!ViY!ViZ!Vi[!Vi]!Vi_!Via!Vic!Vie!Vig!Vix!Vi{!Vi}!Vi!P!Vi!f!Vi!u!Vin!Vip!Vir!Vi!t!Vi!o!Vi!y!Vi!Q!Vi~P!!}O!pjO!w!Si!z!Si#Q!Si#R!Si#S!Si#T!Si#U!Si#V!Si#W!Si#X!Si#Y!Si#Z!Si#[!Si#]!Si#^!Si#_!Si#`!Si#a!Si#b!Si#c!Si#d!Si#e!Si#f!Si#g!Si#h!Si!s!Si~OR!SiS!SiU!SiV!SiX!SiY!SiZ!Si[!Si]!Si_!Sia!Sic!Sie!Sig!Six!Si{!Si}!Si!P!Si!f!Si!u!Sin!Sip!Sir!Si!t!Si!o!Si!y!Si!Q!Si~P!&mO!r#fO!s#gO!o!qX~O!o#jO~O!o#kO~P*fO!o#lO~P*fO!Q#mO~P*fOi#pO~P2bO!s#YO!o!va~O!s#YO!o!va~P*fO!o#sO~P*fO!s#bO!y!xa~O!s$lO!{!xa~OR$ROi$TO~O!s#gO!o!qa~O!s#gO!o!qa~P*fO!o!da!s!da~P*fO!o!da!s!da~PYO!s#YO!o!vi~O!s!ea!y!ea~P*fO!s!ea!{!ea~P*fO!pjO!s!Vi!w!Vi!z!Vi!{!Vi#S!Vi#T!Vi#U!Vi#V!Vi#W!Vi#X!Vi#Y!Vi#Z!Vi#[!Vi#]!Vi#^!Vi#_!Vi#`!Vi#a!Vi#b!Vi#c!Vi#d!Vi#e!Vi#f!Vi#g!Vi#h!Vi~O#Q!Vi#R!Vi~P!-rO#QvO#RvO~P!-rO!pjO#QvO#RvO#SwO#TwO!s!Vi!w!Vi!z!Vi!{!Vi#V!Vi#W!Vi#X!Vi#Y!Vi#Z!Vi#[!Vi#]!Vi#^!Vi#_!Vi#`!Vi#a!Vi#b!Vi#c!Vi#d!Vi#e!Vi#f!Vi#g!Vi#h!Vi~O#U!Vi~P!/zO#UxO~P!/zO!pjO#QvO#RvO#SwO#TwO#UxO#VyO#WyO#XyO#a|O#b|O#c|O#d|O!s!Vi!w!Vi!z!Vi!{!Vi#[!Vi#]!Vi#^!Vi#_!Vi#`!Vi#e!Vi#f!Vi#g!Vi#h!Vi~O#Y!Vi#Z!Vi~P!2PO#YzO#ZzO~P!2PO!pjO#QvO#RvO#SwO#TwO#UxO#VyO#WyO#XyO!s!Vi!w!Vi!z!Vi!{!Vi#e!Vi#f!Vi#g!Vi#h!Vi~O#Y!Vi#Z!Vi#[!Vi#]!Vi#^!Vi#_!Vi#`!Vi#a!Vi#b!Vi#c!Vi#d!Vi~P!4XO#YzO#ZzO#[{O#]{O#^{O#_{O#`{O#a|O#b|O#c|O#d|O~P!4XO!{!Vi~P!!}O!{!Si~P!&mO!r#fO!o!ba!s!ba~O!s#gO!o!qi~Oy$]O!pwy!wwy!zwy#Qwy#Rwy#Swy#Twy#Uwy#Vwy#Wwy#Xwy#Ywy#Zwy#[wy#]wy#^wy#_wy#`wy#awy#bwy#cwy#dwy#ewy#fwy#gwy#hwy!swy~ORwySwyUwyVwyXwyYwyZwy[wy]wy_wyawycwyewygwyxwy{wy}wy!Pwy!fwy!uwynwypwyrwy!twy!owy!ywy!Qwy~P!7oO!o$^O~P*fO!o!di!s!di~P*fO!o!bi!s!bi~P*fO!{wy~P!7oO!o$mO~P*fO!p$pO~OS]ZRZ~",
+  goto: "7}!yPPPPP!zPP!zPPPPP#vP#vP#vP#vP$rP%nP%q%w'Y(]P(]P(]P(a(g)e*b$rPP$rP$rP$rPP(g$r*h+f$r+l,d-Y-|.n/[/v0f1O1f1l1w1}2ZPPP2e4}5y6u5y4}PP7qPPPP7tP7w!sPOW^jntu!P!Q!R!S!T!U!V!W!X!Z!_!a!b!f!k#Q#Y#b#m#o$S$b$c$d$e$f$g$h$i$j$k$l$p!sSOW^jntu!P!Q!R!S!T!U!V!W!X!Z!_!a!b!f!k#Q#Y#b#m#o$S$b$c$d$e$f$g$h$i$j$k$l$p!s[OW^jntu!P!Q!R!S!T!U!V!W!X!Z!_!a!b!f!k#Q#Y#b#m#o$S$b$c$d$e$f$g$h$i$j$k$l$pR!^eQ#Q!]R$S#g!r[OW^jntu!P!Q!R!S!T!U!V!W!X!Z!_!a!b!f!k#Q#Y#b#m#o$S$b$c$d$e$f$g$h$i$j$k$l$pQ!`gQ#T!^Q$W#kQ$X#lQ$_$mQ$`$]R$a$^#RWOW^gjntu!P!Q!R!S!T!U!V!W!X!Z!^!_!a!b!f!k#Q#Y#b#k#l#m#o$S$]$^$b$c$d$e$f$g$h$i$j$k$l$m$pTmWnQpWR!jn!YYOW^jnt!P!Q!R!S!T!U!V!W!X!Z!_!a!b!f!k#Q#Y#b#m#o$S$pi!tu$b$c$d$e$f$g$h$i$j$k$l!ukRXl!c!e!n!p!r!u!v!w!x!y!z!{!|!}#O#U#V#W#[#^#i#n#t#v#w#x#y#z#{#|#}$O$P$Q$Y$Z$[$oQ!fjR#o#Y!YZOW^jnt!P!Q!R!S!T!U!V!W!X!Z!_!a!b!f!k#Q#Y#b#m#o$S$pi$nu$b$c$d$e$f$g$h$i$j$k$lQ!ZZR$k$n!Q!PXl!e!n!v!w!x!y!z!{!|!}#U#V#W#[#^#i#n#t$Y$Z$[$oe$b!r#v#x#y#z#{#|#}$O$P!O!QXl!e!n!w!x!y!z!{!|!}#U#V#W#[#^#i#n#t$Y$Z$[$oc$c!r#v#y#z#{#|#}$O$P|!RXl!e!n!x!y!z!{!|!}#U#V#W#[#^#i#n#t$Y$Z$[$oa$d!r#v#z#{#|#}$O$Pz!SXl!e!n!y!z!{!|!}#U#V#W#[#^#i#n#t$Y$Z$[$o_$e!r#v#{#|#}$O$Pv!TXl!e!n!z!|!}#U#V#W#[#^#i#n#t$Y$Z$[$oZ$f!r#v#|$O$Pt!UXl!e!n!|!}#U#V#W#[#^#i#n#t$Y$Z$[$oX$g!r#v$O$Px!VXl!e!n!y!z!|!}#U#V#W#[#^#i#n#t$Y$Z$[$o]$h!r#v#{#|$O$Pr!WXl!e!n!}#U#V#W#[#^#i#n#t$Y$Z$[$oV$i!r#v$Pp!XXl!e!n#U#V#W#[#^#i#n#t$Y$Z$[$oT$j!r#vQ^OR![^S#h#P#SS$U#h$VR$V#iQnWR!inU#Z!e!f!hS#q#Z#rR#r#[Q#c!nQ#e!rT#u#c#eSXO^SlWnQ!ejQ!ntQ!ruQ!u!PQ!v!QQ!w!RQ!x!SQ!y!TQ!z!UQ!{!VQ!|!WQ!}!XQ#O!ZQ#U!_Q#V!aQ#W!bQ#[!fQ#^!kQ#i#QQ#n#YQ#t#bQ#v$lQ#w$bQ#x$cQ#y$dQ#z$eQ#{$fQ#|$gQ#}$hQ$O$iQ$P$jQ$Q$kQ$Y#mQ$Z#oQ$[$SR$o$p!s]OW^jntu!P!Q!R!S!T!U!V!W!X!Z!_!a!b!f!k#Q#Y#b#m#o$S$b$c$d$e$f$g$h$i$j$k$l$p!sUOW^jntu!P!Q!R!S!T!U!V!W!X!Z!_!a!b!f!k#Q#Y#b#m#o$S$b$c$d$e$f$g$h$i$j$k$l$p!sQOW^jntu!P!Q!R!S!T!U!V!W!X!Z!_!a!b!f!k#Q#Y#b#m#o$S$b$c$d$e$f$g$h$i$j$k$l$pR#R!]R!gjQ!otR!su",
+  nodeNames: "\u26A0 Comment Script Identifier Integer True TRUE T False FALSE F Numeric String Complex Null NULL NA NA Inf Inf NaN NaN FunctionDeclaration function ParamList ... NamedArg Block BlockOpenBrace ReturnStatement return BreakStatement break NextStatement next BlockCloseBrace FunctionCall ArgList NamedArg IfStatement if else RepeatStatement repeat WhileStatement while ForStatement for in IndexStatement VariableAssignment Assignable AssignmentOperator BinaryStatement NamespaceOp ExtractionOp ArithOp ArithOp ArithOp CompareOp MatrixOp LogicOp LogicOp",
+  maxTerm: 116,
+  nodeProps: [
+    ["group", -11, 3, 22, 27, 36, 39, 42, 44, 46, 49, 50, 53, "Expression", -4, 4, 11, 12, 13, "Constant Expression", -2, 5, 8, "Constant Expression Logical", -4, 14, 16, 18, 20, "Expression SpecialConstant"]
+  ],
+  propSources: [rHighlight],
+  skippedNodes: [0, 1],
+  repeatNodeCount: 5,
+  tokenData: "9`~RzX^#upq#uqr$jrs$ust&mtu'Uuv'Zvw)Uwx)cxy+Uyz+Zz{+`{|+e|}+j}!O+o!O!P,U!P!Q1S!Q!R1X!R![3O![!]5j!^!_5}!_!`6p!`!a6}!b!c7Y!c!}-h!}#O7_#P#Q7l#Q#R7y#R#S-h#S#T8O#T#o-h#o#p8w#p#q8|#q#r9Z#y#z#u$f$g#u#BY#BZ#u$IS$I_#u$I|$JO#u$JT$JU#u$KV$KW#u&FU&FV#u~#zY!h~X^#upq#u#y#z#u$f$g#u#BY#BZ#u$IS$I_#u$I|$JO#u$JT$JU#u$KV$KW#u&FU&FV#u~$mP!_!`$p~$uO#]~~$zW[~OY$uZr$urs%ds#O$u#O#P%i#P;'S$u;'S;=`&g<%lO$u~%iO[~~%lRO;'S$u;'S;=`%u;=`O$u~%zX[~OY$uZr$urs%ds#O$u#O#P%i#P;'S$u;'S;=`&g;=`<%l$u<%lO$u~&jP;=`<%l$u~&rSP~OY&mZ;'S&m;'S;=`'O<%lO&m~'RP;=`<%l&m~'ZO#S~~'^Uuv'pz{'u!P!Q(Q#]#^(]#c#d(n#l#m(y~'uO#X~~'xPuv'{~(QO#b~~(TPuv(W~(]O#a~~(`P#b#c(c~(fPuv(i~(nO#`~~(qPuv(t~(yO#c~~(|Puv)P~)UO#d~~)ZP#g~vw)^~)cO#h~~)hW[~OY)cZw)cwx%dx#O)c#O#P*Q#P;'S)c;'S;=`+O<%lO)c~*TRO;'S)c;'S;=`*^;=`O)c~*cX[~OY)cZw)cwx%dx#O)c#O#P*Q#P;'S)c;'S;=`+O;=`<%l)c<%lO)c~+RP;=`<%l)c~+ZO!p~~+`O!o~~+eO#V~~+jO#Y~~+oO!s~~+tP#Z~!`!a+w~+|P!}~!`!a,P~,UO#P~~,ZTR~!O!P,j!Q![.S!c!}-h#R#S-h#T#o-h~,o]R~O!O-h!O!P-h!P!Q-h!Q![-h![!c-h!c!}-h!}#R-h#R#S-h#S#T-h#T#o-h#o;'S-h;'S;=`-|<%lO-h~-mTR~!O!P-h!Q![-h!c!}-h#R#S-h#T#o-h~.PP;=`<%l-h~.ZZZ~R~!O!P-h!Q![.S!c!g-h!g!h.|!h!}-h#R#S-h#T#X-h#X#Y.|#Y#]-h#]#^0l#^#o-h~/RVR~{|/h}!O/h!O!P-h!Q![0O!c!}-h#R#S-h#T#o-h~/kP!Q![/n~/sQZ~!Q![/n#]#^/y~0OO]~~0VVZ~R~!O!P-h!Q![0O!c!}-h#R#S-h#T#]-h#]#^0l#^#o-h~0sT]~R~!O!P-h!Q![-h!c!}-h#R#S-h#T#o-h~1XO#W~~1^WZ~!O!P1v!Q![3O!g!h3g!n!o2y!z!{4X#X#Y3g#]#^/y#l#m4X~1{TZ~!Q![2[!g!h2m!n!o2y#X#Y2m#]#^/y~2aSZ~!Q![2[!g!h2m#X#Y2m#]#^/y~2pR{|/h}!O/h!Q![/n~3OOS~~3TUZ~!O!P1v!Q![3O!g!h3g!n!o2y#X#Y3g#]#^/y~3jR{|3s}!O3s!Q![3y~3vP!Q![3y~4ORZ~!Q![3y!n!o2y#]#^/y~4[U!O!P4n!Q![5Q!c!i5Q!r!s2m#T#Z5Q#d#e2m~4qT!Q![4n!c!i4n!r!s2m#T#Z4n#d#e2m~5TV!O!P4n!Q![5Q!c!i5Q!n!o2y!r!s2m#T#Z5Q#d#e2m~5mP![!]5p~5uP#Q~![!]5x~5}O#R~~6QR}!O6Z!^!_6`!_!`6k~6`O!|~~6cP}!O6f~6kO#O~~6pO#_~~6uP!r~!_!`6x~6}O#[~~7QP!_!`7T~7YO#^~~7_O#T~~7dP!w~!}#O7g~7lO!z~R7qP!yP#P#Q7tQ7yO!{Q~8OO#U~~8RSO#S8_#T;'S8_;'S;=`8q<%lO8_~8bTO#S8_#S#T%d#T;'S8_;'S;=`8q<%lO8_~8tP;=`<%l8_~8|O!u~~9RP#e~#p#q9U~9ZO#f~~9`O!t~",
+  tokenizers: [0, 1],
+  topRules: { "Script": [0, 2] },
+  specialized: [{ term: 3, get: (value) => spec_Identifier[value] || -1 }],
+  tokenPrec: 3376
+});
+
+// node_modules/codemirror-lang-r/dist/index.js
+var rLanguage = /* @__PURE__ */ LRLanguage.define({
+  parser: /* @__PURE__ */ parser.configure({
+    props: [
+      /* @__PURE__ */ indentNodeProp.add({
+        Block: /* @__PURE__ */ delimitedIndent({ closing: "}" }),
+        "ParamList ArgList": /* @__PURE__ */ delimitedIndent({ closing: ")" })
+      }),
+      /* @__PURE__ */ foldNodeProp.add({ Block: foldInside })
+    ]
+  }),
+  languageData: {
+    closeBrackets: { brackets: ["(", "[", "{", "'", '"'] },
+    commentTokens: { line: "#" }
+  }
+});
+function r() {
+  return new LanguageSupport(rLanguage);
+}
+
+// node_modules/@lezer/python/dist/index.js
+var printKeyword = 1;
+var indent = 194;
+var dedent = 195;
+var newline$1 = 196;
+var blankLineStart = 197;
+var newlineBracketed = 198;
+var eof = 199;
+var stringContent = 200;
+var Escape = 2;
+var replacementStart = 3;
+var stringEnd = 201;
+var ParenL = 24;
+var ParenthesizedExpression = 25;
+var TupleExpression = 49;
+var ComprehensionExpression = 50;
+var BracketL = 55;
+var ArrayExpression = 56;
+var ArrayComprehensionExpression = 57;
+var BraceL = 59;
+var DictionaryExpression = 60;
+var DictionaryComprehensionExpression = 61;
+var SetExpression = 62;
+var SetComprehensionExpression = 63;
+var ArgList = 65;
+var subscript = 238;
+var String$1 = 71;
+var stringStart = 241;
+var stringStartD = 242;
+var stringStartL = 243;
+var stringStartLD = 244;
+var stringStartR = 245;
+var stringStartRD = 246;
+var stringStartRL = 247;
+var stringStartRLD = 248;
+var FormatString = 72;
+var stringStartF = 249;
+var stringStartFD = 250;
+var stringStartFL = 251;
+var stringStartFLD = 252;
+var stringStartFR = 253;
+var stringStartFRD = 254;
+var stringStartFRL = 255;
+var stringStartFRLD = 256;
+var FormatReplacement = 73;
+var nestedFormatReplacement = 77;
+var importList = 263;
+var TypeParamList = 112;
+var ParamList = 130;
+var SequencePattern = 151;
+var MappingPattern = 152;
+var PatternArgList = 155;
+var newline = 10;
+var carriageReturn = 13;
+var space = 32;
+var tab = 9;
+var hash = 35;
+var parenOpen = 40;
+var dot = 46;
+var braceOpen = 123;
+var braceClose = 125;
+var singleQuote = 39;
+var doubleQuote = 34;
+var backslash = 92;
+var letter_o = 111;
+var letter_x = 120;
+var letter_N = 78;
+var letter_u = 117;
+var letter_U = 85;
+var bracketed = /* @__PURE__ */ new Set([
+  ParenthesizedExpression,
+  TupleExpression,
+  ComprehensionExpression,
+  importList,
+  ArgList,
+  ParamList,
+  ArrayExpression,
+  ArrayComprehensionExpression,
+  subscript,
+  SetExpression,
+  SetComprehensionExpression,
+  FormatString,
+  FormatReplacement,
+  nestedFormatReplacement,
+  DictionaryExpression,
+  DictionaryComprehensionExpression,
+  SequencePattern,
+  MappingPattern,
+  PatternArgList,
+  TypeParamList
+]);
+function isLineBreak(ch) {
+  return ch == newline || ch == carriageReturn;
+}
+function isHex(ch) {
+  return ch >= 48 && ch <= 57 || ch >= 65 && ch <= 70 || ch >= 97 && ch <= 102;
+}
+var newlines = new ExternalTokenizer((input, stack) => {
+  let prev;
+  if (input.next < 0) {
+    input.acceptToken(eof);
+  } else if (stack.context.flags & cx_Bracketed) {
+    if (isLineBreak(input.next)) input.acceptToken(newlineBracketed, 1);
+  } else if (((prev = input.peek(-1)) < 0 || isLineBreak(prev)) && stack.canShift(blankLineStart)) {
+    let spaces = 0;
+    while (input.next == space || input.next == tab) {
+      input.advance();
+      spaces++;
+    }
+    if (input.next == newline || input.next == carriageReturn || input.next == hash)
+      input.acceptToken(blankLineStart, -spaces);
+  } else if (isLineBreak(input.next)) {
+    input.acceptToken(newline$1, 1);
+  }
+}, { contextual: true });
+var indentation = new ExternalTokenizer((input, stack) => {
+  let context = stack.context;
+  if (context.flags) return;
+  let prev = input.peek(-1);
+  if (prev == newline || prev == carriageReturn) {
+    let depth = 0, chars = 0;
+    for (; ; ) {
+      if (input.next == space) depth++;
+      else if (input.next == tab) depth += 8 - depth % 8;
+      else break;
+      input.advance();
+      chars++;
+    }
+    if (depth != context.indent && input.next != newline && input.next != carriageReturn && input.next != hash) {
+      if (depth < context.indent) input.acceptToken(dedent, -chars);
+      else input.acceptToken(indent);
+    }
+  }
+});
+var cx_Bracketed = 1;
+var cx_String = 2;
+var cx_DoubleQuote = 4;
+var cx_Long = 8;
+var cx_Raw = 16;
+var cx_Format = 32;
+function Context(parent, indent2, flags) {
+  this.parent = parent;
+  this.indent = indent2;
+  this.flags = flags;
+  this.hash = (parent ? parent.hash + parent.hash << 8 : 0) + indent2 + (indent2 << 4) + flags + (flags << 6);
+}
+var topIndent = new Context(null, 0, 0);
+function countIndent(space2) {
+  let depth = 0;
+  for (let i2 = 0; i2 < space2.length; i2++)
+    depth += space2.charCodeAt(i2) == tab ? 8 - depth % 8 : 1;
+  return depth;
+}
+var stringFlags = new Map([
+  [stringStart, 0],
+  [stringStartD, cx_DoubleQuote],
+  [stringStartL, cx_Long],
+  [stringStartLD, cx_Long | cx_DoubleQuote],
+  [stringStartR, cx_Raw],
+  [stringStartRD, cx_Raw | cx_DoubleQuote],
+  [stringStartRL, cx_Raw | cx_Long],
+  [stringStartRLD, cx_Raw | cx_Long | cx_DoubleQuote],
+  [stringStartF, cx_Format],
+  [stringStartFD, cx_Format | cx_DoubleQuote],
+  [stringStartFL, cx_Format | cx_Long],
+  [stringStartFLD, cx_Format | cx_Long | cx_DoubleQuote],
+  [stringStartFR, cx_Format | cx_Raw],
+  [stringStartFRD, cx_Format | cx_Raw | cx_DoubleQuote],
+  [stringStartFRL, cx_Format | cx_Raw | cx_Long],
+  [stringStartFRLD, cx_Format | cx_Raw | cx_Long | cx_DoubleQuote]
+].map(([term, flags]) => [term, flags | cx_String]));
+var trackIndent = new ContextTracker({
+  start: topIndent,
+  reduce(context, term, _, input) {
+    if (context.flags & cx_Bracketed && bracketed.has(term) || (term == String$1 || term == FormatString) && context.flags & cx_String)
+      return context.parent;
+    return context;
+  },
+  shift(context, term, stack, input) {
+    if (term == indent)
+      return new Context(context, countIndent(input.read(input.pos, stack.pos)), 0);
+    if (term == dedent)
+      return context.parent;
+    if (term == ParenL || term == BracketL || term == BraceL || term == replacementStart)
+      return new Context(context, 0, cx_Bracketed);
+    if (stringFlags.has(term))
+      return new Context(context, 0, stringFlags.get(term) | context.flags & cx_Bracketed);
+    return context;
+  },
+  hash(context) {
+    return context.hash;
+  }
+});
+var legacyPrint = new ExternalTokenizer((input) => {
+  for (let i2 = 0; i2 < 5; i2++) {
+    if (input.next != "print".charCodeAt(i2)) return;
+    input.advance();
+  }
+  if (/\w/.test(String.fromCharCode(input.next))) return;
+  for (let off = 0; ; off++) {
+    let next = input.peek(off);
+    if (next == space || next == tab) continue;
+    if (next != parenOpen && next != dot && next != newline && next != carriageReturn && next != hash)
+      input.acceptToken(printKeyword);
+    return;
+  }
+});
+var strings = new ExternalTokenizer((input, stack) => {
+  let { flags } = stack.context;
+  let quote = flags & cx_DoubleQuote ? doubleQuote : singleQuote;
+  let long = (flags & cx_Long) > 0;
+  let escapes = !(flags & cx_Raw);
+  let format = (flags & cx_Format) > 0;
+  let start = input.pos;
+  for (; ; ) {
+    if (input.next < 0) {
+      break;
+    } else if (format && input.next == braceOpen) {
+      if (input.peek(1) == braceOpen) {
+        input.advance(2);
+      } else {
+        if (input.pos == start) {
+          input.acceptToken(replacementStart, 1);
+          return;
+        }
+        break;
+      }
+    } else if (escapes && input.next == backslash) {
+      if (input.pos == start) {
+        input.advance();
+        let escaped = input.next;
+        if (escaped >= 0) {
+          input.advance();
+          skipEscape(input, escaped);
+        }
+        input.acceptToken(Escape);
+        return;
+      }
+      break;
+    } else if (input.next == backslash && !escapes && input.peek(1) > -1) {
+      input.advance(2);
+    } else if (input.next == quote && (!long || input.peek(1) == quote && input.peek(2) == quote)) {
+      if (input.pos == start) {
+        input.acceptToken(stringEnd, long ? 3 : 1);
+        return;
+      }
+      break;
+    } else if (input.next == newline) {
+      if (long) {
+        input.advance();
+      } else if (input.pos == start) {
+        input.acceptToken(stringEnd);
+        return;
+      }
+      break;
+    } else {
+      input.advance();
+    }
+  }
+  if (input.pos > start) input.acceptToken(stringContent);
+});
+function skipEscape(input, ch) {
+  if (ch == letter_o) {
+    for (let i2 = 0; i2 < 2 && input.next >= 48 && input.next <= 55; i2++) input.advance();
+  } else if (ch == letter_x) {
+    for (let i2 = 0; i2 < 2 && isHex(input.next); i2++) input.advance();
+  } else if (ch == letter_u) {
+    for (let i2 = 0; i2 < 4 && isHex(input.next); i2++) input.advance();
+  } else if (ch == letter_U) {
+    for (let i2 = 0; i2 < 8 && isHex(input.next); i2++) input.advance();
+  } else if (ch == letter_N) {
+    if (input.next == braceOpen) {
+      input.advance();
+      while (input.next >= 0 && input.next != braceClose && input.next != singleQuote && input.next != doubleQuote && input.next != newline) input.advance();
+      if (input.next == braceClose) input.advance();
+    }
+  }
+}
+var pythonHighlighting = styleTags({
+  'async "*" "**" FormatConversion FormatSpec': tags.modifier,
+  "for while if elif else try except finally return raise break continue with pass assert await yield match case": tags.controlKeyword,
+  "in not and or is del": tags.operatorKeyword,
+  "from def class global nonlocal lambda": tags.definitionKeyword,
+  import: tags.moduleKeyword,
+  "with as print": tags.keyword,
+  Boolean: tags.bool,
+  None: tags.null,
+  VariableName: tags.variableName,
+  "CallExpression/VariableName": tags.function(tags.variableName),
+  "FunctionDefinition/VariableName": tags.function(tags.definition(tags.variableName)),
+  "ClassDefinition/VariableName": tags.definition(tags.className),
+  PropertyName: tags.propertyName,
+  "CallExpression/MemberExpression/PropertyName": tags.function(tags.propertyName),
+  Comment: tags.lineComment,
+  Number: tags.number,
+  String: tags.string,
+  FormatString: tags.special(tags.string),
+  Escape: tags.escape,
+  UpdateOp: tags.updateOperator,
+  "ArithOp!": tags.arithmeticOperator,
+  BitOp: tags.bitwiseOperator,
+  CompareOp: tags.compareOperator,
+  AssignOp: tags.definitionOperator,
+  Ellipsis: tags.punctuation,
+  At: tags.meta,
+  "( )": tags.paren,
+  "[ ]": tags.squareBracket,
+  "{ }": tags.brace,
+  ".": tags.derefOperator,
+  ", ;": tags.separator
+});
+var spec_identifier = { __proto__: null, await: 44, or: 54, and: 56, in: 60, not: 62, is: 64, if: 70, else: 72, lambda: 76, yield: 94, from: 96, async: 102, for: 104, None: 162, True: 164, False: 164, del: 178, pass: 182, break: 186, continue: 190, return: 194, raise: 202, import: 206, as: 208, global: 212, nonlocal: 214, assert: 218, type: 223, elif: 236, while: 240, try: 246, except: 248, finally: 250, with: 254, def: 258, class: 268, match: 279, case: 285 };
+var parser2 = LRParser.deserialize({
+  version: 14,
+  states: "##jQ`QeOOP$}OSOOO&WQtO'#HUOOQS'#Co'#CoOOQS'#Cp'#CpO'vQdO'#CnO*UQtO'#HTOOQS'#HU'#HUOOQS'#DU'#DUOOQS'#HT'#HTO*rQdO'#D_O+VQdO'#DfO+gQdO'#DjO+zOWO'#DuO,VOWO'#DvO.[QtO'#GuOOQS'#Gu'#GuO'vQdO'#GtO0ZQtO'#GtOOQS'#Eb'#EbO0rQdO'#EcOOQS'#Gs'#GsO0|QdO'#GrOOQV'#Gr'#GrO1XQdO'#FYOOQS'#G^'#G^O1^QdO'#FXOOQV'#IS'#ISOOQV'#Gq'#GqOOQV'#Fq'#FqQ`QeOOO'vQdO'#CqO1lQdO'#C}O1sQdO'#DRO2RQdO'#HYO2cQtO'#EVO'vQdO'#EWOOQS'#EY'#EYOOQS'#E['#E[OOQS'#E^'#E^O2wQdO'#E`O3_QdO'#EdO3rQdO'#EfO3zQtO'#EfO1XQdO'#EiO0rQdO'#ElO1XQdO'#EnO0rQdO'#EtO0rQdO'#EwO4VQdO'#EyO4^QdO'#FOO4iQdO'#EzO0rQdO'#FOO1XQdO'#FQO1XQdO'#FVO4nQdO'#F[P4uOdO'#GpPOOO)CBd)CBdOOQS'#Ce'#CeOOQS'#Cf'#CfOOQS'#Cg'#CgOOQS'#Ch'#ChOOQS'#Ci'#CiOOQS'#Cj'#CjOOQS'#Cl'#ClO'vQdO,59OO'vQdO,59OO'vQdO,59OO'vQdO,59OO'vQdO,59OO'vQdO,59OO5TQdO'#DoOOQS,5:Y,5:YO5hQdO'#HdOOQS,5:],5:]O5uQ!fO,5:]O5zQtO,59YO1lQdO,59bO1lQdO,59bO1lQdO,59bO8jQdO,59bO8oQdO,59bO8vQdO,59jO8}QdO'#HTO:TQdO'#HSOOQS'#HS'#HSOOQS'#D['#D[O:lQdO,59aO'vQdO,59aO:zQdO,59aOOQS,59y,59yO;PQdO,5:RO'vQdO,5:ROOQS,5:Q,5:QO;_QdO,5:QO;dQdO,5:XO'vQdO,5:XO'vQdO,5:VOOQS,5:U,5:UO;uQdO,5:UO;zQdO,5:WOOOW'#Fy'#FyO<POWO,5:aOOQS,5:a,5:aO<[QdO'#HwOOOW'#Dw'#DwOOOW'#Fz'#FzO<lOWO,5:bOOQS,5:b,5:bOOQS'#F}'#F}O<zQtO,5:iO?lQtO,5=`O@VQ#xO,5=`O@vQtO,5=`OOQS,5:},5:}OA_QeO'#GWOBqQdO,5;^OOQV,5=^,5=^OB|QtO'#IPOCkQdO,5;tOOQS-E:[-E:[OOQV,5;s,5;sO4dQdO'#FQOOQV-E9o-E9oOCsQtO,59]OEzQtO,59iOFeQdO'#HVOFpQdO'#HVO1XQdO'#HVOF{QdO'#DTOGTQdO,59mOGYQdO'#HZO'vQdO'#HZO0rQdO,5=tOOQS,5=t,5=tO0rQdO'#EROOQS'#ES'#ESOGwQdO'#GPOHXQdO,58|OHXQdO,58|O*xQdO,5:oOHgQtO'#H]OOQS,5:r,5:rOOQS,5:z,5:zOHzQdO,5;OOI]QdO'#IOO1XQdO'#H}OOQS,5;Q,5;QOOQS'#GT'#GTOIqQtO,5;QOJPQdO,5;QOJUQdO'#IQOOQS,5;T,5;TOJdQdO'#H|OOQS,5;W,5;WOJuQdO,5;YO4iQdO,5;`O4iQdO,5;cOJ}QtO'#ITO'vQdO'#ITOKXQdO,5;eO4VQdO,5;eO0rQdO,5;jO1XQdO,5;lOK^QeO'#EuOLjQgO,5;fO!!kQdO'#IUO4iQdO,5;jO!!vQdO,5;lO!#OQdO,5;qO!#ZQtO,5;vO'vQdO,5;vPOOO,5=[,5=[P!#bOSO,5=[P!#jOdO,5=[O!&bQtO1G.jO!&iQtO1G.jO!)YQtO1G.jO!)dQtO1G.jO!+}QtO1G.jO!,bQtO1G.jO!,uQdO'#HcO!-TQtO'#GuO0rQdO'#HcO!-_QdO'#HbOOQS,5:Z,5:ZO!-gQdO,5:ZO!-lQdO'#HeO!-wQdO'#HeO!.[QdO,5>OOOQS'#Ds'#DsOOQS1G/w1G/wOOQS1G.|1G.|O!/[QtO1G.|O!/cQtO1G.|O1lQdO1G.|O!0OQdO1G/UOOQS'#DZ'#DZO0rQdO,59tOOQS1G.{1G.{O!0VQdO1G/eO!0gQdO1G/eO!0oQdO1G/fO'vQdO'#H[O!0tQdO'#H[O!0yQtO1G.{O!1ZQdO,59iO!2aQdO,5=zO!2qQdO,5=zO!2yQdO1G/mO!3OQtO1G/mOOQS1G/l1G/lO!3`QdO,5=uO!4VQdO,5=uO0rQdO1G/qO!4tQdO1G/sO!4yQtO1G/sO!5ZQtO1G/qOOQS1G/p1G/pOOQS1G/r1G/rOOOW-E9w-E9wOOQS1G/{1G/{O!5kQdO'#HxO0rQdO'#HxO!5|QdO,5>cOOOW-E9x-E9xOOQS1G/|1G/|OOQS-E9{-E9{O!6[Q#xO1G2zO!6{QtO1G2zO'vQdO,5<jOOQS,5<j,5<jOOQS-E9|-E9|OOQS,5<r,5<rOOQS-E:U-E:UOOQV1G0x1G0xO1XQdO'#GRO!7dQtO,5>kOOQS1G1`1G1`O!8RQdO1G1`OOQS'#DV'#DVO0rQdO,5=qOOQS,5=q,5=qO!8WQdO'#FrO!8cQdO,59oO!8kQdO1G/XO!8uQtO,5=uOOQS1G3`1G3`OOQS,5:m,5:mO!9fQdO'#GtOOQS,5<k,5<kOOQS-E9}-E9}O!9wQdO1G.hOOQS1G0Z1G0ZO!:VQdO,5=wO!:gQdO,5=wO0rQdO1G0jO0rQdO1G0jO!:xQdO,5>jO!;ZQdO,5>jO1XQdO,5>jO!;lQdO,5>iOOQS-E:R-E:RO!;qQdO1G0lO!;|QdO1G0lO!<RQdO,5>lO!<aQdO,5>lO!<oQdO,5>hO!=VQdO,5>hO!=hQdO'#EpO0rQdO1G0tO!=sQdO1G0tO!=xQgO1G0zO!AvQgO1G0}O!EqQdO,5>oO!E{QdO,5>oO!FTQtO,5>oO0rQdO1G1PO!F_QdO1G1PO4iQdO1G1UO!!vQdO1G1WOOQV,5;a,5;aO!FdQfO,5;aO!FiQgO1G1QO!JjQdO'#GZO4iQdO1G1QO4iQdO1G1QO!JzQdO,5>pO!KXQdO,5>pO1XQdO,5>pOOQV1G1U1G1UO!KaQdO'#FSO!KrQ!fO1G1WO!KzQdO1G1WOOQV1G1]1G1]O4iQdO1G1]O!LPQdO1G1]O!LXQdO'#F^OOQV1G1b1G1bO!#ZQtO1G1bPOOO1G2v1G2vP!L^OSO1G2vOOQS,5=},5=}OOQS'#Dp'#DpO0rQdO,5=}O!LfQdO,5=|O!LyQdO,5=|OOQS1G/u1G/uO!MRQdO,5>PO!McQdO,5>PO!MkQdO,5>PO!NOQdO,5>PO!N`QdO,5>POOQS1G3j1G3jOOQS7+$h7+$hO!8kQdO7+$pO#!RQdO1G.|O#!YQdO1G.|OOQS1G/`1G/`OOQS,5<`,5<`O'vQdO,5<`OOQS7+%P7+%PO#!aQdO7+%POOQS-E9r-E9rOOQS7+%Q7+%QO#!qQdO,5=vO'vQdO,5=vOOQS7+$g7+$gO#!vQdO7+%PO##OQdO7+%QO##TQdO1G3fOOQS7+%X7+%XO##eQdO1G3fO##mQdO7+%XOOQS,5<_,5<_O'vQdO,5<_O##rQdO1G3aOOQS-E9q-E9qO#$iQdO7+%]OOQS7+%_7+%_O#$wQdO1G3aO#%fQdO7+%_O#%kQdO1G3gO#%{QdO1G3gO#&TQdO7+%]O#&YQdO,5>dO#&sQdO,5>dO#&sQdO,5>dOOQS'#Dx'#DxO#'UO&jO'#DzO#'aO`O'#HyOOOW1G3}1G3}O#'fQdO1G3}O#'nQdO1G3}O#'yQ#xO7+(fO#(jQtO1G2UP#)TQdO'#GOOOQS,5<m,5<mOOQS-E:P-E:POOQS7+&z7+&zOOQS1G3]1G3]OOQS,5<^,5<^OOQS-E9p-E9pOOQS7+$s7+$sO#)bQdO,5=`O#){QdO,5=`O#*^QtO,5<aO#*qQdO1G3cOOQS-E9s-E9sOOQS7+&U7+&UO#+RQdO7+&UO#+aQdO,5<nO#+uQdO1G4UOOQS-E:Q-E:QO#,WQdO1G4UOOQS1G4T1G4TOOQS7+&W7+&WO#,iQdO7+&WOOQS,5<p,5<pO#,tQdO1G4WOOQS-E:S-E:SOOQS,5<l,5<lO#-SQdO1G4SOOQS-E:O-E:OO1XQdO'#EqO#-jQdO'#EqO#-uQdO'#IRO#-}QdO,5;[OOQS7+&`7+&`O0rQdO7+&`O#.SQgO7+&fO!JmQdO'#GXO4iQdO7+&fO4iQdO7+&iO#2QQtO,5<tO'vQdO,5<tO#2[QdO1G4ZOOQS-E:W-E:WO#2fQdO1G4ZO4iQdO7+&kO0rQdO7+&kOOQV7+&p7+&pO!KrQ!fO7+&rO!KzQdO7+&rO`QeO1G0{OOQV-E:X-E:XO4iQdO7+&lO4iQdO7+&lOOQV,5<u,5<uO#2nQdO,5<uO!JmQdO,5<uOOQV7+&l7+&lO#2yQgO7+&lO#6tQdO,5<vO#7PQdO1G4[OOQS-E:Y-E:YO#7^QdO1G4[O#7fQdO'#IWO#7tQdO'#IWO1XQdO'#IWOOQS'#IW'#IWO#8PQdO'#IVOOQS,5;n,5;nO#8XQdO,5;nO0rQdO'#FUOOQV7+&r7+&rO4iQdO7+&rOOQV7+&w7+&wO4iQdO7+&wO#8^QfO,5;xOOQV7+&|7+&|POOO7+(b7+(bO#8cQdO1G3iOOQS,5<c,5<cO#8qQdO1G3hOOQS-E9u-E9uO#9UQdO,5<dO#9aQdO,5<dO#9tQdO1G3kOOQS-E9v-E9vO#:UQdO1G3kO#:^QdO1G3kO#:nQdO1G3kO#:UQdO1G3kOOQS<<H[<<H[O#:yQtO1G1zOOQS<<Hk<<HkP#;WQdO'#FtO8vQdO1G3bO#;eQdO1G3bO#;jQdO<<HkOOQS<<Hl<<HlO#;zQdO7+)QOOQS<<Hs<<HsO#<[QtO1G1yP#<{QdO'#FsO#=YQdO7+)RO#=jQdO7+)RO#=rQdO<<HwO#=wQdO7+({OOQS<<Hy<<HyO#>nQdO,5<bO'vQdO,5<bOOQS-E9t-E9tOOQS<<Hw<<HwOOQS,5<g,5<gO0rQdO,5<gO#>sQdO1G4OOOQS-E9y-E9yO#?^QdO1G4OO<[QdO'#H{OOOO'#D{'#D{OOOO'#F|'#F|O#?oO&jO,5:fOOOW,5>e,5>eOOOW7+)i7+)iO#?zQdO7+)iO#@SQdO1G2zO#@mQdO1G2zP'vQdO'#FuO0rQdO<<IpO1XQdO1G2YP1XQdO'#GSO#AOQdO7+)pO#AaQdO7+)pOOQS<<Ir<<IrP1XQdO'#GUP0rQdO'#GQOOQS,5;],5;]O#ArQdO,5>mO#BQQdO,5>mOOQS1G0v1G0vOOQS<<Iz<<IzOOQV-E:V-E:VO4iQdO<<JQOOQV,5<s,5<sO4iQdO,5<sOOQV<<JQ<<JQOOQV<<JT<<JTO#BYQtO1G2`P#BdQdO'#GYO#BkQdO7+)uO#BuQgO<<JVO4iQdO<<JVOOQV<<J^<<J^O4iQdO<<J^O!KrQ!fO<<J^O#FpQgO7+&gOOQV<<JW<<JWO#FzQgO<<JWOOQV1G2a1G2aO1XQdO1G2aO#JuQdO1G2aO4iQdO<<JWO1XQdO1G2bP0rQdO'#G[O#KQQdO7+)vO#K_QdO7+)vOOQS'#FT'#FTO0rQdO,5>rO#KgQdO,5>rO#KrQdO,5>rO#K}QdO,5>qO#L`QdO,5>qOOQS1G1Y1G1YOOQS,5;p,5;pOOQV<<Jc<<JcO#LhQdO1G1dOOQS7+)T7+)TP#LmQdO'#FwO#L}QdO1G2OO#MbQdO1G2OO#MrQdO1G2OP#M}QdO'#FxO#N[QdO7+)VO#NlQdO7+)VO#NlQdO7+)VO#NtQdO7+)VO$ UQdO7+(|O8vQdO7+(|OOQSAN>VAN>VO$ oQdO<<LmOOQSAN>cAN>cO0rQdO1G1|O$!PQtO1G1|P$!ZQdO'#FvOOQS1G2R1G2RP$!hQdO'#F{O$!uQdO7+)jO$#`QdO,5>gOOOO-E9z-E9zOOOW<<MT<<MTO$#nQdO7+(fOOQSAN?[AN?[OOQS7+'t7+'tO$$XQdO<<M[OOQS,5<q,5<qO$$jQdO1G4XOOQS-E:T-E:TOOQVAN?lAN?lOOQV1G2_1G2_O4iQdOAN?qO$$xQgOAN?qOOQVAN?xAN?xO4iQdOAN?xOOQV<<JR<<JRO4iQdOAN?rO4iQdO7+'{OOQV7+'{7+'{O1XQdO7+'{OOQVAN?rAN?rOOQS7+'|7+'|O$(sQdO<<MbOOQS1G4^1G4^O0rQdO1G4^OOQS,5<w,5<wO$)QQdO1G4]OOQS-E:Z-E:ZOOQU'#G_'#G_O$)cQfO7+'OO$)nQdO'#F_O$*uQdO7+'jO$+VQdO7+'jOOQS7+'j7+'jO$+bQdO<<LqO$+rQdO<<LqO$+rQdO<<LqO$+zQdO'#H^OOQS<<Lh<<LhO$,UQdO<<LhOOQS7+'h7+'hOOQS'#D|'#D|OOOO1G4R1G4RO$,oQdO1G4RO$,wQdO1G4RP!=hQdO'#GVOOQVG25]G25]O4iQdOG25]OOQVG25dG25dOOQVG25^G25^OOQV<<Kg<<KgO4iQdO<<KgOOQS7+)x7+)xP$-SQdO'#G]OOQU-E:]-E:]OOQV<<Jj<<JjO$-vQtO'#FaOOQS'#Fc'#FcO$.WQdO'#FbO$.xQdO'#FbOOQS'#Fb'#FbO$.}QdO'#IYO$)nQdO'#FiO$)nQdO'#FiO$/fQdO'#FjO$)nQdO'#FkO$/mQdO'#IZOOQS'#IZ'#IZO$0[QdO,5;yOOQS<<KU<<KUO$0dQdO<<KUO$0tQdOANB]O$1UQdOANB]O$1^QdO'#H_OOQS'#H_'#H_O1sQdO'#DcO$1wQdO,5=xOOQSANBSANBSOOOO7+)m7+)mO$2`QdO7+)mOOQVLD*wLD*wOOQVANARANARO5uQ!fO'#GaO$2hQtO,5<SO$)nQdO'#FmOOQS,5<W,5<WOOQS'#Fd'#FdO$3YQdO,5;|O$3_QdO,5;|OOQS'#Fg'#FgO$)nQdO'#G`O$4PQdO,5<QO$4kQdO,5>tO$4{QdO,5>tO1XQdO,5<PO$5^QdO,5<TO$5cQdO,5<TO$)nQdO'#I[O$5hQdO'#I[O$5mQdO,5<UOOQS,5<V,5<VO0rQdO'#FpOOQU1G1e1G1eO4iQdO1G1eOOQSAN@pAN@pO$5rQdOG27wO$6SQdO,59}OOQS1G3d1G3dOOOO<<MX<<MXOOQS,5<{,5<{OOQS-E:_-E:_O$6XQtO'#FaO$6`QdO'#I]O$6nQdO'#I]O$6vQdO,5<XOOQS1G1h1G1hO$6{QdO1G1hO$7QQdO,5<zOOQS-E:^-E:^O$7lQdO,5=OO$8TQdO1G4`OOQS-E:b-E:bOOQS1G1k1G1kOOQS1G1o1G1oO$8eQdO,5>vO$)nQdO,5>vOOQS1G1p1G1pOOQS,5<[,5<[OOQU7+'P7+'PO$+zQdO1G/iO$)nQdO,5<YO$8sQdO,5>wO$8zQdO,5>wOOQS1G1s1G1sOOQS7+'S7+'SP$)nQdO'#GdO$9SQdO1G4bO$9^QdO1G4bO$9fQdO1G4bOOQS7+%T7+%TO$9tQdO1G1tO$:SQtO'#FaO$:ZQdO,5<}OOQS,5<},5<}O$:iQdO1G4cOOQS-E:a-E:aO$)nQdO,5<|O$:pQdO,5<|O$:uQdO7+)|OOQS-E:`-E:`O$;PQdO7+)|O$)nQdO,5<ZP$)nQdO'#GcO$;XQdO1G2hO$)nQdO1G2hP$;gQdO'#GbO$;nQdO<<MhO$;xQdO1G1uO$<WQdO7+(SO8vQdO'#C}O8vQdO,59bO8vQdO,59bO8vQdO,59bO$<fQtO,5=`O8vQdO1G.|O0rQdO1G/XO0rQdO7+$pP$<yQdO'#GOO'vQdO'#GtO$=WQdO,59bO$=]QdO,59bO$=dQdO,59mO$=iQdO1G/UO1sQdO'#DRO8vQdO,59j",
+  stateData: "$>S~O%cOS%^OSSOS%]PQ~OPdOVaOfoOhYOopOs!POvqO!PrO!Q{O!T!SO!U!RO!XZO!][O!h`O!r`O!s`O!t`O!{tO!}uO#PvO#RwO#TxO#XyO#ZzO#^|O#_|O#a}O#c!OO#l!QO#o!TO#s!UO#u!VO#z!WO#}hO$P!XO%oRO%pRO%tSO%uWO&Z]O&[]O&]]O&^]O&_]O&`]O&a]O&b]O&c^O&d^O&e^O&f^O&g^O&h^O&i^O&j^O~O%]!YO~OV!aO_!aOa!bOh!iO!X!kO!f!mO%j![O%k!]O%l!^O%m!_O%n!_O%o!`O%p!`O%q!aO%r!aO%s!aO~Ok%xXl%xXm%xXn%xXo%xXp%xXs%xXz%xX{%xX!x%xX#g%xX%[%xX%_%xX%z%xXg%xX!T%xX!U%xX%{%xX!W%xX![%xX!Q%xX#[%xXt%xX!m%xX~P%SOfoOhYO!XZO!][O!h`O!r`O!s`O!t`O%oRO%pRO%tSO%uWO&Z]O&[]O&]]O&^]O&_]O&`]O&a]O&b]O&c^O&d^O&e^O&f^O&g^O&h^O&i^O&j^O~Oz%wX{%wX#g%wX%[%wX%_%wX%z%wX~Ok!pOl!qOm!oOn!oOo!rOp!sOs!tO!x%wX~P)pOV!zOg!|Oo0cOv0qO!PrO~P'vOV#OOo0cOv0qO!W#PO~P'vOV#SOa#TOo0cOv0qO![#UO~P'vOQ#XO%`#XO%a#ZO~OQ#^OR#[O%`#^O%a#`O~OV%iX_%iXa%iXh%iXk%iXl%iXm%iXn%iXo%iXp%iXs%iXz%iX!X%iX!f%iX%j%iX%k%iX%l%iX%m%iX%n%iX%o%iX%p%iX%q%iX%r%iX%s%iXg%iX!T%iX!U%iX~O&Z]O&[]O&]]O&^]O&_]O&`]O&a]O&b]O&c^O&d^O&e^O&f^O&g^O&h^O&i^O&j^O{%iX!x%iX#g%iX%[%iX%_%iX%z%iX%{%iX!W%iX![%iX!Q%iX#[%iXt%iX!m%iX~P,eOz#dO{%hX!x%hX#g%hX%[%hX%_%hX%z%hX~Oo0cOv0qO~P'vO#g#gO%[#iO%_#iO~O%uWO~O!T#nO#u!VO#z!WO#}hO~OopO~P'vOV#sOa#tO%uWO{wP~OV#xOo0cOv0qO!Q#yO~P'vO{#{O!x$QO%z#|O#g!yX%[!yX%_!yX~OV#xOo0cOv0qO#g#SX%[#SX%_#SX~P'vOo0cOv0qO#g#WX%[#WX%_#WX~P'vOh$WO%uWO~O!f$YO!r$YO%uWO~OV$eO~P'vO!U$gO#s$hO#u$iO~O{$jO~OV$qO~P'vOS$sO%[$rO%_$rO%c$tO~OV$}Oa$}Og%POo0cOv0qO~P'vOo0cOv0qO{%SO~P'vO&Y%UO~Oa!bOh!iO!X!kO!f!mOVba_bakbalbambanbaobapbasbazba{ba!xba#gba%[ba%_ba%jba%kba%lba%mba%nba%oba%pba%qba%rba%sba%zbagba!Tba!Uba%{ba!Wba![ba!Qba#[batba!mba~On%ZO~Oo%ZO~P'vOo0cO~P'vOk0eOl0fOm0dOn0dOo0mOp0nOs0rOg%wX!T%wX!U%wX%{%wX!W%wX![%wX!Q%wX#[%wX!m%wX~P)pO%{%]Og%vXz%vX!T%vX!U%vX!W%vX{%vX~Og%_Oz%`O!T%dO!U%cO~Og%_O~Oz%gO!T%dO!U%cO!W&SX~O!W%kO~Oz%lO{%nO!T%dO!U%cO![%}X~O![%rO~O![%sO~OQ#XO%`#XO%a%uO~OV%wOo0cOv0qO!PrO~P'vOQ#^OR#[O%`#^O%a%zO~OV!qa_!qaa!qah!qak!qal!qam!qan!qao!qap!qas!qaz!qa{!qa!X!qa!f!qa!x!qa#g!qa%[!qa%_!qa%j!qa%k!qa%l!qa%m!qa%n!qa%o!qa%p!qa%q!qa%r!qa%s!qa%z!qag!qa!T!qa!U!qa%{!qa!W!qa![!qa!Q!qa#[!qat!qa!m!qa~P#yOz%|O{%ha!x%ha#g%ha%[%ha%_%ha%z%ha~P%SOV&OOopOvqO{%ha!x%ha#g%ha%[%ha%_%ha%z%ha~P'vOz%|O{%ha!x%ha#g%ha%[%ha%_%ha%z%ha~OPdOVaOopOvqO!PrO!Q{O!{tO!}uO#PvO#RwO#TxO#XyO#ZzO#^|O#_|O#a}O#c!OO#g$zX%[$zX%_$zX~P'vO#g#gO%[&TO%_&TO~O!f&UOh&sX%[&sXz&sX#[&sX#g&sX%_&sX#Z&sXg&sX~Oh!iO%[&WO~Okealeameaneaoeapeaseazea{ea!xea#gea%[ea%_ea%zeagea!Tea!Uea%{ea!Wea![ea!Qea#[eatea!mea~P%SOsqazqa{qa#gqa%[qa%_qa%zqa~Ok!pOl!qOm!oOn!oOo!rOp!sO!xqa~PEcO%z&YOz%yX{%yX~O%uWOz%yX{%yX~Oz&]O{wX~O{&_O~Oz%lO#g%}X%[%}X%_%}Xg%}X{%}X![%}X!m%}X%z%}X~OV0lOo0cOv0qO!PrO~P'vO%z#|O#gUa%[Ua%_Ua~Oz&hO#g&PX%[&PX%_&PXn&PX~P%SOz&kO!Q&jO#g#Wa%[#Wa%_#Wa~Oz&lO#[&nO#g&rX%[&rX%_&rXg&rX~O!f$YO!r$YO#Z&qO%uWO~O#Z&qO~Oz&sO#g&tX%[&tX%_&tX~Oz&uO#g&pX%[&pX%_&pX{&pX~O!X&wO%z&xO~Oz&|On&wX~P%SOn'PO~OPdOVaOopOvqO!PrO!Q{O!{tO!}uO#PvO#RwO#TxO#XyO#ZzO#^|O#_|O#a}O#c!OO%['UO~P'vOt'YO#p'WO#q'XOP#naV#naf#nah#nao#nas#nav#na!P#na!Q#na!T#na!U#na!X#na!]#na!h#na!r#na!s#na!t#na!{#na!}#na#P#na#R#na#T#na#X#na#Z#na#^#na#_#na#a#na#c#na#l#na#o#na#s#na#u#na#z#na#}#na$P#na%X#na%o#na%p#na%t#na%u#na&Z#na&[#na&]#na&^#na&_#na&`#na&a#na&b#na&c#na&d#na&e#na&f#na&g#na&h#na&i#na&j#na%Z#na%_#na~Oz'ZO#[']O{&xX~Oh'_O!X&wO~Oh!iO{$jO!X&wO~O{'eO~P%SO%['hO%_'hO~OS'iO%['hO%_'hO~OV!aO_!aOa!bOh!iO!X!kO!f!mO%l!^O%m!_O%n!_O%o!`O%p!`O%q!aO%r!aO%s!aOkWilWimWinWioWipWisWizWi{Wi!xWi#gWi%[Wi%_Wi%jWi%zWigWi!TWi!UWi%{Wi!WWi![Wi!QWi#[WitWi!mWi~O%k!]O~P!#uO%kWi~P!#uOV!aO_!aOa!bOh!iO!X!kO!f!mO%o!`O%p!`O%q!aO%r!aO%s!aOkWilWimWinWioWipWisWizWi{Wi!xWi#gWi%[Wi%_Wi%jWi%kWi%lWi%zWigWi!TWi!UWi%{Wi!WWi![Wi!QWi#[WitWi!mWi~O%m!_O%n!_O~P!&pO%mWi%nWi~P!&pOa!bOh!iO!X!kO!f!mOkWilWimWinWioWipWisWizWi{Wi!xWi#gWi%[Wi%_Wi%jWi%kWi%lWi%mWi%nWi%oWi%pWi%zWigWi!TWi!UWi%{Wi!WWi![Wi!QWi#[WitWi!mWi~OV!aO_!aO%q!aO%r!aO%s!aO~P!)nOVWi_Wi%qWi%rWi%sWi~P!)nO!T%dO!U%cOg&VXz&VX~O%z'kO%{'kO~P,eOz'mOg&UX~Og'oO~Oz'pO{'rO!W&XX~Oo0cOv0qOz'pO{'sO!W&XX~P'vO!W'uO~Om!oOn!oOo!rOp!sOkjisjizji{ji!xji#gji%[ji%_ji%zji~Ol!qO~P!.aOlji~P!.aOk0eOl0fOm0dOn0dOo0mOp0nO~Ot'wO~P!/jOV'|Og'}Oo0cOv0qO~P'vOg'}Oz(OO~Og(QO~O!U(SO~Og(TOz(OO!T%dO!U%cO~P%SOk0eOl0fOm0dOn0dOo0mOp0nOgqa!Tqa!Uqa%{qa!Wqa![qa!Qqa#[qatqa!mqa~PEcOV'|Oo0cOv0qO!W&Sa~P'vOz(WO!W&Sa~O!W(XO~Oz(WO!T%dO!U%cO!W&Sa~P%SOV(]Oo0cOv0qO![%}a#g%}a%[%}a%_%}ag%}a{%}a!m%}a%z%}a~P'vOz(^O![%}a#g%}a%[%}a%_%}ag%}a{%}a!m%}a%z%}a~O![(aO~Oz(^O!T%dO!U%cO![%}a~P%SOz(dO!T%dO!U%cO![&Ta~P%SOz(gO{&lX![&lX!m&lX%z&lX~O{(kO![(mO!m(nO%z(jO~OV&OOopOvqO{%hi!x%hi#g%hi%[%hi%_%hi%z%hi~P'vOz(pO{%hi!x%hi#g%hi%[%hi%_%hi%z%hi~O!f&UOh&sa%[&saz&sa#[&sa#g&sa%_&sa#Z&sag&sa~O%[(uO~OV#sOa#tO%uWO~Oz&]O{wa~OopOvqO~P'vOz(^O#g%}a%[%}a%_%}ag%}a{%}a![%}a!m%}a%z%}a~P%SOz(zO#g%hX%[%hX%_%hX%z%hX~O%z#|O#gUi%[Ui%_Ui~O#g&Pa%[&Pa%_&Pan&Pa~P'vOz(}O#g&Pa%[&Pa%_&Pan&Pa~O%uWO#g&ra%[&ra%_&rag&ra~Oz)SO#g&ra%[&ra%_&rag&ra~Og)VO~OV)WOh$WO%uWO~O#Z)XO~O%uWO#g&ta%[&ta%_&ta~Oz)ZO#g&ta%[&ta%_&ta~Oo0cOv0qO#g&pa%[&pa%_&pa{&pa~P'vOz)^O#g&pa%[&pa%_&pa{&pa~OV)`Oa)`O%uWO~O%z)eO~Ot)hO#j)gOP#hiV#hif#hih#hio#his#hiv#hi!P#hi!Q#hi!T#hi!U#hi!X#hi!]#hi!h#hi!r#hi!s#hi!t#hi!{#hi!}#hi#P#hi#R#hi#T#hi#X#hi#Z#hi#^#hi#_#hi#a#hi#c#hi#l#hi#o#hi#s#hi#u#hi#z#hi#}#hi$P#hi%X#hi%o#hi%p#hi%t#hi%u#hi&Z#hi&[#hi&]#hi&^#hi&_#hi&`#hi&a#hi&b#hi&c#hi&d#hi&e#hi&f#hi&g#hi&h#hi&i#hi&j#hi%Z#hi%_#hi~Ot)iOP#kiV#kif#kih#kio#kis#kiv#ki!P#ki!Q#ki!T#ki!U#ki!X#ki!]#ki!h#ki!r#ki!s#ki!t#ki!{#ki!}#ki#P#ki#R#ki#T#ki#X#ki#Z#ki#^#ki#_#ki#a#ki#c#ki#l#ki#o#ki#s#ki#u#ki#z#ki#}#ki$P#ki%X#ki%o#ki%p#ki%t#ki%u#ki&Z#ki&[#ki&]#ki&^#ki&_#ki&`#ki&a#ki&b#ki&c#ki&d#ki&e#ki&f#ki&g#ki&h#ki&i#ki&j#ki%Z#ki%_#ki~OV)kOn&wa~P'vOz)lOn&wa~Oz)lOn&wa~P%SOn)pO~O%Y)tO~Ot)wO#p'WO#q)vOP#niV#nif#nih#nio#nis#niv#ni!P#ni!Q#ni!T#ni!U#ni!X#ni!]#ni!h#ni!r#ni!s#ni!t#ni!{#ni!}#ni#P#ni#R#ni#T#ni#X#ni#Z#ni#^#ni#_#ni#a#ni#c#ni#l#ni#o#ni#s#ni#u#ni#z#ni#}#ni$P#ni%X#ni%o#ni%p#ni%t#ni%u#ni&Z#ni&[#ni&]#ni&^#ni&_#ni&`#ni&a#ni&b#ni&c#ni&d#ni&e#ni&f#ni&g#ni&h#ni&i#ni&j#ni%Z#ni%_#ni~OV)zOo0cOv0qO{$jO~P'vOo0cOv0qO{&xa~P'vOz*OO{&xa~OV*SOa*TOg*WO%q*UO%uWO~O{$jO&{*YO~Oh'_O~Oh!iO{$jO~O%[*_O~O%[*aO%_*aO~OV$}Oa$}Oo0cOv0qOg&Ua~P'vOz*dOg&Ua~Oo0cOv0qO{*gO!W&Xa~P'vOz*hO!W&Xa~Oo0cOv0qOz*hO{*kO!W&Xa~P'vOo0cOv0qOz*hO!W&Xa~P'vOz*hO{*kO!W&Xa~Om0dOn0dOo0mOp0nOgjikjisjizji!Tji!Uji%{ji!Wji{ji![ji#gji%[ji%_ji!Qji#[jitji!mji%zji~Ol0fO~P!NkOlji~P!NkOV'|Og*pOo0cOv0qO~P'vOn*rO~Og*pOz*tO~Og*uO~OV'|Oo0cOv0qO!W&Si~P'vOz*vO!W&Si~O!W*wO~OV(]Oo0cOv0qO![%}i#g%}i%[%}i%_%}ig%}i{%}i!m%}i%z%}i~P'vOz*zO!T%dO!U%cO![&Ti~Oz*}O![%}i#g%}i%[%}i%_%}ig%}i{%}i!m%}i%z%}i~O![+OO~Oa+QOo0cOv0qO![&Ti~P'vOz*zO![&Ti~O![+SO~OV+UOo0cOv0qO{&la![&la!m&la%z&la~P'vOz+VO{&la![&la!m&la%z&la~O!]+YO&n+[O![!nX~O![+^O~O{(kO![+_O~O{(kO![+_O!m+`O~OV&OOopOvqO{%hq!x%hq#g%hq%[%hq%_%hq%z%hq~P'vOz$ri{$ri!x$ri#g$ri%[$ri%_$ri%z$ri~P%SOV&OOopOvqO~P'vOV&OOo0cOv0qO#g%ha%[%ha%_%ha%z%ha~P'vOz+aO#g%ha%[%ha%_%ha%z%ha~Oz$ia#g$ia%[$ia%_$ian$ia~P%SO#g&Pi%[&Pi%_&Pin&Pi~P'vOz+dO#g#Wq%[#Wq%_#Wq~O#[+eOz$va#g$va%[$va%_$vag$va~O%uWO#g&ri%[&ri%_&rig&ri~Oz+gO#g&ri%[&ri%_&rig&ri~OV+iOh$WO%uWO~O%uWO#g&ti%[&ti%_&ti~Oo0cOv0qO#g&pi%[&pi%_&pi{&pi~P'vO{#{Oz#eX!W#eX~Oz+mO!W&uX~O!W+oO~Ot+rO#j)gOP#hqV#hqf#hqh#hqo#hqs#hqv#hq!P#hq!Q#hq!T#hq!U#hq!X#hq!]#hq!h#hq!r#hq!s#hq!t#hq!{#hq!}#hq#P#hq#R#hq#T#hq#X#hq#Z#hq#^#hq#_#hq#a#hq#c#hq#l#hq#o#hq#s#hq#u#hq#z#hq#}#hq$P#hq%X#hq%o#hq%p#hq%t#hq%u#hq&Z#hq&[#hq&]#hq&^#hq&_#hq&`#hq&a#hq&b#hq&c#hq&d#hq&e#hq&f#hq&g#hq&h#hq&i#hq&j#hq%Z#hq%_#hq~On$|az$|a~P%SOV)kOn&wi~P'vOz+yOn&wi~Oz,TO{$jO#[,TO~O#q,VOP#nqV#nqf#nqh#nqo#nqs#nqv#nq!P#nq!Q#nq!T#nq!U#nq!X#nq!]#nq!h#nq!r#nq!s#nq!t#nq!{#nq!}#nq#P#nq#R#nq#T#nq#X#nq#Z#nq#^#nq#_#nq#a#nq#c#nq#l#nq#o#nq#s#nq#u#nq#z#nq#}#nq$P#nq%X#nq%o#nq%p#nq%t#nq%u#nq&Z#nq&[#nq&]#nq&^#nq&_#nq&`#nq&a#nq&b#nq&c#nq&d#nq&e#nq&f#nq&g#nq&h#nq&i#nq&j#nq%Z#nq%_#nq~O#[,WOz%Oa{%Oa~Oo0cOv0qO{&xi~P'vOz,YO{&xi~O{#{O%z,[Og&zXz&zX~O%uWOg&zXz&zX~Oz,`Og&yX~Og,bO~O%Y,eO~O!T%dO!U%cOg&Viz&Vi~OV$}Oa$}Oo0cOv0qOg&Ui~P'vO{,hOz$la!W$la~Oo0cOv0qO{,iOz$la!W$la~P'vOo0cOv0qO{*gO!W&Xi~P'vOz,lO!W&Xi~Oo0cOv0qOz,lO!W&Xi~P'vOz,lO{,oO!W&Xi~Og$hiz$hi!W$hi~P%SOV'|Oo0cOv0qO~P'vOn,qO~OV'|Og,rOo0cOv0qO~P'vOV'|Oo0cOv0qO!W&Sq~P'vOz$gi![$gi#g$gi%[$gi%_$gig$gi{$gi!m$gi%z$gi~P%SOV(]Oo0cOv0qO~P'vOa+QOo0cOv0qO![&Tq~P'vOz,sO![&Tq~O![,tO~OV(]Oo0cOv0qO![%}q#g%}q%[%}q%_%}qg%}q{%}q!m%}q%z%}q~P'vO{,uO~OV+UOo0cOv0qO{&li![&li!m&li%z&li~P'vOz,zO{&li![&li!m&li%z&li~O!]+YO&n+[O![!na~O{(kO![,}O~OV&OOo0cOv0qO#g%hi%[%hi%_%hi%z%hi~P'vOz-OO#g%hi%[%hi%_%hi%z%hi~O%uWO#g&rq%[&rq%_&rqg&rq~Oz-RO#g&rq%[&rq%_&rqg&rq~OV)`Oa)`O%uWO!W&ua~Oz-TO!W&ua~On$|iz$|i~P%SOV)kO~P'vOV)kOn&wq~P'vOt-XOP#myV#myf#myh#myo#mys#myv#my!P#my!Q#my!T#my!U#my!X#my!]#my!h#my!r#my!s#my!t#my!{#my!}#my#P#my#R#my#T#my#X#my#Z#my#^#my#_#my#a#my#c#my#l#my#o#my#s#my#u#my#z#my#}#my$P#my%X#my%o#my%p#my%t#my%u#my&Z#my&[#my&]#my&^#my&_#my&`#my&a#my&b#my&c#my&d#my&e#my&f#my&g#my&h#my&i#my&j#my%Z#my%_#my~O%Z-]O%_-]O~P`O#q-^OP#nyV#nyf#nyh#nyo#nys#nyv#ny!P#ny!Q#ny!T#ny!U#ny!X#ny!]#ny!h#ny!r#ny!s#ny!t#ny!{#ny!}#ny#P#ny#R#ny#T#ny#X#ny#Z#ny#^#ny#_#ny#a#ny#c#ny#l#ny#o#ny#s#ny#u#ny#z#ny#}#ny$P#ny%X#ny%o#ny%p#ny%t#ny%u#ny&Z#ny&[#ny&]#ny&^#ny&_#ny&`#ny&a#ny&b#ny&c#ny&d#ny&e#ny&f#ny&g#ny&h#ny&i#ny&j#ny%Z#ny%_#ny~Oz-aO{$jO#[-aO~Oo0cOv0qO{&xq~P'vOz-dO{&xq~O%z,[Og&zaz&za~O{#{Og&zaz&za~OV*SOa*TO%q*UO%uWOg&ya~Oz-hOg&ya~O$S-lO~OV$}Oa$}Oo0cOv0qO~P'vOo0cOv0qO{-mOz$li!W$li~P'vOo0cOv0qOz$li!W$li~P'vO{-mOz$li!W$li~Oo0cOv0qO{*gO~P'vOo0cOv0qO{*gO!W&Xq~P'vOz-pO!W&Xq~Oo0cOv0qOz-pO!W&Xq~P'vOs-sO!T%dO!U%cOg&Oq!W&Oq![&Oqz&Oq~P!/jOa+QOo0cOv0qO![&Ty~P'vOz$ji![$ji~P%SOa+QOo0cOv0qO~P'vOV+UOo0cOv0qO~P'vOV+UOo0cOv0qO{&lq![&lq!m&lq%z&lq~P'vO{(kO![-xO!m-yO%z-wO~OV&OOo0cOv0qO#g%hq%[%hq%_%hq%z%hq~P'vO%uWO#g&ry%[&ry%_&ryg&ry~OV)`Oa)`O%uWO!W&ui~Ot-}OP#m!RV#m!Rf#m!Rh#m!Ro#m!Rs#m!Rv#m!R!P#m!R!Q#m!R!T#m!R!U#m!R!X#m!R!]#m!R!h#m!R!r#m!R!s#m!R!t#m!R!{#m!R!}#m!R#P#m!R#R#m!R#T#m!R#X#m!R#Z#m!R#^#m!R#_#m!R#a#m!R#c#m!R#l#m!R#o#m!R#s#m!R#u#m!R#z#m!R#}#m!R$P#m!R%X#m!R%o#m!R%p#m!R%t#m!R%u#m!R&Z#m!R&[#m!R&]#m!R&^#m!R&_#m!R&`#m!R&a#m!R&b#m!R&c#m!R&d#m!R&e#m!R&f#m!R&g#m!R&h#m!R&i#m!R&j#m!R%Z#m!R%_#m!R~Oo0cOv0qO{&xy~P'vOV*SOa*TO%q*UO%uWOg&yi~O$S-lO%Z.VO%_.VO~OV.aOh._O!X.^O!].`O!h.YO!s.[O!t.[O%p.XO%uWO&Z]O&[]O&]]O&^]O&_]O&`]O&a]O&b]O~Oo0cOv0qOz$lq!W$lq~P'vO{.fOz$lq!W$lq~Oo0cOv0qO{*gO!W&Xy~P'vOz.gO!W&Xy~Oo0cOv.kO~P'vOs-sO!T%dO!U%cOg&Oy!W&Oy![&Oyz&Oy~P!/jO{(kO![.nO~O{(kO![.nO!m.oO~OV*SOa*TO%q*UO%uWO~Oh.tO!f.rOz$TX#[$TX%j$TXg$TX~Os$TX{$TX!W$TX![$TX~P$-bO%o.vO%p.vOs$UXz$UX{$UX#[$UX%j$UX!W$UXg$UX![$UX~O!h.xO~Oz.|O#[/OO%j.yOs&|X{&|X!W&|Xg&|X~Oa/RO~P$)zOh.tOs&}Xz&}X{&}X#[&}X%j&}X!W&}Xg&}X![&}X~Os/VO{$jO~Oo0cOv0qOz$ly!W$ly~P'vOo0cOv0qO{*gO!W&X!R~P'vOz/ZO!W&X!R~Og&RXs&RX!T&RX!U&RX!W&RX![&RXz&RX~P!/jOs-sO!T%dO!U%cOg&Qa!W&Qa![&Qaz&Qa~O{(kO![/^O~O!f.rOh$[as$[az$[a{$[a#[$[a%j$[a!W$[ag$[a![$[a~O!h/eO~O%o.vO%p.vOs$Uaz$Ua{$Ua#[$Ua%j$Ua!W$Uag$Ua![$Ua~O%j.yOs$Yaz$Ya{$Ya#[$Ya!W$Yag$Ya![$Ya~Os&|a{&|a!W&|ag&|a~P$)nOz/jOs&|a{&|a!W&|ag&|a~O!W/mO~Og/mO~O{/oO~O![/pO~Oo0cOv0qO{*gO!W&X!Z~P'vO{/sO~O%z/tO~P$-bOz/uO#[/OO%j.yOg'PX~Oz/uOg'PX~Og/wO~O!h/xO~O#[/OOs%Saz%Sa{%Sa%j%Sa!W%Sag%Sa![%Sa~O#[/OO%j.yOs%Waz%Wa{%Wa!W%Wag%Wa~Os&|i{&|i!W&|ig&|i~P$)nOz/zO#[/OO%j.yO!['Oa~Og'Pa~P$)nOz0SOg'Pa~Oa0UO!['Oi~P$)zOz0WO!['Oi~Oz0WO#[/OO%j.yO!['Oi~O#[/OO%j.yOg$biz$bi~O%z0ZO~P$-bO#[/OO%j.yOg%Vaz%Va~Og'Pi~P$)nO{0^O~Oa0UO!['Oq~P$)zOz0`O!['Oq~O#[/OO%j.yOz%Ui![%Ui~Oa0UO~P$)zOa0UO!['Oy~P$)zO#[/OO%j.yOg$ciz$ci~O#[/OO%j.yOz%Uq![%Uq~Oz+aO#g%ha%[%ha%_%ha%z%ha~P%SOV&OOo0cOv0qO~P'vOn0hO~Oo0hO~P'vO{0iO~Ot0jO~P!/jO&]&Z&j&h&i&g&f&d&e&c&b&`&a&_&^&[%u~",
+  goto: "!=j'QPPPPPP'RP'Z*s+[+t,_,y-fP.SP'Z.r.r'ZPPP'Z2[PPPPPP2[5PPP5PP7b7k=sPP=v>h>kPP'Z'ZPP>zPP'Z'ZPP'Z'Z'Z'Z'Z?O?w'ZP?zP@QDXGuGyPG|HWH['ZPPPH_Hk'RP'R'RP'RP'RP'RP'RP'R'R'RP'RPP'RPP'RP'RPHqH}IVPI^IdPI^PI^I^PPPI^PKrPK{LVL]KrPI^LfPI^PLmLsPLwM]MzNeLwLwNkNxLwLwLwLw! ^! d! g! l! o! y!!P!!]!!o!!u!#P!#V!#s!#y!$P!$Z!$a!$g!$y!%T!%Z!%a!%k!%q!%w!%}!&T!&Z!&e!&k!&u!&{!'U!'[!'k!'s!'}!(UPPPPPPPPPPP!([!(_!(e!(n!(x!)TPPPPPPPPPPPP!-u!/Z!3^!6oPP!6w!7W!7a!8Y!8P!8c!8i!8l!8o!8r!8z!9jPPPPPPPPPPPPPPPPP!9m!9q!9wP!:]!:a!:m!:v!;S!;j!;m!;p!;v!;|!<S!<VP!<_!<h!=d!=g]eOn#g$j)t,P'}`OTYZ[adnoprtxy}!P!Q!R!U!X!c!d!e!f!g!h!i!k!o!p!q!s!t!z#O#S#T#[#d#g#x#y#{#}$Q$e$g$h$j$q$}%S%Z%^%`%c%g%l%n%w%|&O&Z&_&h&j&k&u&x&|'P'W'Z'l'm'p'r's'w'|(O(S(W(](^(d(g(p(r(z(})^)e)g)k)l)p)t)z*O*Y*d*g*h*k*q*r*t*v*y*z*}+Q+U+V+Y+a+c+d+k+x+y,P,X,Y,],g,h,i,k,l,o,q,s,u,w,y,z-O-d-f-m-p-s.f.g/V/Z/s0c0d0e0f0h0i0j0k0l0n0r{!cQ#c#p$R$d$p%e%j%p%q&`'O'g(q(|)j*o*x+w,v0g}!dQ#c#p$R$d$p$u%e%j%p%q&`'O'g(q(|)j*o*x+w,v0g!P!eQ#c#p$R$d$p$u$v%e%j%p%q&`'O'g(q(|)j*o*x+w,v0g!R!fQ#c#p$R$d$p$u$v$w%e%j%p%q&`'O'g(q(|)j*o*x+w,v0g!T!gQ#c#p$R$d$p$u$v$w$x%e%j%p%q&`'O'g(q(|)j*o*x+w,v0g!V!hQ#c#p$R$d$p$u$v$w$x$y%e%j%p%q&`'O'g(q(|)j*o*x+w,v0g!Z!hQ!n#c#p$R$d$p$u$v$w$x$y$z%e%j%p%q&`'O'g(q(|)j*o*x+w,v0g'}TOTYZ[adnoprtxy}!P!Q!R!U!X!c!d!e!f!g!h!i!k!o!p!q!s!t!z#O#S#T#[#d#g#x#y#{#}$Q$e$g$h$j$q$}%S%Z%^%`%c%g%l%n%w%|&O&Z&_&h&j&k&u&x&|'P'W'Z'l'm'p'r's'w'|(O(S(W(](^(d(g(p(r(z(})^)e)g)k)l)p)t)z*O*Y*d*g*h*k*q*r*t*v*y*z*}+Q+U+V+Y+a+c+d+k+x+y,P,X,Y,],g,h,i,k,l,o,q,s,u,w,y,z-O-d-f-m-p-s.f.g/V/Z/s0c0d0e0f0h0i0j0k0l0n0r&eVOYZ[dnprxy}!P!Q!U!i!k!o!p!q!s!t#[#d#g#y#{#}$Q$h$j$}%S%Z%^%`%g%l%n%w%|&Z&_&j&k&u&x'P'W'Z'l'm'p'r's'w(O(W(^(d(g(p(r(z)^)e)g)p)t)z*O*Y*d*g*h*k*q*r*t*v*y*z*}+U+V+Y+a+d+k,P,X,Y,],g,h,i,k,l,o,q,s,u,w,y,z-O-d-f-m-p-s.f.g/V/Z/s0c0d0e0f0h0i0j0k0n0r%oXOYZ[dnrxy}!P!Q!U!i!k#[#d#g#y#{#}$Q$h$j$}%S%^%`%g%l%n%w%|&Z&_&j&k&u&x'P'W'Z'l'm'p'r's'w(O(W(^(d(g(p(r(z)^)e)g)p)t)z*O*Y*d*g*h*k*q*t*v*y*z*}+U+V+Y+a+d+k,P,X,Y,],g,h,i,k,l,o,s,u,w,y,z-O-d-f-m-p.f.g/V/Z0i0j0kQ#vqQ/[.kR0o0q't`OTYZ[adnoprtxy}!P!Q!R!U!X!c!d!e!f!g!h!k!o!p!q!s!t!z#O#S#T#[#d#g#x#y#{#}$Q$e$g$h$j$q$}%S%Z%^%`%c%g%l%n%w%|&O&Z&_&h&j&k&u&x&|'P'W'Z'l'p'r's'w'|(O(S(W(](^(d(g(p(r(z(})^)e)g)k)l)p)t)z*O*Y*g*h*k*q*r*t*v*y*z*}+Q+U+V+Y+a+c+d+k+x+y,P,X,Y,],h,i,k,l,o,q,s,u,w,y,z-O-d-f-m-p-s.f.g/V/Z/s0c0d0e0f0h0i0j0k0l0n0rh#jhz{$W$Z&l&q)S)X+f+g-RW#rq&].k0qQ$]|Q$a!OQ$n!VQ$o!WW$|!i'm*d,gS&[#s#tQ'S$iQ(s&UQ)U&nU)Y&s)Z+jW)a&w+m-T-{Q*Q']W*R'_,`-h.TQ+l)`S,_*S*TQ-Q+eQ-_,TQ-c,WQ.R-al.W-l.^._.a.z.|/R/j/o/t/y0U0Z0^Q/S.`Q/a.tQ/l/OU0P/u0S0[X0V/z0W0_0`R&Z#r!_!wYZ!P!Q!k%S%`%g'p'r's(O(W)g*g*h*k*q*t*v,h,i,k,l,o-m-p.f.g/ZR%^!vQ!{YQ%x#[Q&d#}Q&g$QR,{+YT.j-s/s!Y!jQ!n#c#p$R$d$p$u$v$w$x$y$z%e%j%p%q&`'O'g(q(|)j*o*x+w,v0gQ&X#kQ'c$oR*^'dR'l$|Q%V!mR/_.r'|_OTYZ[adnoprtxy}!P!Q!R!U!X!c!d!e!f!g!h!i!k!o!p!q!s!t!z#O#S#T#[#d#g#x#y#{#}$Q$e$g$h$j$q$}%S%Z%^%`%c%g%l%n%w%|&O&Z&_&h&j&k&u&x&|'P'W'Z'l'm'p'r's'w'|(O(S(W(](^(d(g(p(r(z(})^)e)g)k)l)p)t)z*O*Y*d*g*h*k*q*r*t*v*y*z*}+Q+U+V+Y+a+c+d+k+x+y,P,X,Y,],g,h,i,k,l,o,q,s,u,w,y,z-O-d-f-m-p-s.f.g/V/Z/s0c0d0e0f0h0i0j0k0l0n0rS#a_#b!P.[-l.^._.`.a.t.z.|/R/j/o/t/u/y/z0S0U0W0Z0[0^0_0`'|_OTYZ[adnoprtxy}!P!Q!R!U!X!c!d!e!f!g!h!i!k!o!p!q!s!t!z#O#S#T#[#d#g#x#y#{#}$Q$e$g$h$j$q$}%S%Z%^%`%c%g%l%n%w%|&O&Z&_&h&j&k&u&x&|'P'W'Z'l'm'p'r's'w'|(O(S(W(](^(d(g(p(r(z(})^)e)g)k)l)p)t)z*O*Y*d*g*h*k*q*r*t*v*y*z*}+Q+U+V+Y+a+c+d+k+x+y,P,X,Y,],g,h,i,k,l,o,q,s,u,w,y,z-O-d-f-m-p-s.f.g/V/Z/s0c0d0e0f0h0i0j0k0l0n0rT#a_#bT#^^#_R(o%xa(l%x(n(o+`,{-y-z.oT+[(k+]R-z,{Q$PsQ+l)aQ,^*RR-e,_X#}s$O$P&fQ&y$aQ'a$nQ'd$oR)s'SQ)b&wV-S+m-T-{ZgOn$j)t,PXkOn)t,PQ$k!TQ&z$bQ&{$cQ'^$mQ'b$oQ)q'RQ)x'WQ){'XQ)|'YQ*Z'`S*]'c'dQ+s)gQ+u)hQ+v)iQ+z)oS+|)r*[Q,Q)vQ,R)wS,S)y)zQ,d*^Q-V+rQ-W+tQ-Y+{S-Z+},OQ-`,UQ-b,VQ-|-XQ.O-[Q.P-^Q.Q-_Q.p-}Q.q.RQ/W.dR/r/XWkOn)t,PR#mjQ'`$nS)r'S'aR,O)sQ,]*RR-f,^Q*['`Q+})rR-[,OZiOjn)t,PQ'f$pR*`'gT-j,e-ku.c-l.^._.a.t.z.|/R/j/o/t/u/y0S0U0Z0[0^t.c-l.^._.a.t.z.|/R/j/o/t/u/y0S0U0Z0[0^Q/S.`X0V/z0W0_0`!P.Z-l.^._.`.a.t.z.|/R/j/o/t/u/y/z0S0U0W0Z0[0^0_0`Q.w.YR/f.xg.z.].{/b/i/n/|0O0Q0]0a0bu.b-l.^._.a.t.z.|/R/j/o/t/u/y0S0U0Z0[0^X.u.W.b/a0PR/c.tV0R/u0S0[R/X.dQnOS#on,PR,P)tQ&^#uR(x&^S%m#R#wS(_%m(bT(b%p&`Q%a!yQ%h!}W(P%a%h(U(YQ(U%eR(Y%jQ&i$RR)O&iQ(e%qQ*{(`T+R(e*{Q'n%OR*e'nS'q%R%SY*i'q*j,m-q.hU*j'r's'tU,m*k*l*mS-q,n,oR.h-rQ#Y]R%t#YQ#_^R%y#_Q(h%vS+W(h+XR+X(iQ+](kR,|+]Q#b_R%{#bQ#ebQ%}#cW&Q#e%}({+bQ({&cR+b0gQ$OsS&e$O&fR&f$PQ&v$_R)_&vQ&V#jR(t&VQ&m$VS)T&m+hR+h)UQ$Z{R&p$ZQ&t$]R)[&tQ+n)bR-U+nQ#hfR&S#hQ)f&zR+q)fQ&}$dS)m&})nR)n'OQ'V$kR)u'VQ'[$lS*P'[,ZR,Z*QQ,a*VR-i,aWjOn)t,PR#ljQ-k,eR.U-kd.{.]/b/i/n/|0O0Q0]0a0bR/h.{U.s.W/a0PR/`.sQ/{/nS0X/{0YR0Y/|S/v/b/cR0T/vQ.}.]R/k.}R!ZPXmOn)t,PWlOn)t,PR'T$jYfOn$j)t,PR&R#g[sOn#g$j)t,PR&d#}&dQOYZ[dnprxy}!P!Q!U!i!k!o!p!q!s!t#[#d#g#y#{#}$Q$h$j$}%S%Z%^%`%g%l%n%w%|&Z&_&j&k&u&x'P'W'Z'l'm'p'r's'w(O(W(^(d(g(p(r(z)^)e)g)p)t)z*O*Y*d*g*h*k*q*r*t*v*y*z*}+U+V+Y+a+d+k,P,X,Y,],g,h,i,k,l,o,q,s,u,w,y,z-O-d-f-m-p-s.f.g/V/Z/s0c0d0e0f0h0i0j0k0n0rQ!nTQ#caQ#poU$Rt%c(SS$d!R$gQ$p!XQ$u!cQ$v!dQ$w!eQ$x!fQ$y!gQ$z!hQ%e!zQ%j#OQ%p#SQ%q#TQ&`#xQ'O$eQ'g$qQ(q&OU(|&h(}+cW)j&|)l+x+yQ*o'|Q*x(]Q+w)kQ,v+QR0g0lQ!yYQ!}ZQ$b!PQ$c!QQ%R!kQ't%S^'{%`%g(O(W*q*t*v^*f'p*h,k,l-p.g/ZQ*l'rQ*m'sQ+t)gQ,j*gQ,n*kQ-n,hQ-o,iQ-r,oQ.e-mR/Y.f[bOn#g$j)t,P!^!vYZ!P!Q!k%S%`%g'p'r's(O(W)g*g*h*k*q*t*v,h,i,k,l,o-m-p.f.g/ZQ#R[Q#fdS#wrxQ$UyW$_}$Q'P)pS$l!U$hW${!i'm*d,gS%v#[+Y`&P#d%|(p(r(z+a-O0kQ&a#yQ&b#{Q&c#}Q'j$}Q'z%^W([%l(^*y*}Q(`%nQ(i%wQ(v&ZS(y&_0iQ)P&jQ)Q&kU)]&u)^+kQ)d&xQ)y'WY)}'Z*O,X,Y-dQ*b'lS*n'w0jW+P(d*z,s,wW+T(g+V,y,zQ+p)eQ,U)zQ,c*YQ,x+UQ-P+dQ-e,]Q-v,uQ.S-fR/q/VhUOn#d#g$j%|&_'w(p(r)t,P%U!uYZ[drxy}!P!Q!U!i!k#[#y#{#}$Q$h$}%S%^%`%g%l%n%w&Z&j&k&u&x'P'W'Z'l'm'p'r's(O(W(^(d(g(z)^)e)g)p)z*O*Y*d*g*h*k*q*t*v*y*z*}+U+V+Y+a+d+k,X,Y,],g,h,i,k,l,o,s,u,w,y,z-O-d-f-m-p.f.g/V/Z0i0j0kQ#qpW%W!o!s0d0nQ%X!pQ%Y!qQ%[!tQ%f0cS'v%Z0hQ'x0eQ'y0fQ,p*rQ-u,qS.i-s/sR0p0rU#uq.k0qR(w&][cOn#g$j)t,PZ!xY#[#}$Q+YQ#W[Q#zrR$TxQ%b!yQ%i!}Q%o#RQ'j${Q(V%eQ(Z%jQ(c%pQ(f%qQ*|(`Q,f*bQ-t,pQ.m-uR/].lQ$StQ(R%cR*s(SQ.l-sR/}/sR#QZR#V[R%Q!iQ%O!iV*c'm*d,g!Z!lQ!n#c#p$R$d$p$u$v$w$x$y$z%e%j%p%q&`'O'g(q(|)j*o*x+w,v0gR%T!kT#]^#_Q%x#[R,{+YQ(m%xS+_(n(oQ,}+`Q-x,{S.n-y-zR/^.oT+Z(k+]Q$`}Q&g$QQ)o'PR+{)pQ$XzQ)W&qR+i)XQ$XzQ&o$WQ)W&qR+i)XQ#khW$Vz$W&q)XQ$[{Q&r$ZZ)R&l)S+f+g-RR$^|R)c&wXlOn)t,PQ$f!RR'Q$gQ$m!UR'R$hR*X'_Q*V'_V-g,`-h.TQ.d-lQ/P.^R/Q._U.]-l.^._Q/U.aQ/b.tQ/g.zU/i.|/j/yQ/n/RQ/|/oQ0O/tU0Q/u0S0[Q0]0UQ0a0ZR0b0^R/T.`R/d.t",
+  nodeNames: "\u26A0 print Escape { Comment Script AssignStatement * BinaryExpression BitOp BitOp BitOp BitOp ArithOp ArithOp @ ArithOp ** UnaryExpression ArithOp BitOp AwaitExpression await ) ( ParenthesizedExpression BinaryExpression or and CompareOp in not is UnaryExpression ConditionalExpression if else LambdaExpression lambda ParamList VariableName AssignOp , : NamedExpression AssignOp YieldExpression yield from TupleExpression ComprehensionExpression async for LambdaExpression ] [ ArrayExpression ArrayComprehensionExpression } { DictionaryExpression DictionaryComprehensionExpression SetExpression SetComprehensionExpression CallExpression ArgList AssignOp MemberExpression . PropertyName Number String FormatString FormatReplacement FormatSelfDoc FormatConversion FormatSpec FormatReplacement FormatSelfDoc ContinuedString Ellipsis None Boolean TypeDef AssignOp UpdateStatement UpdateOp ExpressionStatement DeleteStatement del PassStatement pass BreakStatement break ContinueStatement continue ReturnStatement return YieldStatement PrintStatement RaiseStatement raise ImportStatement import as ScopeStatement global nonlocal AssertStatement assert TypeDefinition type TypeParamList TypeParam StatementGroup ; IfStatement Body elif WhileStatement while ForStatement TryStatement try except finally WithStatement with FunctionDefinition def ParamList AssignOp TypeDef ClassDefinition class DecoratedStatement Decorator At MatchStatement match MatchBody MatchClause case CapturePattern LiteralPattern ArithOp ArithOp AsPattern OrPattern LogicOp AttributePattern SequencePattern MappingPattern StarPattern ClassPattern PatternArgList KeywordPattern KeywordPattern Guard",
+  maxTerm: 277,
+  context: trackIndent,
+  nodeProps: [
+    ["isolate", -5, 4, 71, 72, 73, 77, ""],
+    ["group", -15, 6, 85, 87, 88, 90, 92, 94, 96, 98, 99, 100, 102, 105, 108, 110, "Statement Statement", -22, 8, 18, 21, 25, 40, 49, 50, 56, 57, 60, 61, 62, 63, 64, 67, 70, 71, 72, 79, 80, 81, 82, "Expression", -10, 114, 116, 119, 121, 122, 126, 128, 133, 135, 138, "Statement", -9, 143, 144, 147, 148, 150, 151, 152, 153, 154, "Pattern"],
+    ["openedBy", 23, "(", 54, "[", 58, "{"],
+    ["closedBy", 24, ")", 55, "]", 59, "}"]
+  ],
+  propSources: [pythonHighlighting],
+  skippedNodes: [0, 4],
+  repeatNodeCount: 34,
+  tokenData: "!2|~R!`OX%TXY%oY[%T[]%o]p%Tpq%oqr'ars)Yst*xtu%Tuv,dvw-hwx.Uxy/tyz0[z{0r{|2S|}2p}!O3W!O!P4_!P!Q:Z!Q!R;k!R![>_![!]Do!]!^Es!^!_FZ!_!`Gk!`!aHX!a!b%T!b!cIf!c!dJU!d!eK^!e!hJU!h!i!#f!i!tJU!t!u!,|!u!wJU!w!x!.t!x!}JU!}#O!0S#O#P&o#P#Q!0j#Q#R!1Q#R#SJU#S#T%T#T#UJU#U#VK^#V#YJU#Y#Z!#f#Z#fJU#f#g!,|#g#iJU#i#j!.t#j#oJU#o#p!1n#p#q!1s#q#r!2a#r#s!2f#s$g%T$g;'SJU;'S;=`KW<%lOJU`%YT&n`O#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%T`%lP;=`<%l%To%v]&n`%c_OX%TXY%oY[%T[]%o]p%Tpq%oq#O%T#O#P&o#P#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%To&tX&n`OY%TYZ%oZ]%T]^%o^#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tc'f[&n`O!_%T!_!`([!`#T%T#T#U(r#U#f%T#f#g(r#g#h(r#h#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tc(cTmR&n`O#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tc(yT!mR&n`O#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk)aV&n`&[ZOr%Trs)vs#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk){V&n`Or%Trs*bs#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk*iT&n`&^ZO#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%To+PZS_&n`OY*xYZ%TZ]*x]^%T^#o*x#o#p+r#p#q*x#q#r+r#r;'S*x;'S;=`,^<%lO*x_+wTS_OY+rZ]+r^;'S+r;'S;=`,W<%lO+r_,ZP;=`<%l+ro,aP;=`<%l*xj,kV%rQ&n`O!_%T!_!`-Q!`#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tj-XT!xY&n`O#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tj-oV%lQ&n`O!_%T!_!`-Q!`#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk.]V&n`&ZZOw%Twx.rx#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk.wV&n`Ow%Twx/^x#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk/eT&n`&]ZO#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk/{ThZ&n`O#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tc0cTgR&n`O#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk0yXVZ&n`Oz%Tz{1f{!_%T!_!`-Q!`#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk1mVaR&n`O!_%T!_!`-Q!`#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk2ZV%oZ&n`O!_%T!_!`-Q!`#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tc2wTzR&n`O#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%To3_W%pZ&n`O!_%T!_!`-Q!`!a3w!a#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Td4OT&{S&n`O#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk4fX!fQ&n`O!O%T!O!P5R!P!Q%T!Q![6T![#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk5WV&n`O!O%T!O!P5m!P#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk5tT!rZ&n`O#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Ti6[a!hX&n`O!Q%T!Q![6T![!g%T!g!h7a!h!l%T!l!m9s!m#R%T#R#S6T#S#X%T#X#Y7a#Y#^%T#^#_9s#_#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Ti7fZ&n`O{%T{|8X|}%T}!O8X!O!Q%T!Q![8s![#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Ti8^V&n`O!Q%T!Q![8s![#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Ti8z]!hX&n`O!Q%T!Q![8s![!l%T!l!m9s!m#R%T#R#S8s#S#^%T#^#_9s#_#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Ti9zT!hX&n`O#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk:bX%qR&n`O!P%T!P!Q:}!Q!_%T!_!`-Q!`#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tj;UV%sQ&n`O!_%T!_!`-Q!`#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Ti;ro!hX&n`O!O%T!O!P=s!P!Q%T!Q![>_![!d%T!d!e?q!e!g%T!g!h7a!h!l%T!l!m9s!m!q%T!q!rA]!r!z%T!z!{Bq!{#R%T#R#S>_#S#U%T#U#V?q#V#X%T#X#Y7a#Y#^%T#^#_9s#_#c%T#c#dA]#d#l%T#l#mBq#m#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Ti=xV&n`O!Q%T!Q![6T![#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Ti>fc!hX&n`O!O%T!O!P=s!P!Q%T!Q![>_![!g%T!g!h7a!h!l%T!l!m9s!m#R%T#R#S>_#S#X%T#X#Y7a#Y#^%T#^#_9s#_#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Ti?vY&n`O!Q%T!Q!R@f!R!S@f!S#R%T#R#S@f#S#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Ti@mY!hX&n`O!Q%T!Q!R@f!R!S@f!S#R%T#R#S@f#S#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%TiAbX&n`O!Q%T!Q!YA}!Y#R%T#R#SA}#S#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%TiBUX!hX&n`O!Q%T!Q!YA}!Y#R%T#R#SA}#S#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%TiBv]&n`O!Q%T!Q![Co![!c%T!c!iCo!i#R%T#R#SCo#S#T%T#T#ZCo#Z#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%TiCv]!hX&n`O!Q%T!Q![Co![!c%T!c!iCo!i#R%T#R#SCo#S#T%T#T#ZCo#Z#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%ToDvV{_&n`O!_%T!_!`E]!`#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%TcEdT%{R&n`O#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%TkEzT#gZ&n`O#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%TkFbXmR&n`O!^%T!^!_F}!_!`([!`!a([!a#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%TjGUV%mQ&n`O!_%T!_!`-Q!`#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%TkGrV%zZ&n`O!_%T!_!`([!`#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%TkH`WmR&n`O!_%T!_!`([!`!aHx!a#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%TjIPV%nQ&n`O!_%T!_!`-Q!`#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%TkIoV_Q#}P&n`O!_%T!_!`-Q!`#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%ToJ_]&n`&YS%uZO!Q%T!Q![JU![!c%T!c!}JU!}#R%T#R#SJU#S#T%T#T#oJU#p#q%T#r$g%T$g;'SJU;'S;=`KW<%lOJUoKZP;=`<%lJUoKge&n`&YS%uZOr%Trs)Ysw%Twx.Ux!Q%T!Q![JU![!c%T!c!tJU!t!uLx!u!}JU!}#R%T#R#SJU#S#T%T#T#fJU#f#gLx#g#oJU#p#q%T#r$g%T$g;'SJU;'S;=`KW<%lOJUoMRa&n`&YS%uZOr%TrsNWsw%Twx! vx!Q%T!Q![JU![!c%T!c!}JU!}#R%T#R#SJU#S#T%T#T#oJU#p#q%T#r$g%T$g;'SJU;'S;=`KW<%lOJUkN_V&n`&`ZOr%TrsNts#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%TkNyV&n`Or%Trs! `s#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk! gT&n`&bZO#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk! }V&n`&_ZOw%Twx!!dx#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk!!iV&n`Ow%Twx!#Ox#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk!#VT&n`&aZO#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%To!#oe&n`&YS%uZOr%Trs!%Qsw%Twx!&px!Q%T!Q![JU![!c%T!c!tJU!t!u!(`!u!}JU!}#R%T#R#SJU#S#T%T#T#fJU#f#g!(`#g#oJU#p#q%T#r$g%T$g;'SJU;'S;=`KW<%lOJUk!%XV&n`&dZOr%Trs!%ns#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk!%sV&n`Or%Trs!&Ys#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk!&aT&n`&fZO#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk!&wV&n`&cZOw%Twx!'^x#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk!'cV&n`Ow%Twx!'xx#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk!(PT&n`&eZO#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%To!(ia&n`&YS%uZOr%Trs!)nsw%Twx!+^x!Q%T!Q![JU![!c%T!c!}JU!}#R%T#R#SJU#S#T%T#T#oJU#p#q%T#r$g%T$g;'SJU;'S;=`KW<%lOJUk!)uV&n`&hZOr%Trs!*[s#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk!*aV&n`Or%Trs!*vs#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk!*}T&n`&jZO#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk!+eV&n`&gZOw%Twx!+zx#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk!,PV&n`Ow%Twx!,fx#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tk!,mT&n`&iZO#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%To!-Vi&n`&YS%uZOr%TrsNWsw%Twx! vx!Q%T!Q![JU![!c%T!c!dJU!d!eLx!e!hJU!h!i!(`!i!}JU!}#R%T#R#SJU#S#T%T#T#UJU#U#VLx#V#YJU#Y#Z!(`#Z#oJU#p#q%T#r$g%T$g;'SJU;'S;=`KW<%lOJUo!.}a&n`&YS%uZOr%Trs)Ysw%Twx.Ux!Q%T!Q![JU![!c%T!c!}JU!}#R%T#R#SJU#S#T%T#T#oJU#p#q%T#r$g%T$g;'SJU;'S;=`KW<%lOJUk!0ZT!XZ&n`O#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tc!0qT!WR&n`O#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%Tj!1XV%kQ&n`O!_%T!_!`-Q!`#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%T~!1sO!]~k!1zV%jR&n`O!_%T!_!`-Q!`#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%T~!2fO![~i!2mT%tX&n`O#o%T#p#q%T#r;'S%T;'S;=`%i<%lO%T",
+  tokenizers: [legacyPrint, indentation, newlines, strings, 0, 1, 2, 3, 4],
+  topRules: { "Script": [0, 5] },
+  specialized: [{ term: 221, get: (value) => spec_identifier[value] || -1 }],
+  tokenPrec: 7668
+});
+
+// node_modules/@codemirror/autocomplete/dist/index.js
+function toSet(chars) {
+  let flat = Object.keys(chars).join("");
+  let words = /\w/.test(flat);
+  if (words)
+    flat = flat.replace(/\w/g, "");
+  return `[${words ? "\\w" : ""}${flat.replace(/[^\w\s]/g, "\\$&")}]`;
+}
+function prefixMatch(options) {
+  let first = /* @__PURE__ */ Object.create(null), rest = /* @__PURE__ */ Object.create(null);
+  for (let { label } of options) {
+    first[label[0]] = true;
+    for (let i2 = 1; i2 < label.length; i2++)
+      rest[label[i2]] = true;
+  }
+  let source = toSet(first) + toSet(rest) + "*$";
+  return [new RegExp("^" + source), new RegExp(source)];
+}
+function completeFromList(list) {
+  let options = list.map((o) => typeof o == "string" ? { label: o } : o);
+  let [validFor, match] = options.every((o) => /^\w+$/.test(o.label)) ? [/\w*$/, /\w+$/] : prefixMatch(options);
+  return (context) => {
+    let token = context.matchBefore(match);
+    return token || context.explicit ? { from: token ? token.from : context.pos, options, validFor } : null;
+  };
+}
+function ifNotIn(nodes, source) {
+  return (context) => {
+    for (let pos = syntaxTree(context.state).resolveInner(context.pos, -1); pos; pos = pos.parent) {
+      if (nodes.indexOf(pos.name) > -1)
+        return null;
+      if (pos.type.isTop)
+        break;
+    }
+    return source(context);
+  };
+}
+var pickedCompletion = /* @__PURE__ */ Annotation.define();
+var windows = typeof navigator == "object" && /* @__PURE__ */ /Win/.test(navigator.platform);
+var baseTheme3 = /* @__PURE__ */ EditorView.baseTheme({
+  ".cm-tooltip.cm-tooltip-autocomplete": {
+    "& > ul": {
+      fontFamily: "monospace",
+      whiteSpace: "nowrap",
+      overflow: "hidden auto",
+      maxWidth_fallback: "700px",
+      maxWidth: "min(700px, 95vw)",
+      minWidth: "250px",
+      maxHeight: "10em",
+      height: "100%",
+      listStyle: "none",
+      margin: 0,
+      padding: 0,
+      "& > li, & > completion-section": {
+        padding: "1px 3px",
+        lineHeight: 1.2
+      },
+      "& > li": {
+        overflowX: "hidden",
+        textOverflow: "ellipsis",
+        cursor: "pointer"
+      },
+      "& > completion-section": {
+        display: "list-item",
+        borderBottom: "1px solid silver",
+        paddingLeft: "0.5em",
+        opacity: 0.7
+      }
+    }
+  },
+  "&light .cm-tooltip-autocomplete ul li[aria-selected]": {
+    background: "#17c",
+    color: "white"
+  },
+  "&light .cm-tooltip-autocomplete-disabled ul li[aria-selected]": {
+    background: "#777"
+  },
+  "&dark .cm-tooltip-autocomplete ul li[aria-selected]": {
+    background: "#347",
+    color: "white"
+  },
+  "&dark .cm-tooltip-autocomplete-disabled ul li[aria-selected]": {
+    background: "#444"
+  },
+  ".cm-completionListIncompleteTop:before, .cm-completionListIncompleteBottom:after": {
+    content: '"\xB7\xB7\xB7"',
+    opacity: 0.5,
+    display: "block",
+    textAlign: "center",
+    cursor: "pointer"
+  },
+  ".cm-tooltip.cm-completionInfo": {
+    position: "absolute",
+    padding: "3px 9px",
+    width: "max-content",
+    maxWidth: `${400}px`,
+    boxSizing: "border-box",
+    whiteSpace: "pre-line"
+  },
+  ".cm-completionInfo.cm-completionInfo-left": { right: "100%" },
+  ".cm-completionInfo.cm-completionInfo-right": { left: "100%" },
+  ".cm-completionInfo.cm-completionInfo-left-narrow": { right: `${30}px` },
+  ".cm-completionInfo.cm-completionInfo-right-narrow": { left: `${30}px` },
+  "&light .cm-snippetField": { backgroundColor: "#00000022" },
+  "&dark .cm-snippetField": { backgroundColor: "#ffffff22" },
+  ".cm-snippetFieldPosition": {
+    verticalAlign: "text-top",
+    width: 0,
+    height: "1.15em",
+    display: "inline-block",
+    margin: "0 -0.7px -.7em",
+    borderLeft: "1.4px dotted #888"
+  },
+  ".cm-completionMatchedText": {
+    textDecoration: "underline"
+  },
+  ".cm-completionDetail": {
+    marginLeft: "0.5em",
+    fontStyle: "italic"
+  },
+  ".cm-completionIcon": {
+    fontSize: "90%",
+    width: ".8em",
+    display: "inline-block",
+    textAlign: "center",
+    paddingRight: ".6em",
+    opacity: "0.6",
+    boxSizing: "content-box"
+  },
+  ".cm-completionIcon-function, .cm-completionIcon-method": {
+    "&:after": { content: "'\u0192'" }
+  },
+  ".cm-completionIcon-class": {
+    "&:after": { content: "'\u25CB'" }
+  },
+  ".cm-completionIcon-interface": {
+    "&:after": { content: "'\u25CC'" }
+  },
+  ".cm-completionIcon-variable": {
+    "&:after": { content: "'\u{1D465}'" }
+  },
+  ".cm-completionIcon-constant": {
+    "&:after": { content: "'\u{1D436}'" }
+  },
+  ".cm-completionIcon-type": {
+    "&:after": { content: "'\u{1D461}'" }
+  },
+  ".cm-completionIcon-enum": {
+    "&:after": { content: "'\u222A'" }
+  },
+  ".cm-completionIcon-property": {
+    "&:after": { content: "'\u25A1'" }
+  },
+  ".cm-completionIcon-keyword": {
+    "&:after": { content: "'\u{1F511}\uFE0E'" }
+    // Disable emoji rendering
+  },
+  ".cm-completionIcon-namespace": {
+    "&:after": { content: "'\u25A2'" }
+  },
+  ".cm-completionIcon-text": {
+    "&:after": { content: "'abc'", fontSize: "50%", verticalAlign: "middle" }
+  }
+});
+var FieldPos = class {
+  constructor(field, line, from, to) {
+    this.field = field;
+    this.line = line;
+    this.from = from;
+    this.to = to;
+  }
+};
+var FieldRange = class _FieldRange {
+  constructor(field, from, to) {
+    this.field = field;
+    this.from = from;
+    this.to = to;
+  }
+  map(changes) {
+    let from = changes.mapPos(this.from, -1, MapMode.TrackDel);
+    let to = changes.mapPos(this.to, 1, MapMode.TrackDel);
+    return from == null || to == null ? null : new _FieldRange(this.field, from, to);
+  }
+};
+var Snippet = class _Snippet {
+  constructor(lines, fieldPositions) {
+    this.lines = lines;
+    this.fieldPositions = fieldPositions;
+  }
+  instantiate(state, pos) {
+    let text = [], lineStart = [pos];
+    let lineObj = state.doc.lineAt(pos), baseIndent = /^\s*/.exec(lineObj.text)[0];
+    for (let line of this.lines) {
+      if (text.length) {
+        let indent2 = baseIndent, tabs = /^\t*/.exec(line)[0].length;
+        for (let i2 = 0; i2 < tabs; i2++)
+          indent2 += state.facet(indentUnit);
+        lineStart.push(pos + indent2.length - tabs);
+        line = indent2 + line.slice(tabs);
+      }
+      text.push(line);
+      pos += line.length + 1;
+    }
+    let ranges = this.fieldPositions.map((pos2) => new FieldRange(pos2.field, lineStart[pos2.line] + pos2.from, lineStart[pos2.line] + pos2.to));
+    return { text, ranges };
+  }
+  static parse(template) {
+    let fields = [];
+    let lines = [], positions = [], m;
+    for (let line of template.split(/\r\n?|\n/)) {
+      while (m = /[#$]\{(?:(\d+)(?::([^{}]*))?|((?:\\[{}]|[^{}])*))\}/.exec(line)) {
+        let seq = m[1] ? +m[1] : null, rawName = m[2] || m[3] || "", found = -1;
+        if (seq === 0)
+          seq = 1e9;
+        let name2 = rawName.replace(/\\[{}]/g, (m2) => m2[1]);
+        for (let i2 = 0; i2 < fields.length; i2++) {
+          if (seq != null ? fields[i2].seq == seq : name2 ? fields[i2].name == name2 : false)
+            found = i2;
+        }
+        if (found < 0) {
+          let i2 = 0;
+          while (i2 < fields.length && (seq == null || fields[i2].seq != null && fields[i2].seq < seq))
+            i2++;
+          fields.splice(i2, 0, { seq, name: name2 });
+          found = i2;
+          for (let pos of positions)
+            if (pos.field >= found)
+              pos.field++;
+        }
+        for (let pos of positions)
+          if (pos.line == lines.length && pos.from > m.index) {
+            let snip = m[2] ? 3 + (m[1] || "").length : 2;
+            pos.from -= snip;
+            pos.to -= snip;
+          }
+        positions.push(new FieldPos(found, lines.length, m.index, m.index + name2.length));
+        line = line.slice(0, m.index) + rawName + line.slice(m.index + m[0].length);
+      }
+      line = line.replace(/\\([{}])/g, (_, brace, index) => {
+        for (let pos of positions)
+          if (pos.line == lines.length && pos.from > index) {
+            pos.from--;
+            pos.to--;
+          }
+        return brace;
+      });
+      lines.push(line);
+    }
+    return new _Snippet(lines, positions);
+  }
+};
+var fieldMarker = /* @__PURE__ */ Decoration.widget({ widget: /* @__PURE__ */ new class extends WidgetType {
+  toDOM() {
+    let span = document.createElement("span");
+    span.className = "cm-snippetFieldPosition";
+    return span;
+  }
+  ignoreEvent() {
+    return false;
+  }
+}() });
+var fieldRange = /* @__PURE__ */ Decoration.mark({ class: "cm-snippetField" });
+var ActiveSnippet = class _ActiveSnippet {
+  constructor(ranges, active) {
+    this.ranges = ranges;
+    this.active = active;
+    this.deco = Decoration.set(ranges.map((r2) => (r2.from == r2.to ? fieldMarker : fieldRange).range(r2.from, r2.to)), true);
+  }
+  map(changes) {
+    let ranges = [];
+    for (let r2 of this.ranges) {
+      let mapped = r2.map(changes);
+      if (!mapped)
+        return null;
+      ranges.push(mapped);
+    }
+    return new _ActiveSnippet(ranges, this.active);
+  }
+  selectionInsideField(sel) {
+    return sel.ranges.every((range) => this.ranges.some((r2) => r2.field == this.active && r2.from <= range.from && r2.to >= range.to));
+  }
+};
+var setActive = /* @__PURE__ */ StateEffect.define({
+  map(value, changes) {
+    return value && value.map(changes);
+  }
+});
+var moveToField = /* @__PURE__ */ StateEffect.define();
+var snippetState = /* @__PURE__ */ StateField.define({
+  create() {
+    return null;
+  },
+  update(value, tr) {
+    for (let effect of tr.effects) {
+      if (effect.is(setActive))
+        return effect.value;
+      if (effect.is(moveToField) && value)
+        return new ActiveSnippet(value.ranges, effect.value);
+    }
+    if (value && tr.docChanged)
+      value = value.map(tr.changes);
+    if (value && tr.selection && !value.selectionInsideField(tr.selection))
+      value = null;
+    return value;
+  },
+  provide: (f) => EditorView.decorations.from(f, (val) => val ? val.deco : Decoration.none)
+});
+function fieldSelection(ranges, field) {
+  return EditorSelection.create(ranges.filter((r2) => r2.field == field).map((r2) => EditorSelection.range(r2.from, r2.to)));
+}
+function snippet(template) {
+  let snippet2 = Snippet.parse(template);
+  return (editor, completion, from, to) => {
+    let { text, ranges } = snippet2.instantiate(editor.state, from);
+    let { main } = editor.state.selection;
+    let spec = {
+      changes: { from, to: to == main.from ? main.to : to, insert: Text.of(text) },
+      scrollIntoView: true,
+      annotations: completion ? [pickedCompletion.of(completion), Transaction.userEvent.of("input.complete")] : void 0
+    };
+    if (ranges.length)
+      spec.selection = fieldSelection(ranges, 0);
+    if (ranges.some((r2) => r2.field > 0)) {
+      let active = new ActiveSnippet(ranges, 0);
+      let effects = spec.effects = [setActive.of(active)];
+      if (editor.state.field(snippetState, false) === void 0)
+        effects.push(StateEffect.appendConfig.of([snippetState, addSnippetKeymap, snippetPointerHandler, baseTheme3]));
+    }
+    editor.dispatch(editor.state.update(spec));
+  };
+}
+function moveField(dir) {
+  return ({ state, dispatch }) => {
+    let active = state.field(snippetState, false);
+    if (!active || dir < 0 && active.active == 0)
+      return false;
+    let next = active.active + dir, last = dir > 0 && !active.ranges.some((r2) => r2.field == next + dir);
+    dispatch(state.update({
+      selection: fieldSelection(active.ranges, next),
+      effects: setActive.of(last ? null : new ActiveSnippet(active.ranges, next)),
+      scrollIntoView: true
+    }));
+    return true;
+  };
+}
+var clearSnippet = ({ state, dispatch }) => {
+  let active = state.field(snippetState, false);
+  if (!active)
+    return false;
+  dispatch(state.update({ effects: setActive.of(null) }));
+  return true;
+};
+var nextSnippetField = /* @__PURE__ */ moveField(1);
+var prevSnippetField = /* @__PURE__ */ moveField(-1);
+var defaultSnippetKeymap = [
+  { key: "Tab", run: nextSnippetField, shift: prevSnippetField },
+  { key: "Escape", run: clearSnippet }
+];
+var snippetKeymap = /* @__PURE__ */ Facet.define({
+  combine(maps) {
+    return maps.length ? maps[0] : defaultSnippetKeymap;
+  }
+});
+var addSnippetKeymap = /* @__PURE__ */ Prec.highest(/* @__PURE__ */ keymap.compute([snippetKeymap], (state) => state.facet(snippetKeymap)));
+function snippetCompletion(template, completion) {
+  return { ...completion, apply: snippet(template) };
+}
+var snippetPointerHandler = /* @__PURE__ */ EditorView.domEventHandlers({
+  mousedown(event, view) {
+    let active = view.state.field(snippetState, false), pos;
+    if (!active || (pos = view.posAtCoords({ x: event.clientX, y: event.clientY })) == null)
+      return false;
+    let match = active.ranges.find((r2) => r2.from <= pos && r2.to >= pos);
+    if (!match || match.field == active.active)
+      return false;
+    view.dispatch({
+      selection: fieldSelection(active.ranges, match.field),
+      effects: setActive.of(active.ranges.some((r2) => r2.field > match.field) ? new ActiveSnippet(active.ranges, match.field) : null),
+      scrollIntoView: true
+    });
+    return true;
+  }
+});
+var closedBracket = /* @__PURE__ */ new class extends RangeValue {
+}();
+closedBracket.startSide = 1;
+closedBracket.endSide = -1;
+var android = typeof navigator == "object" && /* @__PURE__ */ /Android\b/.test(navigator.userAgent);
+
+// node_modules/@codemirror/lang-python/dist/index.js
+var cache = /* @__PURE__ */ new NodeWeakMap();
+var ScopeNodes = /* @__PURE__ */ new Set([
+  "Script",
+  "Body",
+  "FunctionDefinition",
+  "ClassDefinition",
+  "LambdaExpression",
+  "ForStatement",
+  "MatchClause"
+]);
+function defID(type) {
+  return (node, def, outer) => {
+    if (outer)
+      return false;
+    let id2 = node.node.getChild("VariableName");
+    if (id2)
+      def(id2, type);
+    return true;
+  };
+}
+var gatherCompletions = {
+  FunctionDefinition: /* @__PURE__ */ defID("function"),
+  ClassDefinition: /* @__PURE__ */ defID("class"),
+  ForStatement(node, def, outer) {
+    if (outer)
+      for (let child = node.node.firstChild; child; child = child.nextSibling) {
+        if (child.name == "VariableName")
+          def(child, "variable");
+        else if (child.name == "in")
+          break;
+      }
+  },
+  ImportStatement(_node, def) {
+    var _a2, _b;
+    let { node } = _node;
+    let isFrom = ((_a2 = node.firstChild) === null || _a2 === void 0 ? void 0 : _a2.name) == "from";
+    for (let ch = node.getChild("import"); ch; ch = ch.nextSibling) {
+      if (ch.name == "VariableName" && ((_b = ch.nextSibling) === null || _b === void 0 ? void 0 : _b.name) != "as")
+        def(ch, isFrom ? "variable" : "namespace");
+    }
+  },
+  AssignStatement(node, def) {
+    for (let child = node.node.firstChild; child; child = child.nextSibling) {
+      if (child.name == "VariableName")
+        def(child, "variable");
+      else if (child.name == ":" || child.name == "AssignOp")
+        break;
+    }
+  },
+  ParamList(node, def) {
+    for (let prev = null, child = node.node.firstChild; child; child = child.nextSibling) {
+      if (child.name == "VariableName" && (!prev || !/\*|AssignOp/.test(prev.name)))
+        def(child, "variable");
+      prev = child;
+    }
+  },
+  CapturePattern: /* @__PURE__ */ defID("variable"),
+  AsPattern: /* @__PURE__ */ defID("variable"),
+  __proto__: null
+};
+function getScope(doc2, node) {
+  let cached = cache.get(node);
+  if (cached)
+    return cached;
+  let completions = [], top2 = true;
+  function def(node2, type) {
+    let name2 = doc2.sliceString(node2.from, node2.to);
+    completions.push({ label: name2, type });
+  }
+  node.cursor(IterMode.IncludeAnonymous).iterate((node2) => {
+    if (node2.name) {
+      let gather = gatherCompletions[node2.name];
+      if (gather && gather(node2, def, top2) || !top2 && ScopeNodes.has(node2.name))
+        return false;
+      top2 = false;
+    } else if (node2.to - node2.from > 8192) {
+      for (let c of getScope(doc2, node2.node))
+        completions.push(c);
+      return false;
+    }
+  });
+  cache.set(node, completions);
+  return completions;
+}
+var Identifier = /^[\w\xa1-\uffff][\w\d\xa1-\uffff]*$/;
+var dontComplete = ["String", "FormatString", "Comment", "PropertyName"];
+function localCompletionSource(context) {
+  let inner = syntaxTree(context.state).resolveInner(context.pos, -1);
+  if (dontComplete.indexOf(inner.name) > -1)
+    return null;
+  let isWord = inner.name == "VariableName" || inner.to - inner.from < 20 && Identifier.test(context.state.sliceDoc(inner.from, inner.to));
+  if (!isWord && !context.explicit)
+    return null;
+  let options = [];
+  for (let pos = inner; pos; pos = pos.parent) {
+    if (ScopeNodes.has(pos.name))
+      options = options.concat(getScope(context.state.doc, pos));
+  }
+  return {
+    options,
+    from: isWord ? inner.from : context.pos,
+    validFor: Identifier
+  };
+}
+var globals = /* @__PURE__ */ [
+  "__annotations__",
+  "__builtins__",
+  "__debug__",
+  "__doc__",
+  "__import__",
+  "__name__",
+  "__loader__",
+  "__package__",
+  "__spec__",
+  "False",
+  "None",
+  "True"
+].map((n) => ({ label: n, type: "constant" })).concat(/* @__PURE__ */ [
+  "ArithmeticError",
+  "AssertionError",
+  "AttributeError",
+  "BaseException",
+  "BlockingIOError",
+  "BrokenPipeError",
+  "BufferError",
+  "BytesWarning",
+  "ChildProcessError",
+  "ConnectionAbortedError",
+  "ConnectionError",
+  "ConnectionRefusedError",
+  "ConnectionResetError",
+  "DeprecationWarning",
+  "EOFError",
+  "Ellipsis",
+  "EncodingWarning",
+  "EnvironmentError",
+  "Exception",
+  "FileExistsError",
+  "FileNotFoundError",
+  "FloatingPointError",
+  "FutureWarning",
+  "GeneratorExit",
+  "IOError",
+  "ImportError",
+  "ImportWarning",
+  "IndentationError",
+  "IndexError",
+  "InterruptedError",
+  "IsADirectoryError",
+  "KeyError",
+  "KeyboardInterrupt",
+  "LookupError",
+  "MemoryError",
+  "ModuleNotFoundError",
+  "NameError",
+  "NotADirectoryError",
+  "NotImplemented",
+  "NotImplementedError",
+  "OSError",
+  "OverflowError",
+  "PendingDeprecationWarning",
+  "PermissionError",
+  "ProcessLookupError",
+  "RecursionError",
+  "ReferenceError",
+  "ResourceWarning",
+  "RuntimeError",
+  "RuntimeWarning",
+  "StopAsyncIteration",
+  "StopIteration",
+  "SyntaxError",
+  "SyntaxWarning",
+  "SystemError",
+  "SystemExit",
+  "TabError",
+  "TimeoutError",
+  "TypeError",
+  "UnboundLocalError",
+  "UnicodeDecodeError",
+  "UnicodeEncodeError",
+  "UnicodeError",
+  "UnicodeTranslateError",
+  "UnicodeWarning",
+  "UserWarning",
+  "ValueError",
+  "Warning",
+  "ZeroDivisionError"
+].map((n) => ({ label: n, type: "type" }))).concat(/* @__PURE__ */ [
+  "bool",
+  "bytearray",
+  "bytes",
+  "classmethod",
+  "complex",
+  "float",
+  "frozenset",
+  "int",
+  "list",
+  "map",
+  "memoryview",
+  "object",
+  "range",
+  "set",
+  "staticmethod",
+  "str",
+  "super",
+  "tuple",
+  "type"
+].map((n) => ({ label: n, type: "class" }))).concat(/* @__PURE__ */ [
+  "abs",
+  "aiter",
+  "all",
+  "anext",
+  "any",
+  "ascii",
+  "bin",
+  "breakpoint",
+  "callable",
+  "chr",
+  "compile",
+  "delattr",
+  "dict",
+  "dir",
+  "divmod",
+  "enumerate",
+  "eval",
+  "exec",
+  "exit",
+  "filter",
+  "format",
+  "getattr",
+  "globals",
+  "hasattr",
+  "hash",
+  "help",
+  "hex",
+  "id",
+  "input",
+  "isinstance",
+  "issubclass",
+  "iter",
+  "len",
+  "license",
+  "locals",
+  "max",
+  "min",
+  "next",
+  "oct",
+  "open",
+  "ord",
+  "pow",
+  "print",
+  "property",
+  "quit",
+  "repr",
+  "reversed",
+  "round",
+  "setattr",
+  "slice",
+  "sorted",
+  "sum",
+  "vars",
+  "zip"
+].map((n) => ({ label: n, type: "function" })));
+var snippets = [
+  /* @__PURE__ */ snippetCompletion("def ${name}(${params}):\n	${}", {
+    label: "def",
+    detail: "function",
+    type: "keyword"
+  }),
+  /* @__PURE__ */ snippetCompletion("for ${name} in ${collection}:\n	${}", {
+    label: "for",
+    detail: "loop",
+    type: "keyword"
+  }),
+  /* @__PURE__ */ snippetCompletion("while ${}:\n	${}", {
+    label: "while",
+    detail: "loop",
+    type: "keyword"
+  }),
+  /* @__PURE__ */ snippetCompletion("try:\n	${}\nexcept ${error}:\n	${}", {
+    label: "try",
+    detail: "/ except block",
+    type: "keyword"
+  }),
+  /* @__PURE__ */ snippetCompletion("if ${}:\n	\n", {
+    label: "if",
+    detail: "block",
+    type: "keyword"
+  }),
+  /* @__PURE__ */ snippetCompletion("if ${}:\n	${}\nelse:\n	${}", {
+    label: "if",
+    detail: "/ else block",
+    type: "keyword"
+  }),
+  /* @__PURE__ */ snippetCompletion("class ${name}:\n	def __init__(self, ${params}):\n			${}", {
+    label: "class",
+    detail: "definition",
+    type: "keyword"
+  }),
+  /* @__PURE__ */ snippetCompletion("import ${module}", {
+    label: "import",
+    detail: "statement",
+    type: "keyword"
+  }),
+  /* @__PURE__ */ snippetCompletion("from ${module} import ${names}", {
+    label: "from",
+    detail: "import",
+    type: "keyword"
+  })
+];
+var globalCompletion = /* @__PURE__ */ ifNotIn(dontComplete, /* @__PURE__ */ completeFromList(/* @__PURE__ */ globals.concat(snippets)));
+function innerBody(context) {
+  let { node, pos } = context;
+  let lineIndent = context.lineIndent(pos, -1);
+  let found = null;
+  for (; ; ) {
+    let before = node.childBefore(pos);
+    if (!before) {
+      break;
+    } else if (before.name == "Comment") {
+      pos = before.from;
+    } else if (before.name == "Body" || before.name == "MatchBody") {
+      if (context.baseIndentFor(before) + context.unit <= lineIndent)
+        found = before;
+      node = before;
+    } else if (before.name == "MatchClause") {
+      node = before;
+    } else if (before.type.is("Statement")) {
+      node = before;
+    } else {
+      break;
+    }
+  }
+  return found;
+}
+function indentBody(context, node) {
+  let base2 = context.baseIndentFor(node);
+  let line = context.lineAt(context.pos, -1), to = line.from + line.text.length;
+  if (/^\s*($|#)/.test(line.text) && context.node.to < to + 100 && !/\S/.test(context.state.sliceDoc(to, context.node.to)) && context.lineIndent(context.pos, -1) <= base2)
+    return null;
+  if (/^\s*(else:|elif |except |finally:|case\s+[^=:]+:)/.test(context.textAfter) && context.lineIndent(context.pos, -1) > base2)
+    return null;
+  return base2 + context.unit;
+}
+var pythonLanguage = /* @__PURE__ */ LRLanguage.define({
+  name: "python",
+  parser: /* @__PURE__ */ parser2.configure({
+    props: [
+      /* @__PURE__ */ indentNodeProp.add({
+        Body: (context) => {
+          var _a2;
+          let body = /^\s*(#|$)/.test(context.textAfter) && innerBody(context) || context.node;
+          return (_a2 = indentBody(context, body)) !== null && _a2 !== void 0 ? _a2 : context.continue();
+        },
+        MatchBody: (context) => {
+          var _a2;
+          let inner = innerBody(context);
+          return (_a2 = indentBody(context, inner || context.node)) !== null && _a2 !== void 0 ? _a2 : context.continue();
+        },
+        IfStatement: (cx) => /^\s*(else:|elif )/.test(cx.textAfter) ? cx.baseIndent : cx.continue(),
+        "ForStatement WhileStatement": (cx) => /^\s*else:/.test(cx.textAfter) ? cx.baseIndent : cx.continue(),
+        TryStatement: (cx) => /^\s*(except[ :]|finally:|else:)/.test(cx.textAfter) ? cx.baseIndent : cx.continue(),
+        MatchStatement: (cx) => {
+          if (/^\s*case /.test(cx.textAfter))
+            return cx.baseIndent + cx.unit;
+          return cx.continue();
+        },
+        "TupleExpression ComprehensionExpression ParamList ArgList ParenthesizedExpression": /* @__PURE__ */ delimitedIndent({ closing: ")" }),
+        "DictionaryExpression DictionaryComprehensionExpression SetExpression SetComprehensionExpression": /* @__PURE__ */ delimitedIndent({ closing: "}" }),
+        "ArrayExpression ArrayComprehensionExpression": /* @__PURE__ */ delimitedIndent({ closing: "]" }),
+        MemberExpression: (cx) => cx.baseIndent + cx.unit,
+        "String FormatString": () => null,
+        Script: (context) => {
+          var _a2;
+          let inner = innerBody(context);
+          return (_a2 = inner && indentBody(context, inner)) !== null && _a2 !== void 0 ? _a2 : context.continue();
+        }
+      }),
+      /* @__PURE__ */ foldNodeProp.add({
+        "ArrayExpression DictionaryExpression SetExpression TupleExpression": foldInside,
+        Body: (node, state) => ({ from: node.from + 1, to: node.to - (node.to == state.doc.length ? 0 : 1) }),
+        "String FormatString": (node, state) => ({ from: state.doc.lineAt(node.from).to, to: node.to })
+      })
+    ]
+  }),
+  languageData: {
+    closeBrackets: {
+      brackets: ["(", "[", "{", "'", '"', "'''", '"""'],
+      stringPrefixes: [
+        "f",
+        "fr",
+        "rf",
+        "r",
+        "u",
+        "b",
+        "br",
+        "rb",
+        "F",
+        "FR",
+        "RF",
+        "R",
+        "U",
+        "B",
+        "BR",
+        "RB"
+      ]
+    },
+    commentTokens: { line: "#" },
+    // Indent logic logic are triggered upon below input patterns
+    indentOnInput: /^\s*([\}\]\)]|else:|elif |except |finally:|case\s+[^:]*:?)$/
+  }
+});
+function python() {
+  return new LanguageSupport(pythonLanguage, [
+    pythonLanguage.data.of({ autocomplete: localCompletionSource }),
+    pythonLanguage.data.of({ autocomplete: globalCompletion })
+  ]);
+}
+export {
+  EditorView,
+  bracketMatching,
+  highlightActiveLine,
+  indentWithTab,
+  lineNumbers,
+  python,
+  r
+};

--- a/crates/core/src/site/mod.rs
+++ b/crates/core/src/site/mod.rs
@@ -264,6 +264,17 @@ const STYLES_CSS: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/assets/shared/styles.css"
 ));
+/// The vendored CodeMirror 6 ESM bundle: a pre-built (one-time esbuild authoring,
+/// NOT build-time codegen — ADR-0008) bundle of the CM6 core (`EditorView`) plus
+/// the R and Python language packs and the UX-polish extensions (`lineNumbers`,
+/// `highlightActiveLine`, `bracketMatching`, `indentWithTab`). Shared by every
+/// target — the editor is runtime-agnostic, so the bundle is assembled once here
+/// rather than forked per target (§4.2). Main-thread-only (no web workers) to
+/// avoid COOP/COEP conflicts; the seam AC-2/AC-3 consume read-only.
+const CODEMIRROR_JS: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/assets/shared/codemirror.js"
+));
 
 /// A build target's own client assets: its page shell and its runner adapter.
 ///
@@ -295,6 +306,7 @@ fn assemble(assets: TargetAssets<'_>, lessons: &[(LessonSlug, Lesson)]) -> SiteF
         asset("coi-serviceworker.js", COI_SERVICEWORKER_JS),
         asset("feedback.js", FEEDBACK_JS),
         asset("styles.css", STYLES_CSS),
+        asset("codemirror.js", CODEMIRROR_JS),
     ];
 
     let mut slugs = Vec::new();
@@ -699,6 +711,7 @@ mod tests {
             "lesson-runner-core.js",
             "coi-serviceworker.js",
             "styles.css",
+            "codemirror.js",
         ] {
             assert_eq!(
                 file(&webr, shared).contents,
@@ -1287,5 +1300,122 @@ mod tests {
             validated_page,
             "the eval-results page is identical across targets for the same summary"
         );
+    }
+
+    #[test]
+    fn plan_site_emits_vendored_codemirror_bundle() {
+        // AC-1 (code-editor): a pre-built CodeMirror 6 ESM bundle is vendored as a
+        // committed static asset at assets/shared/codemirror.js, embedded at compile
+        // time via include_str! (CODEMIRROR_JS const) and emitted to built sites for
+        // BOTH targets through the shared `assemble` step — not forked per target.
+        //
+        // 8 clauses pin the invariant (§1.5 — predicates, not coincident shape):
+        //   1. codemirror.js present in SiteFiles for both targets
+        //   2. byte-identical across targets (shared, not forked — §4.2)
+        //   3. contents.len() > 10_000 (catches empty/comment-only stub)
+        //   4. contains EditorView (CM6 core export — catches wrong-library/UMD)
+        //   5. contains evidence of lang-r + lang-python + lineNumbers +
+        //      highlightActiveLine + bracketMatching + indentWithTab
+        //   6. no `new Worker(` (COOP/COEP isolation — no web workers)
+        //   7. deterministic order: after styles.css AND before any lessons/ file
+        //      (full positional invariant, not weak "after styles.css" proxy)
+        //   8. CODEMIRROR_JS const compiles — proved by the test running
+        //      (include_str! refuses a missing asset at compile time — §1.3.1)
+        let webr = plan(&r_course(), BuildTarget::Webr).expect("plans");
+        let pyodide = plan(&python_course(), BuildTarget::Pyodide).expect("plans");
+
+        // Clause 1: codemirror.js lands as a planned file for both targets — a
+        // target that forgot to include it (or embedded it in webr.rs/pyodide.rs
+        // instead of shared mod.rs) misses here.
+        let webr_cm = file(&webr, "codemirror.js").contents.clone();
+        let pyodide_cm = file(&pyodide, "codemirror.js").contents.clone();
+
+        // Clause 2: byte-identical across targets — the bundle is shared, not
+        // forked per target (§4.2). A divergence means a target forked the bundle.
+        assert_eq!(
+            webr_cm, pyodide_cm,
+            "codemirror.js must be byte-identical across targets (shared, not forked)"
+        );
+
+        // Clause 3: the bundle is a real CM6 build, not an empty/comment-only stub.
+        // CM6 core + lang-r + lang-python is ~150-250KB minified; a 23-byte stub
+        // fails here.
+        assert!(
+            webr_cm.len() > 10_000,
+            "codemirror.js must be a real bundle (>10_000 bytes), got {} bytes",
+            webr_cm.len()
+        );
+
+        // Clause 4: EditorView — the CM6 core export. A wrong-library or UMD-global
+        // bundle lacking the ESM EditorView export fails here.
+        assert!(
+            webr_cm.contains("EditorView"),
+            "codemirror.js must contain EditorView (CM6 core ESM export)"
+        );
+
+        // Clause 5: evidence of both language packs AND the UX-polish exports.
+        // - `rLanguage` is the R language descriptor name (lang-r evidence —
+        //   distinctive, preserved by esbuild; the bare export name `r` is too
+        //   short to grep reliably).
+        // - `python` is the lang-python export name (11 occurrences in the bundle).
+        // - lineNumbers, highlightActiveLine, bracketMatching, indentWithTab are
+        //   the UX-polish exports AC-3 consumes (AC-1 owns the complete export set).
+        // A core-only bundle missing the language packs, or a bundle missing the
+        // UX exports, fails here.
+        for needle in [
+            "rLanguage",
+            "python",
+            "lineNumbers",
+            "highlightActiveLine",
+            "bracketMatching",
+            "indentWithTab",
+        ] {
+            assert!(
+                webr_cm.contains(needle),
+                "codemirror.js must contain `{needle}` (language pack or UX export evidence)"
+            );
+        }
+
+        // Clause 6: no web workers — CM6 must be main-thread-only to avoid COOP/COEP
+        // conflicts. A bundler-emitted `new Worker(` (e.g. a future WASM-parser
+        // extension) fails here.
+        assert!(
+            !webr_cm.contains("new Worker("),
+            "codemirror.js must not contain `new Worker(` (COOP/COEP isolation)"
+        );
+
+        // Clause 7: full positional invariant — codemirror.js sits after styles.css
+        // AND before any lessons/ file in the deterministic files vector. This is
+        // the sufficient condition (not the weak "after styles.css" proxy): a rule
+        // appended after codemirror.js but before lessons/ would still pass the weak
+        // proxy but break the intended order. Checking both bounds pins the full
+        // invariant.
+        let webr_files = webr.files();
+        let pos = |name: &str| -> usize {
+            webr_files
+                .iter()
+                .position(|f| f.path == Path::new(name))
+                .unwrap_or_else(|| panic!("{name} must be in the planned site"))
+        };
+        let cm_pos = pos("codemirror.js");
+        let styles_pos = pos("styles.css");
+        let first_lesson_pos = webr_files
+            .iter()
+            .position(|f| f.path.starts_with("lessons/"))
+            .expect("at least one lessons/ file exists");
+        assert!(
+            cm_pos > styles_pos,
+            "codemirror.js (index {cm_pos}) must come after styles.css (index {styles_pos})"
+        );
+        assert!(
+            cm_pos < first_lesson_pos,
+            "codemirror.js (index {cm_pos}) must come before the first lessons/ file \
+             (index {first_lesson_pos})"
+        );
+
+        // Clause 8: CODEMIRROR_JS const compiles — proved by the test running at
+        // all. include_str! refuses a missing asset at compile time (§1.3.1), so
+        // reaching this assertion means the const resolved. No runtime check needed;
+        // the test's existence is the proof.
     }
 }

--- a/docs/evidence/64/README.md
+++ b/docs/evidence/64/README.md
@@ -1,0 +1,67 @@
+# Issue #64 — E2E Evidence
+
+## AC
+Vendor a pre-built CodeMirror 6 bundle (core + lang-r + lang-python + commands +
+language) as a committed static asset at `crates/core/assets/shared/codemirror.js`,
+wired into the site build pipeline via `include_str!` + `assemble`.
+
+## Verification medium: `code` (cargo test)
+
+## Evidence
+
+### 1. Integration test (8-clause predicate) — PASS
+
+```
+$ uv run cargo test -p blendtutor-core --lib plan_site_emits_vendored_codemirror_bundle -- --nocapture
+
+running 1 test
+test site::tests::plan_site_emits_vendored_codemirror_bundle ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 109 filtered out
+```
+
+Full suite: 110 passed, 0 failed (see `run.log`).
+
+The test `plan_site_emits_vendored_codemirror_bundle` exercises all 8 clauses:
+1. `codemirror.js` present in SiteFiles for both `BuildTarget::Webr` and `BuildTarget::Pyodide`
+2. byte-identical across targets (shared, not forked — §4.2)
+3. `contents.len() > 10_000` (catches empty/comment-only stub)
+4. contains `EditorView` (CM6 core ESM export — catches wrong-library/UMD)
+5. contains evidence of `rLanguage` (lang-r) + `python` (lang-python) + `lineNumbers`
+   + `highlightActiveLine` + `bracketMatching` + `indentWithTab`
+6. no `new Worker(` (COOP/COEP isolation — no web workers)
+7. deterministic order: after `styles.css` AND before any `lessons/` file
+   (full positional invariant, not weak "after styles.css" proxy)
+8. `CODEMIRROR_JS` const compiles — proved by the test running (`include_str!`
+   refuses a missing asset at compile time — §1.3.1)
+
+### 2. Bundle authoring (one-time, NOT build-time codegen)
+
+The bundle was produced via one-time esbuild authoring — NOT part of
+`blendtutor build` (ADR-0008: no build-time code execution). The committed
+artifact at `crates/core/assets/shared/codemirror.js` is embedded at compile
+time via `include_str!`, the same pattern as `STYLES_CSS` and
+`COI_SERVICEWORKER_JS`. No build script was added to `Cargo.toml`.
+
+**Note on `@codemirror/lang-r`:** The official `@codemirror/lang-r` package does
+not exist on npm. The community package `codemirror-lang-r@0.1.1` (depends on
+`lezer-r` parser + `@codemirror/language`) was used instead — it exports the
+same `r()` function returning a `LanguageSupport`. Reported to Director.
+
+### 3. Binary compiles with embedded bundle — PASS
+
+```
+$ uv run cargo build -p blendtutor-core
+
+   Compiling blendtutor-core v0.1.0
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.65s
+```
+
+The 687KB bundle is embedded via `include_str!` into the binary's `.rodata`.
+See `build.log`.
+
+### 4. Bundle stats
+- Size: 687180 bytes (671 KB)
+- Format: ESM (`export { EditorView, bracketMatching, highlightActiveLine, indentWithTab, lineNumbers, python, r }`)
+- No `new Worker(` (verified: 0 occurrences)
+- No build script added to Cargo.toml

--- a/docs/evidence/64/build.log
+++ b/docs/evidence/64/build.log
@@ -1,0 +1,3 @@
+   Compiling blendtutor-core v0.1.0 (/Users/carbonite/Documents/coding/portfolio/blendtutor/crates/core)
+   Compiling blendtutor-cli v0.1.0 (/Users/carbonite/Documents/coding/portfolio/blendtutor/crates/cli)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.18s

--- a/docs/evidence/64/bundle-authoring.md
+++ b/docs/evidence/64/bundle-authoring.md
@@ -1,0 +1,53 @@
+# Issue #64 — E2E Evidence
+
+## AC
+Vendor a pre-built CodeMirror 6 bundle (core + lang-r + lang-python + commands + language) as a committed static asset at `crates/core/assets/shared/codemirror.js`, wired into the site build pipeline via `include_str!` + `assemble`.
+
+## Verification medium: `code` (cargo test)
+
+## Evidence
+
+### 1. Integration test (8-clause predicate) — PASS
+See `run.log`. The test `plan_site_emits_vendored_codemirror_bundle` exercises all 8 clauses:
+1. `codemirror.js` present in SiteFiles for both `BuildTarget::Webr` and `BuildTarget::Pyodide`
+2. byte-identical across targets (shared, not forked)
+3. `contents.len() > 10_000` (catches empty/comment-only stub)
+4. contains `EditorView` (CM6 core ESM export)
+5. contains evidence of `rLanguage` (lang-r) + `python` (lang-python) + `lineNumbers` + `highlightActiveLine` + `bracketMatching` + `indentWithTab`
+6. no `new Worker(` (COOP/COEP isolation)
+7. deterministic order: after `styles.css` AND before any `lessons/` file (full positional invariant)
+8. `CODEMIRROR_JS` const compiles (proved by test running — `include_str!` refuses missing asset at compile time)
+
+Full suite: 110 passed, 0 failed.
+
+### 2. Binary compiles with embedded bundle — PASS
+See `build.log`. `cargo build` succeeds — the 687KB bundle is embedded via `include_str!` into the binary's `.rodata`.
+
+### 3. Negative control — stub bundle caught
+Replaced `codemirror.js` with an 8-byte stub (`// stub\n`). Test failed on clause 3:
+```
+codemirror.js must be a real bundle (>10_000 bytes), got 8 bytes
+```
+Real bundle restored (687180 bytes), test passes again.
+
+### 4. Bundle authoring (one-time, NOT build-time codegen)
+The bundle was produced via one-time esbuild authoring — NOT part of `blendtutor build` (ADR-0008: no build-time code execution). Steps:
+
+```bash
+mkdir -p /tmp/cm6-bundle && cd /tmp/cm6-bundle
+npm init -y
+npm install @codemirror/view @codemirror/state @codemirror/commands \
+  @codemirror/language @codemirror/lang-python codemirror-lang-r esbuild
+# entry.js re-exports: EditorView, lineNumbers, highlightActiveLine (view),
+#   bracketMatching (language), indentWithTab (commands), r (lang-r), python (lang-python)
+npx esbuild entry.js --bundle --format=esm \
+  --outfile=crates/core/assets/shared/codemirror.js
+```
+
+**Note on `@codemirror/lang-r`:** The official `@codemirror/lang-r` package does not exist on npm. The community package `codemirror-lang-r@0.1.1` (depends on `lezer-r` parser + `@codemirror/language`) was used instead — it exports the same `r()` function returning a `LanguageSupport`. This is a deviation from the issue's literal `npm install @codemirror/lang-r` instruction, reported to Director.
+
+### 5. Bundle stats
+- Size: 687180 bytes (671 KB)
+- Format: ESM (`export { EditorView, bracketMatching, highlightActiveLine, indentWithTab, lineNumbers, python, r }`)
+- No `new Worker(` (verified: 0 occurrences)
+- No build script added to Cargo.toml

--- a/docs/evidence/64/run.log
+++ b/docs/evidence/64/run.log
@@ -1,0 +1,14 @@
+   Compiling blendtutor-core v0.1.0 (/Users/carbonite/Documents/coding/portfolio/blendtutor/crates/core)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 2.20s
+     Running unittests src/lib.rs (target/debug/deps/blendtutor_core-e6b2900eafa92e80)
+
+running 1 test
+test site::tests::plan_site_emits_vendored_codemirror_bundle ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 109 filtered out; finished in 0.01s
+
+test site::tests::plan_site_emits_vendored_codemirror_bundle ... ok
+test site::tests::plan_site_workspace_styles_use_tokens_and_status_renders_as_pill ... ok
+
+test result: ok. 110 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+

--- a/docs/okf/interfaces/site-build-pipeline.md
+++ b/docs/okf/interfaces/site-build-pipeline.md
@@ -1,0 +1,59 @@
+---
+type: Interface
+title: Site build pipeline
+description: plan_site → write_site public API + include_str! asset embedding.
+resource: crates/core/src/site/mod.rs:413
+tags: [rust, static-site, build, assets, include-str]
+timestamp: 2026-06-25
+pure: true
+---
+
+# Responsibility
+
+The public API surface for building a static site: plan files (pure) then write them (effectful). All assets embedded at compile time via `include_str!` — no runtime asset loading, no codegen, no templating.
+
+# Interface
+
+- `pub fn plan_site(lessons: &[(LessonSlug, Lesson)], target: BuildTarget, eval: &EvalSummary) -> Result<SiteFiles, PlanError>` — pure
+- `pub fn write_site(out_dir: &Path, site: &SiteFiles) -> std::io::Result<()>` — effectful
+- `pub fn eval_summary_from_report_json(json: &str) -> Result<EvalSummary, EvalReportError>` — pure
+
+**Asset embedding** (`include_str!`, 8 assets):
+- `assets/shared/lesson-runner-core.js`, `assets/shared/coi-serviceworker.js`, `assets/shared/feedback.js`, `assets/shared/styles.css`, `assets/shared/codemirror.js`
+- `assets/webr/{index.html,lesson-runner.js}`, `assets/pyodide/{index.html,lesson-runner.js}`
+
+**`assemble` output order** (deterministic):
+1. `index.html` (target shell)
+2. `lesson-runner.js` (target adapter)
+3. `lesson-runner-core.js` (shared)
+4. `coi-serviceworker.js` (shared)
+5. `feedback.js` (shared)
+6. `styles.css` (shared)
+7. `codemirror.js` (shared — vendored CM6 ESM bundle)
+8. `lessons/{i}.json` per lesson (keyed by index, not slug)
+9. `lessons.json` (ordered slug index)
+10. `eval-results.html` (target-independent, folded after dispatch)
+
+# Dependencies
+
+- Implemented by [site](/modules/site.md).
+- Assets define [js-runtime-seam](/interfaces/js-runtime-seam.md).
+- Types in [site-types](/data-models/site-types.md).
+- Called by [cli](/modules/cli.md) build command.
+
+# Invariants
+
+- No LLM calls, no code execution at build time (ADR-0008).
+- Per-lesson JSON keyed by index — slug is never a filesystem path component.
+- `SiteLesson::from_lesson` drops `llm_evaluation_prompt` (the prompt template never ships to the browser).
+- `write_site` writes files verbatim — the only effectful step.
+
+# Pure/Effectful
+
+`plan_site` + `eval_summary_from_report_json` pure. `write_site` effectful (FS).
+
+# Citations
+
+- `crates/core/src/site/mod.rs:280` (`assemble`), `:413` (`plan_site`), `:444` (`write_site`)
+- `crates/core/src/site/{webr,pyodide}.rs` (`include_str!`)
+- ADR-0008 (static site build)


### PR DESCRIPTION
## Summary
Vendor a pre-built CodeMirror 6 bundle (core + lang-r + lang-python + commands + language) as a committed static asset at assets/shared/codemirror.js, wired into the site build pipeline via include_str! + assemble.

Closes #64

## Changes
- NEW: crates/core/assets/shared/codemirror.js (687KB vendored CM6 ESM bundle)
- MODIFIED: crates/core/src/site/mod.rs (CODEMIRROR_JS const + asset() entry + cross-target identity test + 8-clause test)
- MODIFIED: docs/okf/interfaces/site-build-pipeline.md (asset count 7 to 8)

## Test Results
- plan_site_emits_vendored_codemirror_bundle: PASS (8 clauses)
- Full suite: 110 passed, 0 failed
- cargo build: PASS
- cargo clippy: clean

## Notes
- @codemirror/lang-r does not exist on npm. Used community package codemirror-lang-r@0.1.1 (same r() API, depends on lezer-r parser + @codemirror/language).
- Bundle produced via one-time esbuild authoring (not build-time codegen, per ADR-0008).
- Evidence: docs/evidence/64/

## Plan Reference
Slice: AC-1 from code-editor