### PR TITLE
feat(examples): create Python example course (5 lessons + eval suites) (#74)

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }
+blendtutor-core = { path = "../core" }
 insta = { workspace = true }
 predicates = { workspace = true }
 regex-lite = { workspace = true }

--- a/crates/cli/tests/write_less_code_python.rs
+++ b/crates/cli/tests/write_less_code_python.rs
@@ -1,0 +1,369 @@
+//! Integration tests for the Python example course at `examples/write-less-code-python/`.
+//!
+//! Validates the 9-point compound predicate from AC-4:
+//! 1. Course structure — `blendtutor list` returns 5 rows, all `language: "python"`
+//! 2. Lesson validity — each YAML parses with `language == Python`, `{student_code}`
+//!    placeholder, `textbook_reference` non-empty
+//! 3. Packages bidirectional — `packages` contains `"pandas"` ⟺ solution/checks
+//!    reference pandas
+//! 4. Checks non-empty and specific — no vacuous assertions, every check contains
+//!    `assert`
+//! 5. Lesson 4 explicit for-loop — positive grep `for\s+\w+\s+in\s+` AND no list
+//!    comprehension
+//! 6. Copy-paste-trap concrete bug — lesson 2 prompt contains literal `stress_6`
+//! 7. Validate gate — `blendtutor validate` exits 0
+//! 8. Run gate — `blendtutor run` exits 0 with `correct` (wiremock stub)
+//! 9. Eval suites — ≥4 cases, ≥2 correct, ≥2 incorrect, ≥1 near-miss
+
+mod common;
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use blendtutor_core::eval::{EvalSuite, ExpectedVerdict, parse_eval_suite};
+use blendtutor_core::lesson::{Language, Lesson, read_lesson_file};
+use regex_lite::Regex;
+use wiremock::MockServer;
+
+/// The Python example course directory, relative to the CLI crate.
+const COURSE_DIR: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../examples/write-less-code-python"
+);
+
+/// The 5 lesson file names in manifest order.
+const LESSON_FILES: &[&str] = &[
+    "01_seed_data.yaml",
+    "02_copy_paste_trap.yaml",
+    "03_write_a_function.yaml",
+    "04_map_over_columns.yaml",
+    "05_rule_of_three.yaml",
+];
+
+/// The 5 eval-suite file names, one per lesson.
+const EVAL_FILES: &[&str] = &[
+    "eval_01_seed_data.yaml",
+    "eval_02_copy_paste_trap.yaml",
+    "eval_03_write_a_function.yaml",
+    "eval_04_map_over_columns.yaml",
+    "eval_05_rule_of_three.yaml",
+];
+
+fn course_dir() -> &'static Path {
+    Path::new(COURSE_DIR)
+}
+
+fn lesson_path(filename: &str) -> PathBuf {
+    course_dir().join(filename)
+}
+
+fn eval_path(filename: &str) -> PathBuf {
+    course_dir().join(filename)
+}
+
+fn load_lesson(filename: &str) -> Lesson {
+    read_lesson_file(&lesson_path(filename))
+        .unwrap_or_else(|e| panic!("lesson {filename} should parse: {e}"))
+}
+
+fn load_eval_suite(filename: &str) -> EvalSuite {
+    let text = std::fs::read_to_string(eval_path(filename))
+        .unwrap_or_else(|e| panic!("eval suite {filename} should be readable: {e}"));
+    parse_eval_suite(&text).unwrap_or_else(|e| panic!("eval suite {filename} should parse: {e}"))
+}
+
+/// True (after printing a notice) when `uv` is not on `PATH`, so a real-interpreter
+/// test can `return` early instead of failing on machines without `uv` installed.
+fn uv_absent() -> bool {
+    let present = std::process::Command::new("uv")
+        .arg("--version")
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false);
+    if !present {
+        eprintln!("SKIP: uv absent — skipping Python interpreter test");
+    }
+    !present
+}
+
+// ─── Predicate 1: Course structure ───────────────────────────────────────────
+
+/// `blendtutor list` returns exactly 5 rows, every row `language == "python"`.
+#[test]
+fn list_returns_five_python_lessons() {
+    let output = Command::cargo_bin("blendtutor")
+        .unwrap()
+        .arg("list")
+        .arg(course_dir())
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "`list` should exit 0, got {:?}; stderr={:?}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("list json did not parse: {e}; stdout={stdout:?}"));
+
+    assert_eq!(rows.len(), 5, "course should list exactly 5 lessons");
+
+    for (i, row) in rows.iter().enumerate() {
+        assert_eq!(
+            row["language"], "python",
+            "lesson {i} should be python, got {:?}",
+            row["language"]
+        );
+    }
+}
+
+// ─── Predicate 2: Lesson validity ────────────────────────────────────────────
+
+/// Each lesson parses with `language == Python`, `{student_code}` placeholder,
+/// and non-empty `textbook_reference`.
+#[test]
+fn each_lesson_is_valid_python_with_student_code_and_textbook() {
+    for (idx, filename) in LESSON_FILES.iter().enumerate() {
+        let lesson = load_lesson(filename);
+        assert_eq!(
+            lesson.language,
+            Language::Python,
+            "lesson {idx} ({filename}) should be Python"
+        );
+        assert!(
+            lesson
+                .exercise
+                .llm_evaluation_prompt
+                .contains("{student_code}"),
+            "lesson {idx} ({filename}) should contain the {{student_code}} placeholder"
+        );
+        assert!(
+            lesson
+                .textbook_reference
+                .as_ref()
+                .map(|s| !s.is_empty())
+                .unwrap_or(false),
+            "lesson {idx} ({filename}) should have a non-empty textbook_reference"
+        );
+    }
+}
+
+// ─── Predicate 3: Packages bidirectional ─────────────────────────────────────
+
+/// `packages` contains `"pandas"` ⟺ the lesson's solution or checks reference
+/// pandas (`import\s+pandas|pd\.`). Declaring without using OR using without
+/// declaring both fail.
+#[test]
+fn packages_bidirectional_pandas_iff_used() {
+    let pandas_re = Regex::new(r"import\s+pandas|pd\.").unwrap();
+    for (idx, filename) in LESSON_FILES.iter().enumerate() {
+        let lesson = load_lesson(filename);
+        let solution = lesson.exercise.solution.as_deref().unwrap_or("");
+        let checks_joined = lesson.checks.join("\n");
+        let combined = format!("{solution}\n{checks_joined}");
+        let uses_pandas = pandas_re.is_match(&combined);
+        let declares_pandas = lesson.packages.iter().any(|p| p == "pandas");
+        assert_eq!(
+            uses_pandas, declares_pandas,
+            "lesson {idx} ({filename}): packages bidirectional violated — \
+             uses pandas ({uses_pandas}) should equal declares pandas ({declares_pandas})"
+        );
+    }
+}
+
+// ─── Predicate 4: Checks non-empty and specific ──────────────────────────────
+
+/// Every lesson has non-empty `checks`; no check matches the vacuous-assertion
+/// regex; every check contains `assert`.
+#[test]
+fn checks_non_empty_and_specific() {
+    let vacuous_re =
+        Regex::new(r"(?m)^\s*assert\s+(True|1\s*==\s*1|1\b)\s*$|^\s*pass\s*$").unwrap();
+    for (idx, filename) in LESSON_FILES.iter().enumerate() {
+        let lesson = load_lesson(filename);
+        assert!(
+            !lesson.checks.is_empty(),
+            "lesson {idx} ({filename}) should have non-empty checks"
+        );
+        for (ci, check) in lesson.checks.iter().enumerate() {
+            assert!(
+                check.contains("assert"),
+                "lesson {idx} ({filename}) check {ci} should contain 'assert': {check:?}"
+            );
+            assert!(
+                !vacuous_re.is_match(check),
+                "lesson {idx} ({filename}) check {ci} should not be a vacuous assertion: {check:?}"
+            );
+        }
+    }
+}
+
+// ─── Predicate 5: Lesson 4 explicit for-loop ────────────────────────────────
+
+/// Lesson 4 (map-over-columns) solution matches `for\s+\w+\s+in\s+` (positive)
+/// AND does NOT match the list-comprehension regex (negative).
+#[test]
+fn lesson_4_solution_uses_explicit_for_loop_not_list_comprehension() {
+    let lesson = load_lesson(LESSON_FILES[3]); // 0-indexed: lesson 4
+    let solution = lesson.exercise.solution.as_deref().unwrap_or("");
+    let for_loop_re = Regex::new(r"for\s+\w+\s+in\s+").unwrap();
+    let list_comp_re = Regex::new(r"\[[^\]]*\s+for\s+[^\]]*\s+in\s+[^\]]*\]").unwrap();
+    assert!(
+        for_loop_re.is_match(solution),
+        "lesson 4 solution should contain an explicit for loop: {solution:?}"
+    );
+    assert!(
+        !list_comp_re.is_match(solution),
+        "lesson 4 solution should NOT contain a list comprehension: {solution:?}"
+    );
+}
+
+// ─── Predicate 6: Copy-paste-trap concrete bug ──────────────────────────────
+
+/// Lesson 2 (copy-paste-trap) exercise prompt contains the literal token
+/// `stress_6`.
+#[test]
+fn lesson_2_prompt_contains_literal_stress_6() {
+    let lesson = load_lesson(LESSON_FILES[1]); // 0-indexed: lesson 2
+    assert!(
+        lesson.exercise.prompt.contains("stress_6"),
+        "lesson 2 prompt should contain the literal 'stress_6': {:?}",
+        lesson.exercise.prompt
+    );
+}
+
+// ─── Predicate 7: Validate gate ─────────────────────────────────────────────
+
+/// `blendtutor validate <lesson>` exits 0 for every lesson in the course.
+#[test]
+fn validate_each_lesson_exits_zero() {
+    for filename in LESSON_FILES {
+        let path = lesson_path(filename);
+        Command::cargo_bin("blendtutor")
+            .unwrap()
+            .arg("validate")
+            .arg(&path)
+            .assert()
+            .success();
+    }
+}
+
+// ─── Predicate 8: Run gate (wiremock stub) ──────────────────────────────────
+
+/// `blendtutor run <lesson> --code <solution_file>` exits 0 and stdout contains
+/// `correct`, with the LLM provider stubbed via wiremock.
+#[tokio::test]
+async fn run_solution_exits_zero_with_correct() {
+    if uv_absent() {
+        return;
+    }
+    let server = MockServer::start().await;
+    common::mount_feedback(&server, true, "Well done — your solution is correct.").await;
+
+    // Write the lesson 1 solution to a temp file.
+    let lesson = load_lesson(LESSON_FILES[0]);
+    let solution = lesson.exercise.solution.as_deref().unwrap();
+    let mut temp_file = tempfile::NamedTempFile::new().unwrap();
+    temp_file.write_all(solution.as_bytes()).unwrap();
+
+    let lesson_path = lesson_path(LESSON_FILES[0]);
+    let code_path = temp_file.path().to_path_buf();
+    let uri = server.uri();
+
+    let output = tokio::task::spawn_blocking(move || {
+        common::blendtutor_output(
+            vec![
+                "run".to_string(),
+                lesson_path.to_string_lossy().into_owned(),
+                "--code".to_string(),
+                code_path.to_string_lossy().into_owned(),
+            ],
+            uri,
+        )
+    })
+    .await
+    .expect("the blocking command task should join");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "a correct submission exits 0; stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        stdout.to_lowercase().contains("correct"),
+        "stdout should report a `correct` verdict, got: {stdout:?}"
+    );
+}
+
+// ─── Predicate 9: Eval suites ───────────────────────────────────────────────
+
+/// Each eval suite has ≥4 cases, ≥2 correct, ≥2 incorrect.
+#[test]
+fn eval_suites_have_correct_case_distribution() {
+    for (idx, filename) in EVAL_FILES.iter().enumerate() {
+        let suite = load_eval_suite(filename);
+        assert!(
+            suite.cases.len() >= 4,
+            "eval suite {idx} ({filename}) should have >= 4 cases, got {}",
+            suite.cases.len()
+        );
+        let correct_count = suite
+            .cases
+            .iter()
+            .filter(|c| c.expected == ExpectedVerdict::Correct)
+            .count();
+        let incorrect_count = suite
+            .cases
+            .iter()
+            .filter(|c| c.expected == ExpectedVerdict::Incorrect)
+            .count();
+        assert!(
+            correct_count >= 2,
+            "eval suite {idx} ({filename}) should have >= 2 correct cases, got {correct_count}"
+        );
+        assert!(
+            incorrect_count >= 2,
+            "eval suite {idx} ({filename}) should have >= 2 incorrect cases, got {incorrect_count}"
+        );
+    }
+}
+
+/// Each eval suite has at least one near-miss: an incorrect case whose submission
+/// runs cleanly via `uv run --with pandas python -I -c <submission>` with exit 0.
+#[test]
+fn eval_suites_have_near_miss_that_runs_cleanly() {
+    if uv_absent() {
+        return;
+    }
+    for (idx, filename) in EVAL_FILES.iter().enumerate() {
+        let suite = load_eval_suite(filename);
+        let has_near_miss = suite
+            .cases
+            .iter()
+            .filter(|c| c.expected == ExpectedVerdict::Incorrect)
+            .any(|c| submission_runs_cleanly(&c.submission));
+        assert!(
+            has_near_miss,
+            "eval suite {idx} ({filename}) should have at least one near-miss \
+             (incorrect case whose submission runs cleanly)"
+        );
+    }
+}
+
+/// Run `submission` via `uv run --with pandas python -I -c <submission>` and
+/// return `true` if it exits 0 (the submission is valid Python that runs cleanly).
+fn submission_runs_cleanly(submission: &str) -> bool {
+    std::process::Command::new("uv")
+        .args(["run", "--with", "pandas", "python", "-I", "-c", submission])
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}

--- a/docs/evidence/74/list-human.txt
+++ b/docs/evidence/74/list-human.txt
@@ -1,0 +1,5 @@
+seed-data         python   Seed Data
+copy-paste-trap   python   Copy-Paste Trap
+write-a-function  python   Write a Function
+map-over-columns  python   Map Over Columns
+rule-of-three     python   Rule of Three

--- a/docs/evidence/74/list-output.json
+++ b/docs/evidence/74/list-output.json
@@ -1,0 +1,10 @@
+   Compiling hyper v1.10.1
+   Compiling hyper-util v0.1.20
+   Compiling hyper-rustls v0.27.9
+   Compiling reqwest v0.13.4
+   Compiling rig-core v0.38.1
+   Compiling blendtutor-core v0.1.0 (/Users/carbonite/Documents/coding/portfolio/worktree-issue-74/crates/core)
+   Compiling blendtutor-cli v0.1.0 (/Users/carbonite/Documents/coding/portfolio/worktree-issue-74/crates/cli)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 18.19s
+     Running `target/debug/blendtutor list examples/write-less-code-python --format json`
+[{"id":"seed-data","language":"python","title":"Seed Data","error":null},{"id":"copy-paste-trap","language":"python","title":"Copy-Paste Trap","error":null},{"id":"write-a-function","language":"python","title":"Write a Function","error":null},{"id":"map-over-columns","language":"python","title":"Map Over Columns","error":null},{"id":"rule-of-three","language":"python","title":"Rule of Three","error":null}]

--- a/docs/evidence/74/test-suite.log
+++ b/docs/evidence/74/test-suite.log
@@ -1,0 +1,16 @@
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.30s
+────────────
+ Nextest run ID 0f686493-7a21-4347-a719-5781425d6b17 with nextest profile: default
+    Starting 10 tests across 1 binary
+        PASS [   0.064s] ( 1/10) blendtutor-cli::write_less_code_python lesson_2_prompt_contains_literal_stress_6
+        PASS [   0.064s] ( 2/10) blendtutor-cli::write_less_code_python lesson_4_solution_uses_explicit_for_loop_not_list_comprehension
+        PASS [   0.068s] ( 3/10) blendtutor-cli::write_less_code_python checks_non_empty_and_specific
+        PASS [   0.061s] ( 4/10) blendtutor-cli::write_less_code_python packages_bidirectional_pandas_iff_used
+        PASS [   0.066s] ( 5/10) blendtutor-cli::write_less_code_python each_lesson_is_valid_python_with_student_code_and_textbook
+        PASS [   0.068s] ( 6/10) blendtutor-cli::write_less_code_python eval_suites_have_correct_case_distribution
+        PASS [   0.725s] ( 7/10) blendtutor-cli::write_less_code_python list_returns_five_python_lessons
+        PASS [   0.772s] ( 8/10) blendtutor-cli::write_less_code_python validate_each_lesson_exits_zero
+        PASS [   2.741s] ( 9/10) blendtutor-cli::write_less_code_python eval_suites_have_near_miss_that_runs_cleanly
+        PASS [   2.911s] (10/10) blendtutor-cli::write_less_code_python run_solution_exits_zero_with_correct
+────────────
+     Summary [   2.926s] 10 tests run: 10 passed, 0 skipped

--- a/docs/evidence/74/validate-output.txt
+++ b/docs/evidence/74/validate-output.txt
@@ -1,0 +1,10 @@
+=== validate examples/write-less-code-python/01_seed_data.yaml ===
+OK: "Seed Data" is a valid lesson
+=== validate examples/write-less-code-python/02_copy_paste_trap.yaml ===
+OK: "Copy-Paste Trap" is a valid lesson
+=== validate examples/write-less-code-python/03_write_a_function.yaml ===
+OK: "Write a Function" is a valid lesson
+=== validate examples/write-less-code-python/04_map_over_columns.yaml ===
+OK: "Map Over Columns" is a valid lesson
+=== validate examples/write-less-code-python/05_rule_of_three.yaml ===
+OK: "Rule of Three" is a valid lesson

--- a/examples/write-less-code-python/01_seed_data.yaml
+++ b/examples/write-less-code-python/01_seed_data.yaml
@@ -1,0 +1,54 @@
+lesson_name: "Seed Data"
+language: Python
+description: "Create a pandas DataFrame with survey data including stress columns"
+textbook_reference: "Just Enough Software Engineering - Chapter 8: Write Less Code, Part II"
+
+exercise:
+  type: "function_writing"
+  prompt: |
+    Create a pandas DataFrame called `survey_data` with 5 respondents and
+    columns `respondent_id`, `stress_1` through `stress_6`. Each stress
+    column should contain integer values between 1 and 5.
+  code_template: |
+    import pandas as pd
+
+    # Create survey_data with 5 respondents and stress_1 through stress_6
+  solution: |
+    import pandas as pd
+
+    survey_data = pd.DataFrame({
+        'respondent_id': [1, 2, 3, 4, 5],
+        'stress_1': [3, 4, 2, 5, 3],
+        'stress_2': [2, 3, 4, 3, 2],
+        'stress_3': [4, 5, 3, 4, 3],
+        'stress_4': [3, 2, 4, 5, 4],
+        'stress_5': [2, 3, 5, 4, 3],
+        'stress_6': [4, 3, 2, 3, 5],
+    })
+  example_usage: |
+    print(survey_data.shape)  # (5, 7)
+    print(list(survey_data.columns))  # ['respondent_id', 'stress_1', ..., 'stress_6']
+  success_criteria: |
+    - DataFrame has 5 rows and 7 columns
+    - Contains a `stress_6` column
+    - All stress columns contain integers
+  llm_evaluation_prompt: |
+    You are evaluating student code for a software engineering course.
+
+    Exercise: Create a pandas DataFrame called `survey_data` with 5 respondents
+    and columns `respondent_id`, `stress_1` through `stress_6`.
+
+    Student submitted this code:
+    {student_code}
+
+    Evaluate the code and call the respond_with_feedback function with your assessment.
+    Set is_correct to true if the code meets all requirements, false otherwise.
+    Provide brief, encouraging feedback (2-3 sentences) in feedback_message.
+
+checks:
+  - "assert len(survey_data) == 5"
+  - "assert 'stress_6' in survey_data.columns"
+  - "assert survey_data['stress_6'].sum() == 17"
+
+packages:
+  - pandas

--- a/examples/write-less-code-python/02_copy_paste_trap.yaml
+++ b/examples/write-less-code-python/02_copy_paste_trap.yaml
@@ -1,0 +1,72 @@
+lesson_name: "Copy-Paste Trap"
+language: Python
+description: "Fix a copy-paste bug where stress_6 was not properly reversed"
+textbook_reference: "Just Enough Software Engineering - Chapter 8: Write Less Code, Part II"
+
+exercise:
+  type: "function_writing"
+  prompt: |
+    A colleague copy-pasted code to reverse the `stress_6` column but
+    forgot to actually reverse it — they assigned `stress_6` to itself
+    instead of `stress_6[::-1]`. Fix the bug so `stress_6_rev` contains
+    the reversed values of the `stress_6` column from `survey_data`.
+
+    The survey_data DataFrame is provided. Create `stress_6_rev` as a
+    numpy array (or list) containing the values of `stress_6` in
+    reverse order.
+  code_template: |
+    import pandas as pd
+
+    survey_data = pd.DataFrame({
+        'respondent_id': [1, 2, 3, 4, 5],
+        'stress_1': [3, 4, 2, 5, 3],
+        'stress_2': [2, 3, 4, 3, 2],
+        'stress_3': [4, 5, 3, 4, 3],
+        'stress_4': [3, 2, 4, 5, 4],
+        'stress_5': [2, 3, 5, 4, 3],
+        'stress_6': [4, 3, 2, 3, 5],
+    })
+
+    # BUG: copy-paste left stress_6 unreversed
+    stress_6_rev = survey_data['stress_6'].values
+  solution: |
+    import pandas as pd
+
+    survey_data = pd.DataFrame({
+        'respondent_id': [1, 2, 3, 4, 5],
+        'stress_1': [3, 4, 2, 5, 3],
+        'stress_2': [2, 3, 4, 3, 2],
+        'stress_3': [4, 5, 3, 4, 3],
+        'stress_4': [3, 2, 4, 5, 4],
+        'stress_5': [2, 3, 5, 4, 3],
+        'stress_6': [4, 3, 2, 3, 5],
+    })
+
+    stress_6_rev = survey_data['stress_6'].values[::-1]
+  example_usage: |
+    print(stress_6_rev)  # [5 3 2 3 4]
+  success_criteria: |
+    - stress_6_rev contains the reversed values of stress_6
+    - First element is 5 (was last in stress_6)
+    - Last element is 4 (was first in stress_6)
+  llm_evaluation_prompt: |
+    You are evaluating student code for a software engineering course.
+
+    Exercise: Fix the copy-paste bug so `stress_6_rev` contains the
+    reversed values of the `stress_6` column. The original bug assigned
+    `stress_6` to itself instead of reversing it.
+
+    Student submitted this code:
+    {student_code}
+
+    Evaluate the code and call the respond_with_feedback function with your assessment.
+    Set is_correct to true if the code meets all requirements, false otherwise.
+    Provide brief, encouraging feedback (2-3 sentences) in feedback_message.
+
+checks:
+  - "assert stress_6_rev[0] == 5"
+  - "assert stress_6_rev[-1] == 4"
+  - "assert len(stress_6_rev) == 5"
+
+packages:
+  - pandas

--- a/examples/write-less-code-python/03_write_a_function.yaml
+++ b/examples/write-less-code-python/03_write_a_function.yaml
@@ -1,0 +1,47 @@
+lesson_name: "Write a Function"
+language: Python
+description: "Write a function that computes the mean of a DataFrame column"
+textbook_reference: "Just Enough Software Engineering - Chapter 8: Write Less Code, Part II"
+
+exercise:
+  type: "function_writing"
+  prompt: |
+    Write a function called `mean_stress` that takes a pandas DataFrame
+    and a column name, and returns the mean of that column.
+  code_template: |
+    import pandas as pd
+
+    def mean_stress(df, col):
+        ...
+  solution: |
+    import pandas as pd
+
+    def mean_stress(df, col):
+        return df[col].mean()
+  example_usage: |
+    df = pd.DataFrame({'stress': [1, 2, 3]})
+    print(mean_stress(df, 'stress'))  # 2.0
+  success_criteria: |
+    - Function is named `mean_stress`
+    - Takes two parameters (df, col)
+    - Returns the mean of the specified column
+  llm_evaluation_prompt: |
+    You are evaluating student code for a software engineering course.
+
+    Exercise: Write a function called `mean_stress` that takes a pandas
+    DataFrame and a column name, and returns the mean of that column.
+
+    Student submitted this code:
+    {student_code}
+
+    Evaluate the code and call the respond_with_feedback function with your assessment.
+    Set is_correct to true if the code meets all requirements, false otherwise.
+    Provide brief, encouraging feedback (2-3 sentences) in feedback_message.
+
+checks:
+  - "assert mean_stress(pd.DataFrame({'s': [1, 2, 3]}), 's') == 2.0"
+  - "assert mean_stress(pd.DataFrame({'s': [10, 20]}), 's') == 15.0"
+  - "assert mean_stress(pd.DataFrame({'s': [0, 0, 0]}), 's') == 0.0"
+
+packages:
+  - pandas

--- a/examples/write-less-code-python/04_map_over_columns.yaml
+++ b/examples/write-less-code-python/04_map_over_columns.yaml
@@ -1,0 +1,63 @@
+lesson_name: "Map Over Columns"
+language: Python
+description: "Normalize multiple DataFrame columns using an explicit for loop"
+textbook_reference: "Just Enough Software Engineering - Chapter 8: Write Less Code, Part II"
+
+exercise:
+  type: "function_writing"
+  prompt: |
+    Write a function called `normalize_columns` that takes a pandas
+    DataFrame and a list of column names, and normalizes each column
+    to the range [0, 1] using min-max normalization.
+
+    Use an explicit for loop to iterate over the columns. Do NOT use
+    a list comprehension.
+
+    Min-max normalization formula:
+    normalized = (value - min) / (max - min)
+  code_template: |
+    import pandas as pd
+
+    def normalize_columns(df, columns):
+        # Use an explicit for loop (not a list comprehension)
+        ...
+  solution: |
+    import pandas as pd
+
+    def normalize_columns(df, columns):
+        for col in columns:
+            df[col] = (df[col] - df[col].min()) / (df[col].max() - df[col].min())
+        return df
+  example_usage: |
+    df = pd.DataFrame({'a': [0, 10], 'b': [0, 5]})
+    print(normalize_columns(df, ['a', 'b']))
+    #    a    b
+    # 0  0.0  0.0
+    # 1  1.0  1.0
+  success_criteria: |
+    - Function is named `normalize_columns`
+    - Uses an explicit for loop (not a list comprehension)
+    - Normalizes each column to [0, 1] range
+    - Returns the modified DataFrame
+  llm_evaluation_prompt: |
+    You are evaluating student code for a software engineering course.
+
+    Exercise: Write a function called `normalize_columns` that takes a
+    pandas DataFrame and a list of column names, and normalizes each
+    column to the range [0, 1] using min-max normalization. Use an
+    explicit for loop to iterate over the columns.
+
+    Student submitted this code:
+    {student_code}
+
+    Evaluate the code and call the respond_with_feedback function with your assessment.
+    Set is_correct to true if the code meets all requirements, false otherwise.
+    Provide brief, encouraging feedback (2-3 sentences) in feedback_message.
+
+checks:
+  - "assert normalize_columns(pd.DataFrame({'a': [0, 10]}), ['a'])['a'].tolist() == [0.0, 1.0]"
+  - "assert normalize_columns(pd.DataFrame({'a': [0, 10], 'b': [0, 5]}), ['a', 'b'])['b'].tolist() == [0.0, 1.0]"
+  - "assert normalize_columns(pd.DataFrame({'a': [5, 5]}), ['a'])['a'].tolist() == [0.0, 0.0]"
+
+packages:
+  - pandas

--- a/examples/write-less-code-python/05_rule_of_three.yaml
+++ b/examples/write-less-code-python/05_rule_of_three.yaml
@@ -1,0 +1,63 @@
+lesson_name: "Rule of Three"
+language: Python
+description: "Refactor repeated column-stat computations into a single function"
+textbook_reference: "Just Enough Software Engineering - Chapter 8: Write Less Code, Part II"
+
+exercise:
+  type: "function_writing"
+  prompt: |
+    A colleague wrote three nearly identical blocks of code to compute
+    the mean of `stress_1`, `stress_2`, and `stress_3` columns from a
+    DataFrame. Apply the Rule of Three: refactor the repeated code into
+    a single function called `compute_column_means` that takes a
+    DataFrame and a list of column names, and returns a dictionary
+    mapping each column name to its mean.
+  code_template: |
+    import pandas as pd
+
+    # Before (repeated code):
+    # mean_1 = df['stress_1'].mean()
+    # mean_2 = df['stress_2'].mean()
+    # mean_3 = df['stress_3'].mean()
+
+    # After: refactor into one function
+    def compute_column_means(df, columns):
+        ...
+  solution: |
+    import pandas as pd
+
+    def compute_column_means(df, columns):
+        results = {}
+        for col in columns:
+            results[col] = df[col].mean()
+        return results
+  example_usage: |
+    df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
+    print(compute_column_means(df, ['a', 'b']))  # {'a': 2.0, 'b': 5.0}
+  success_criteria: |
+    - Function is named `compute_column_means`
+    - Takes a DataFrame and a list of column names
+    - Returns a dictionary mapping column names to means
+    - Eliminates the repeated code pattern
+  llm_evaluation_prompt: |
+    You are evaluating student code for a software engineering course.
+
+    Exercise: Apply the Rule of Three — refactor repeated column-mean
+    computations into a single function called `compute_column_means`
+    that takes a DataFrame and a list of column names, and returns a
+    dictionary mapping each column name to its mean.
+
+    Student submitted this code:
+    {student_code}
+
+    Evaluate the code and call the respond_with_feedback function with your assessment.
+    Set is_correct to true if the code meets all requirements, false otherwise.
+    Provide brief, encouraging feedback (2-3 sentences) in feedback_message.
+
+checks:
+  - "assert compute_column_means(pd.DataFrame({'a': [1, 2, 3]}), ['a']) == {'a': 2.0}"
+  - "assert compute_column_means(pd.DataFrame({'a': [1, 2], 'b': [3, 4]}), ['a', 'b']) == {'a': 1.5, 'b': 3.5}"
+  - "assert compute_column_means(pd.DataFrame({'x': [10, 20, 30]}), ['x']) == {'x': 20.0}"
+
+packages:
+  - pandas

--- a/examples/write-less-code-python/blendtutor.toml
+++ b/examples/write-less-code-python/blendtutor.toml
@@ -1,0 +1,22 @@
+# Write Less Code, Part II — Python example course.
+# A 5-lesson pandas arc mirroring the R example course (AC-3).
+# Each lesson declares `packages: [pandas]` and uses assert-based checks.
+[[lessons]]
+id = "seed-data"
+path = "01_seed_data.yaml"
+
+[[lessons]]
+id = "copy-paste-trap"
+path = "02_copy_paste_trap.yaml"
+
+[[lessons]]
+id = "write-a-function"
+path = "03_write_a_function.yaml"
+
+[[lessons]]
+id = "map-over-columns"
+path = "04_map_over_columns.yaml"
+
+[[lessons]]
+id = "rule-of-three"
+path = "05_rule_of_three.yaml"

--- a/examples/write-less-code-python/eval_01_seed_data.yaml
+++ b/examples/write-less-code-python/eval_01_seed_data.yaml
@@ -1,0 +1,47 @@
+# Eval suite for 01_seed_data.yaml — 4 cases: 2 correct, 2 incorrect, 1 near-miss.
+# The near-miss (case 3) is valid Python that runs cleanly but omits stress_6.
+cases:
+  # Correct: full solution with all required columns
+  - submission: |-
+      import pandas as pd
+      survey_data = pd.DataFrame({
+          'respondent_id': [1, 2, 3, 4, 5],
+          'stress_1': [3, 4, 2, 5, 3],
+          'stress_2': [2, 3, 4, 3, 2],
+          'stress_3': [4, 5, 3, 4, 3],
+          'stress_4': [3, 2, 4, 5, 4],
+          'stress_5': [2, 3, 5, 4, 3],
+          'stress_6': [4, 3, 2, 3, 5],
+      })
+    expected: correct
+  # Correct: different values but same structure
+  - submission: |-
+      import pandas as pd
+      survey_data = pd.DataFrame({
+          'respondent_id': [10, 20, 30, 40, 50],
+          'stress_1': [1, 2, 3, 4, 5],
+          'stress_2': [5, 4, 3, 2, 1],
+          'stress_3': [2, 3, 4, 5, 1],
+          'stress_4': [3, 1, 5, 2, 4],
+          'stress_5': [4, 5, 1, 3, 2],
+          'stress_6': [1, 2, 3, 4, 5],
+      })
+    expected: correct
+  # Near-miss: valid Python, runs cleanly, but missing stress_6 column
+  - submission: |-
+      import pandas as pd
+      survey_data = pd.DataFrame({
+          'respondent_id': [1, 2, 3, 4, 5],
+          'stress_1': [3, 4, 2, 5, 3],
+          'stress_2': [2, 3, 4, 3, 2],
+          'stress_3': [4, 5, 3, 4, 3],
+      })
+    expected: incorrect
+  # Incorrect: wrong number of rows
+  - submission: |-
+      import pandas as pd
+      survey_data = pd.DataFrame({
+          'respondent_id': [1, 2, 3],
+          'stress_6': [4, 3, 2],
+      })
+    expected: incorrect

--- a/examples/write-less-code-python/eval_02_copy_paste_trap.yaml
+++ b/examples/write-less-code-python/eval_02_copy_paste_trap.yaml
@@ -1,0 +1,51 @@
+# Eval suite for 02_copy_paste_trap.yaml — 4 cases: 2 correct, 2 incorrect, 1 near-miss.
+# The near-miss (case 3) is valid Python that runs cleanly but doesn't reverse stress_6.
+cases:
+  # Correct: properly reversed
+  - submission: |-
+      import pandas as pd
+      survey_data = pd.DataFrame({
+          'respondent_id': [1, 2, 3, 4, 5],
+          'stress_1': [3, 4, 2, 5, 3],
+          'stress_2': [2, 3, 4, 3, 2],
+          'stress_3': [4, 5, 3, 4, 3],
+          'stress_4': [3, 2, 4, 5, 4],
+          'stress_5': [2, 3, 5, 4, 3],
+          'stress_6': [4, 3, 2, 3, 5],
+      })
+      stress_6_rev = survey_data['stress_6'].values[::-1]
+    expected: correct
+  # Correct: reversed using reversed()
+  - submission: |-
+      import pandas as pd
+      survey_data = pd.DataFrame({
+          'respondent_id': [1, 2, 3, 4, 5],
+          'stress_1': [3, 4, 2, 5, 3],
+          'stress_2': [2, 3, 4, 3, 2],
+          'stress_3': [4, 5, 3, 4, 3],
+          'stress_4': [3, 2, 4, 5, 4],
+          'stress_5': [2, 3, 5, 4, 3],
+          'stress_6': [4, 3, 2, 3, 5],
+      })
+      stress_6_rev = list(reversed(survey_data['stress_6'].values))
+    expected: correct
+  # Near-miss: valid Python, runs cleanly, but stress_6 not reversed (the original bug)
+  - submission: |-
+      import pandas as pd
+      survey_data = pd.DataFrame({
+          'respondent_id': [1, 2, 3, 4, 5],
+          'stress_1': [3, 4, 2, 5, 3],
+          'stress_2': [2, 3, 4, 3, 2],
+          'stress_3': [4, 5, 3, 4, 3],
+          'stress_4': [3, 2, 4, 5, 4],
+          'stress_5': [2, 3, 5, 4, 3],
+          'stress_6': [4, 3, 2, 3, 5],
+      })
+      stress_6_rev = survey_data['stress_6'].values
+    expected: incorrect
+  # Incorrect: syntax error
+  - submission: |-
+      import pandas as pd
+      survey_data = pd.DataFrame({'stress_6': [4, 3, 2, 3, 5]})
+      stress_6_rev = survey_data['stress_6'].values[::
+    expected: incorrect

--- a/examples/write-less-code-python/eval_03_write_a_function.yaml
+++ b/examples/write-less-code-python/eval_03_write_a_function.yaml
@@ -1,0 +1,27 @@
+# Eval suite for 03_write_a_function.yaml — 4 cases: 2 correct, 2 incorrect, 1 near-miss.
+# The near-miss (case 3) is valid Python that runs cleanly but returns sum instead of mean.
+cases:
+  # Correct: uses .mean()
+  - submission: |-
+      import pandas as pd
+      def mean_stress(df, col):
+          return df[col].mean()
+    expected: correct
+  # Correct: computes mean manually
+  - submission: |-
+      import pandas as pd
+      def mean_stress(df, col):
+          return df[col].sum() / len(df[col])
+    expected: correct
+  # Near-miss: valid Python, runs cleanly, but returns sum instead of mean
+  - submission: |-
+      import pandas as pd
+      def mean_stress(df, col):
+          return df[col].sum()
+    expected: incorrect
+  # Incorrect: syntax error
+  - submission: |-
+      import pandas as pd
+      def mean_stress(df, col
+          return df[col].mean()
+    expected: incorrect

--- a/examples/write-less-code-python/eval_04_map_over_columns.yaml
+++ b/examples/write-less-code-python/eval_04_map_over_columns.yaml
@@ -1,0 +1,37 @@
+# Eval suite for 04_map_over_columns.yaml — 4 cases: 2 correct, 2 incorrect, 1 near-miss.
+# The near-miss (case 3) is valid Python that runs cleanly but uses list comprehension
+# instead of an explicit for loop (wrong idiom, but functional).
+cases:
+  # Correct: explicit for loop with min-max normalization
+  - submission: |-
+      import pandas as pd
+      def normalize_columns(df, columns):
+          for col in columns:
+              df[col] = (df[col] - df[col].min()) / (df[col].max() - df[col].min())
+          return df
+    expected: correct
+  # Correct: explicit for loop with different variable name
+  - submission: |-
+      import pandas as pd
+      def normalize_columns(df, columns):
+          for c in columns:
+              minimum = df[c].min()
+              maximum = df[c].max()
+              df[c] = (df[c] - minimum) / (maximum - minimum)
+          return df
+    expected: correct
+  # Near-miss: valid Python, runs cleanly, but uses list comprehension instead of for loop
+  - submission: |-
+      import pandas as pd
+      def normalize_columns(df, columns):
+          [df.__setitem__(c, (df[c] - df[c].min()) / (df[c].max() - df[c].min())) for c in columns]
+          return df
+    expected: incorrect
+  # Incorrect: syntax error
+  - submission: |-
+      import pandas as pd
+      def normalize_columns(df, columns):
+          for col in columns:
+              df[col] = (df[col] - df[col].min()) / (df[col].max() - df[col].min()
+          return df
+    expected: incorrect

--- a/examples/write-less-code-python/eval_05_rule_of_three.yaml
+++ b/examples/write-less-code-python/eval_05_rule_of_three.yaml
@@ -1,0 +1,36 @@
+# Eval suite for 05_rule_of_three.yaml — 4 cases: 2 correct, 2 incorrect, 1 near-miss.
+# The near-miss (case 3) is valid Python that runs cleanly but returns max instead of mean.
+cases:
+  # Correct: uses for loop to build dict of means
+  - submission: |-
+      import pandas as pd
+      def compute_column_means(df, columns):
+          results = {}
+          for col in columns:
+              results[col] = df[col].mean()
+          return results
+    expected: correct
+  # Correct: uses dict comprehension (valid Python, correct result)
+  - submission: |-
+      import pandas as pd
+      def compute_column_means(df, columns):
+          return {col: df[col].mean() for col in columns}
+    expected: correct
+  # Near-miss: valid Python, runs cleanly, but returns max instead of mean
+  - submission: |-
+      import pandas as pd
+      def compute_column_means(df, columns):
+          results = {}
+          for col in columns:
+              results[col] = df[col].max()
+          return results
+    expected: incorrect
+  # Incorrect: syntax error
+  - submission: |-
+      import pandas as pd
+      def compute_column_means(df, columns:
+          results = {}
+          for col in columns:
+              results[col] = df[col].mean()
+          return results
+    expected: incorrect


### PR DESCRIPTION
## Summary
Create Python example course at `examples/write-less-code-python/` mirroring the Write Less Code Part II chapter arc. 5 lessons with pandas throughout, explicit for-loop in lesson 4, eval suites with near-miss cases, and a 9-point integration test covering all AC-4 predicates.

## Issue
Closes #74

## ACs implemented
- [x] `blendtutor.toml` lists 5 lessons; `blendtutor list` returns 5 rows, all `language: "python"`
- [x] Each YAML parses with `language == Python`, `{student_code}` placeholder, `textbook_reference` non-empty
- [x] Packages bidirectional: `packages` contains "pandas" iff solution/checks reference pandas
- [x] Checks non-empty and specific (no `assert True` or `assert 1 == 1`)
- [x] Lesson 4 solution has explicit for loop (positive grep) AND no list comprehension (negative grep)
- [x] Lesson 2 prompt contains literal `stress_6` (concrete bug)
- [x] `blendtutor validate` exits 0
- [x] `blendtutor run` exits 0 with correct (wiremock stub, gated on AC-2)
- [x] Each eval suite: >=4 cases, >=2 correct, >=2 incorrect, >=1 near-miss

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested
- [x] Verification medium satisfied (code)
- [x] Design intent respected
- [x] No scope creep

## Test plan
- [x] All tests pass (`cargo nextest run -p blendtutor-cli` — 59 tests, 0 failures)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] PR review findings resolved