### PR TITLE
feat(llm): swap Fireworks default model to DeepSeek v4 Flash (#71)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,10 @@ jobs:
       # nonzero exit (no `--no-run`, no `continue-on-error`, no `|| true`).
       - name: Test
         run: cargo nextest run --locked
+
+      # Issue #71 — the Fireworks default model id is a dual-consumer field
+      # (Rust CLI + JS BYOK). This asserts both sides agree on the same id and
+      # that the retired `qwen3-vl-30b-a3b-instruct` leaves no dead-code ghost.
+      # Uses grep (not rg) so ubuntu-latest needs no extra install.
+      - name: Model alignment
+        run: ./scripts/check-model-alignment.sh

--- a/crates/core/src/llm/provider.rs
+++ b/crates/core/src/llm/provider.rs
@@ -47,12 +47,13 @@ impl ProviderChoice {
 
     /// The default model id for this provider.
     ///
-    /// Fireworks ports the R package's default (`evaluate_with_llm`); Anthropic
-    /// uses a current Claude model. Model selection is not yet configurable — a
-    /// later slice can lift these to a setting.
+    /// Fireworks mirrors the browser BYOK fallback (`deepseek-v4-flash` in
+    /// `assets/shared/feedback.js`); Anthropic uses a current Claude model. Model
+    /// selection is not yet configurable — a later slice can lift these to a
+    /// setting.
     pub fn default_model(self) -> &'static str {
         match self {
-            ProviderChoice::Fireworks => "accounts/fireworks/models/qwen3-vl-30b-a3b-instruct",
+            ProviderChoice::Fireworks => "accounts/fireworks/models/deepseek-v4-flash",
             ProviderChoice::Anthropic => "claude-sonnet-4-5",
         }
     }
@@ -95,15 +96,16 @@ mod tests {
 
     #[test]
     fn each_provider_has_a_recognizable_default_model() {
-        // Pinned by a substring so a model-id bump stays green while an empty or
-        // wrong default does not (the mock ignores the model, so nothing else
-        // exercises this value).
-        assert!(
-            ProviderChoice::Fireworks
-                .default_model()
-                .contains("fireworks"),
-            "the Fireworks model id names the provider, got {}",
-            ProviderChoice::Fireworks.default_model()
+        // Pinned by exact equality so a wrong-but-similar model id (prefix typo,
+        // stale bump) fails rather than sneaking through a substring match. The
+        // mock ignores the model field, so nothing else exercises this value —
+        // this assertion is load-bearing. Anthropic stays a substring because its
+        // CLI default (`claude-sonnet-4-5`) differs from the browser BYOK default
+        // (`claude-opus-4-8`); only the Claude family is invariant across both.
+        assert_eq!(
+            ProviderChoice::Fireworks.default_model(),
+            "accounts/fireworks/models/deepseek-v4-flash",
+            "the Fireworks default model id must match the browser BYOK fallback",
         );
         assert!(
             ProviderChoice::Anthropic.default_model().contains("claude"),

--- a/docs/okf/modules/llm-provider.md
+++ b/docs/okf/modules/llm-provider.md
@@ -1,0 +1,37 @@
+---
+type: Module
+title: llm::provider
+description: Closed set of LLM backend metadata.
+resource: crates/core/src/llm/provider.rs
+tags: [rust, llm, provider, closed-enum]
+timestamp: 2026-06-25
+pure: true
+---
+
+# Responsibility
+
+Enumerates supported LLM backends and their metadata (env var, base URL, default model). Does NOT perform HTTP and does NOT own the API key.
+
+# Interface
+
+- `#[derive(Default)] enum ProviderChoice { Fireworks (default), Anthropic }`
+- `pub fn key_var(self) -> &'static str` → `"FIREWORKS_API_KEY"` / `"ANTHROPIC_API_KEY"`
+- `pub fn default_base_url(self) -> &'static str`
+- `pub fn default_model(self) -> &'static str`
+
+# Dependencies
+
+- Consumed by [llm-feedback](/modules/llm-feedback.md), [run](/modules/run.md), [eval](/modules/eval.md).
+
+# Invariants
+
+- Enum, not string (§1.2). Exhaustive matches, no wildcard — a new provider forces new arms everywhere.
+- CLI `run`/`eval` and the browser BYOK path share the Fireworks default (`deepseek-v4-flash`); Anthropic still differs — CLI `claude-sonnet-4-5` vs browser `claude-opus-4-8` — see [js-runtime-seam](/interfaces/js-runtime-seam.md).
+
+# Pure/Effectful
+
+Pure: metadata only.
+
+# Citations
+
+- `crates/core/src/llm/provider.rs`

--- a/scripts/check-model-alignment.sh
+++ b/scripts/check-model-alignment.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Assert the Fireworks default model id is identical across the two consumers
+# that hardcode it — the Rust CLI (`provider.rs`) and the browser BYOK path
+# (`feedback.js`) — and that the retired model id (`qwen3-vl-30b-a3b-instruct`)
+# leaves no dead-code ghost anywhere in `crates/core/src/`.
+#
+# This is the executable spec for issue #71's cross-file alignment AC. The same
+# predicates CI enforces, runnable by hand:
+#   scripts/check-model-alignment.sh
+#
+# Uses `grep` (not `rg`) so CI needs no extra install — ubuntu-latest ships grep.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+model="accounts/fireworks/models/deepseek-v4-flash"
+rust_src="crates/core/src/llm/provider.rs"
+js_src="crates/core/assets/shared/feedback.js"
+retired="qwen3-vl-30b-a3b-instruct"
+
+# AC1 — exact model id present in the Rust provider (the CLI default).
+test -f "$rust_src" \
+  || { echo "model-align: missing $rust_src" >&2; exit 1; }
+grep -qF "$model" "$rust_src" \
+  || { echo "model-align: $rust_src missing model id '$model'" >&2; exit 1; }
+
+# AC2 — the same model id present in the JS BYOK fallback (browser default).
+test -f "$js_src" \
+  || { echo "model-align: missing $js_src" >&2; exit 1; }
+grep -qF "$model" "$js_src" \
+  || { echo "model-align: $js_src missing model id '$model'" >&2; exit 1; }
+
+# AC3 (negative) — the retired model id appears NOWHERE in crates/core/src/,
+# catching a dead-code ghost left in a comment or unreachable branch.
+if grep -rqF "$retired" crates/core/src/; then
+  echo "model-align: retired model id '$retired' still present in crates/core/src/:" >&2
+  grep -rnF "$retired" crates/core/src/ >&2 || true
+  exit 1
+fi
+
+echo "model-align: OK — Rust and JS agree on '$model', '$retired' absent"


### PR DESCRIPTION
Closes #71. Swap hardcoded Fireworks default model from qwen3-vl-30b-a3b-instruct to accounts/fireworks/models/deepseek-v4-flash. Aligns CLI default with browser BYOK fallback. Exact equality test, negative grep, cross-file alignment grep test.