### PR TITLE
feat(examples): create R example course (5 lessons + eval suites) (#73)

### DIFF
--- a/crates/cli/tests/cutover.rs
+++ b/crates/cli/tests/cutover.rs
@@ -60,10 +60,13 @@ fn tracked_files(root: &Path) -> Vec<String> {
 /// crates' `.R` student-code fixtures (kept under `crates/`).
 fn is_retired_r_package_path(path: &str) -> bool {
     // `crates/` keeps the Rust runner's `.R` student-code fixtures; `legacy-r/`
-    // is the spec's documented relocation alternative to deletion. Neither is
-    // the retired root package, so both are out of scope here (the latter
-    // mirrors the AC2 grep probe's `!legacy-r/**` exclusion).
-    if path.starts_with("crates/") || path.starts_with("legacy-r/") {
+    // is the spec's documented relocation alternative to deletion; `examples/`
+    // holds the example course's `.R` solution files (legitimate educational
+    // content, not retired R package sources). None of these are the retired
+    // root package, so all are out of scope here (the latter two mirror the
+    // AC2 grep probe's `!legacy-r/**` exclusion).
+    if path.starts_with("crates/") || path.starts_with("legacy-r/") || path.starts_with("examples/")
+    {
         return false;
     }
     path.starts_with("R/")

--- a/crates/cli/tests/write_less_code_r.rs
+++ b/crates/cli/tests/write_less_code_r.rs
@@ -166,8 +166,12 @@ fn layer3_solutions_execute_cleanly() {
     if rscript_absent() {
         return;
     }
+    let skip_lesson4 = purrr_dplyr_absent();
     let lessons = load_all_lessons();
     for (i, lesson) in lessons.iter().enumerate() {
+        if i == 3 && skip_lesson4 {
+            continue;
+        }
         let solution = lesson
             .exercise
             .solution
@@ -189,8 +193,12 @@ fn layer4_checks_pass_against_reference_solution() {
     if rscript_absent() {
         return;
     }
+    let skip_lesson4 = purrr_dplyr_absent();
     let lessons = load_all_lessons();
     for (i, lesson) in lessons.iter().enumerate() {
+        if i == 3 && skip_lesson4 {
+            continue;
+        }
         let solution = lesson
             .exercise
             .solution
@@ -250,8 +258,12 @@ fn layer6_each_lesson_has_genuine_near_miss() {
     if rscript_absent() {
         return;
     }
+    let skip_lesson4 = purrr_dplyr_absent();
     let suites = load_all_eval_suites();
     for (i, suite) in suites.iter().enumerate() {
+        if i == 3 && skip_lesson4 {
+            continue;
+        }
         let has_near_miss = suite.cases.iter().any(|case| {
             case.expected == ExpectedVerdict::Incorrect && rscript_exits_zero(&case.submission)
         });
@@ -352,6 +364,7 @@ fn negative_checks_fail_against_wrong_submissions() {
     if rscript_absent() {
         return;
     }
+    let skip_lesson4 = purrr_dplyr_absent();
     // For each lesson, craft a WRONG submission and assert at least one check fails
     let wrong_submissions: &[(&str, &str)] = &[
         // Lesson 1: wrong dimensions (6 cols instead of 7)
@@ -369,6 +382,11 @@ fn negative_checks_fail_against_wrong_submissions() {
             "survey_data <- data.frame(respondent_id=1:5,stress_1=c(3,4,5,2,1),stress_2=c(2,3,4,5,1),stress_3=c(1,2,3,4,5),stress_4=c(5,4,3,2,1),stress_5=c(4,3,2,1,5),stress_6=c(1,2,3,4,5)); reverse_score <- function(x) 5 - x",
             "stopifnot(identical(reverse_score(c(1, 2, 3, 4, 5)), c(5, 4, 3, 2, 1)))",
         ),
+        // Lesson 4: only reverses stress_1 (not all six) — uses purrr/dplyr
+        (
+            "library(purrr); library(dplyr); survey_data <- data.frame(respondent_id=1:5,stress_1=c(3,4,5,2,1),stress_2=c(2,3,4,5,1),stress_3=c(1,2,3,4,5),stress_4=c(5,4,3,2,1),stress_5=c(4,3,2,1,5),stress_6=c(1,2,3,4,5)); survey_data <- survey_data |> mutate(stress_1_rev = 6 - stress_1)",
+            "stopifnot(all(c('stress_1_rev', 'stress_6_rev') %in% names(survey_data)))",
+        ),
         // Lesson 5: wrong decision (count > 3 instead of count >= 3)
         (
             "survey_data <- data.frame(respondent_id=1:5,stress_1=c(3,4,5,2,1),stress_2=c(2,3,4,5,1),stress_3=c(1,2,3,4,5),stress_4=c(5,4,3,2,1),stress_5=c(4,3,2,1,5),stress_6=c(1,2,3,4,5)); should_abstract <- function(count) count > 3",
@@ -377,6 +395,9 @@ fn negative_checks_fail_against_wrong_submissions() {
     ];
 
     for (i, (wrong, check)) in wrong_submissions.iter().enumerate() {
+        if i == 3 && skip_lesson4 {
+            continue;
+        }
         let program = format!("{wrong}\n{check}");
         let output = StdCommand::new("Rscript")
             .args(["--vanilla", "-e", &program])
@@ -385,6 +406,44 @@ fn negative_checks_fail_against_wrong_submissions() {
         assert!(
             !output.status.success(),
             "lesson {i} check should FAIL against the WRONG submission (check-pass-through cheat)"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Negative 3: near-miss submissions fail at least one check (near-miss-not-near)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn near_miss_submissions_fail_at_least_one_check() {
+    if rscript_absent() {
+        return;
+    }
+    let skip_lesson4 = purrr_dplyr_absent();
+    let lessons = load_all_lessons();
+    let suites = load_all_eval_suites();
+    for (i, (lesson, suite)) in lessons.iter().zip(suites.iter()).enumerate() {
+        if i == 3 && skip_lesson4 {
+            continue;
+        }
+        // Find the near-miss: expected incorrect AND runs cleanly via Rscript
+        let near_miss = suite
+            .cases
+            .iter()
+            .find(|case| {
+                case.expected == ExpectedVerdict::Incorrect && rscript_exits_zero(&case.submission)
+            })
+            .unwrap_or_else(|| {
+                panic!("lesson {i} should have a near-miss case (incorrect + runs cleanly)")
+            });
+        // At least one check must fail against the near-miss submission
+        let any_check_fails = lesson.checks.iter().any(|check| {
+            let program = format!("{}\n{}", near_miss.submission, check);
+            !rscript_exits_zero(&program)
+        });
+        assert!(
+            any_check_fails,
+            "lesson {i} near-miss should fail at least one check (near-miss-not-near guard)"
         );
     }
 }

--- a/crates/cli/tests/write_less_code_r.rs
+++ b/crates/cli/tests/write_less_code_r.rs
@@ -1,0 +1,446 @@
+//! Integration tests for the R example course at `examples/write-less-code-r/`.
+//!
+//! Exercises the 9-layer compound predicate from AC-3's executable spec:
+//!   1. `blendtutor validate` exits 0 for all 5 lessons
+//!   2. `blendtutor list` returns 5 rows, all `language == "r"`
+//!   3. Each lesson's solution executes cleanly via `Rscript --vanilla -e`
+//!   4. Each check passes against the reference solution (load-bearing:
+//!      `format!("{submission}\n{check}")` in fresh Rscript per check)
+//!   5. Each eval suite has >=4 cases, >=2 correct, >=2 incorrect
+//!   6. Each lesson has >=1 genuine near-miss (incorrect case that runs cleanly)
+//!   7. Lessons 2-5 solutions contain `survey_data` (self-contained)
+//!   8. Each lesson has a non-empty `textbook_reference`
+//!   9. `blendtutor run` exits 0 with verdict=correct (wiremock stub)
+//!
+//! Plus negative tests for each cheat the spec calls out.
+
+mod common;
+
+use blendtutor_core::eval::{ExpectedVerdict, parse_eval_suite};
+use blendtutor_core::lesson::read_lesson_file;
+use common::{blendtutor_output, mount_feedback, rscript_absent};
+
+use std::path::Path;
+use std::process::Command as StdCommand;
+
+use assert_cmd::Command as AssertCommand;
+use wiremock::MockServer;
+
+/// The R example course directory, at the repo root under `examples/`.
+const COURSE_DIR: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../examples/write-less-code-r"
+);
+
+/// Lesson YAML files in manifest order.
+const LESSON_FILES: &[&str] = &[
+    "01_seed_data.yaml",
+    "02_copy_paste_trap.yaml",
+    "03_write_a_function.yaml",
+    "04_map_over_columns.yaml",
+    "05_rule_of_three.yaml",
+];
+
+/// Solution .R files, parallel to LESSON_FILES.
+const SOLUTION_FILES: &[&str] = &[
+    "01_seed_data.R",
+    "02_copy_paste_trap.R",
+    "03_write_a_function.R",
+    "04_map_over_columns.R",
+    "05_rule_of_three.R",
+];
+
+/// Eval suite YAML files, parallel to LESSON_FILES.
+const EVAL_FILES: &[&str] = &[
+    "eval_01_seed_data.yaml",
+    "eval_02_copy_paste_trap.yaml",
+    "eval_03_write_a_function.yaml",
+    "eval_04_map_over_columns.yaml",
+    "eval_05_rule_of_three.yaml",
+];
+
+/// Load all 5 lessons from the course directory.
+fn load_all_lessons() -> Vec<blendtutor_core::lesson::Lesson> {
+    LESSON_FILES
+        .iter()
+        .map(|name| {
+            let path = Path::new(COURSE_DIR).join(name);
+            read_lesson_file(&path).unwrap_or_else(|e| panic!("lesson {name} should parse: {e}"))
+        })
+        .collect()
+}
+
+/// Load all 5 eval suites from the course directory.
+fn load_all_eval_suites() -> Vec<blendtutor_core::eval::EvalSuite> {
+    EVAL_FILES
+        .iter()
+        .map(|name| {
+            let path = Path::new(COURSE_DIR).join(name);
+            let text = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("eval file {name} should read: {e}"));
+            parse_eval_suite(&text)
+                .unwrap_or_else(|e| panic!("eval suite {name} should parse: {e}"))
+        })
+        .collect()
+}
+
+/// Run `Rscript --vanilla -e <code>` and return whether it exited 0.
+fn rscript_exits_zero(code: &str) -> bool {
+    StdCommand::new("Rscript")
+        .args(["--vanilla", "-e", code])
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+/// True (after printing a notice) when `purrr` or `dplyr` is not installed,
+/// so lesson 4 tests can skip rather than fail on machines without those packages.
+fn purrr_dplyr_absent() -> bool {
+    let present = rscript_exits_zero("library(purrr); library(dplyr)");
+    if !present {
+        eprintln!("SKIP: purrr/dplyr absent — skipping lesson 4 package tests");
+    }
+    !present
+}
+
+// ---------------------------------------------------------------------------
+// Layer 1: validate exits 0 for all 5 lessons
+// ---------------------------------------------------------------------------
+
+#[test]
+fn layer1_validate_exits_zero_for_all_lessons() {
+    for name in LESSON_FILES {
+        let path = Path::new(COURSE_DIR).join(name);
+        AssertCommand::cargo_bin("blendtutor")
+            .unwrap()
+            .arg("validate")
+            .arg(&path)
+            .assert()
+            .success()
+            .stdout(predicates::str::is_match(r"(?i)\bOK\b|\bvalid\b").unwrap());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Layer 2: list returns 5 rows, all language == "r"
+// ---------------------------------------------------------------------------
+
+#[test]
+fn layer2_list_returns_five_r_lessons() {
+    let output = AssertCommand::cargo_bin("blendtutor")
+        .unwrap()
+        .arg("list")
+        .arg(COURSE_DIR)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "`list` should exit 0; stderr={:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("list json did not parse: {e}; stdout={stdout:?}"));
+
+    assert_eq!(rows.len(), 5, "course has exactly 5 lessons");
+
+    for (i, row) in rows.iter().enumerate() {
+        assert_eq!(
+            row["language"], "r",
+            "row {i} language should be r, got {:?}",
+            row["language"]
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Layer 3: each solution executes cleanly via Rscript
+// ---------------------------------------------------------------------------
+
+#[test]
+fn layer3_solutions_execute_cleanly() {
+    if rscript_absent() {
+        return;
+    }
+    let lessons = load_all_lessons();
+    for (i, lesson) in lessons.iter().enumerate() {
+        let solution = lesson
+            .exercise
+            .solution
+            .as_ref()
+            .unwrap_or_else(|| panic!("lesson {i} should have a solution"));
+        assert!(
+            rscript_exits_zero(solution),
+            "lesson {i} solution should execute cleanly via Rscript"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Layer 4: each check passes against the reference solution
+// ---------------------------------------------------------------------------
+
+#[test]
+fn layer4_checks_pass_against_reference_solution() {
+    if rscript_absent() {
+        return;
+    }
+    let lessons = load_all_lessons();
+    for (i, lesson) in lessons.iter().enumerate() {
+        let solution = lesson
+            .exercise
+            .solution
+            .as_ref()
+            .unwrap_or_else(|| panic!("lesson {i} should have a solution"));
+        for (j, check) in lesson.checks.iter().enumerate() {
+            // Mirrors grade.rs:132: format!("{submission}\n{check}")
+            let program = format!("{solution}\n{check}");
+            assert!(
+                rscript_exits_zero(&program),
+                "lesson {i} check {j} should pass against the reference solution"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Layer 5: each eval suite has >=4 cases, >=2 correct, >=2 incorrect
+// ---------------------------------------------------------------------------
+
+#[test]
+fn layer5_eval_suites_have_minimum_cases() {
+    let suites = load_all_eval_suites();
+    for (i, suite) in suites.iter().enumerate() {
+        assert!(
+            suite.cases.len() >= 4,
+            "eval suite {i} should have >=4 cases, got {}",
+            suite.cases.len()
+        );
+        let correct = suite
+            .cases
+            .iter()
+            .filter(|c| c.expected == ExpectedVerdict::Correct)
+            .count();
+        let incorrect = suite
+            .cases
+            .iter()
+            .filter(|c| c.expected == ExpectedVerdict::Incorrect)
+            .count();
+        assert!(
+            correct >= 2,
+            "eval suite {i} should have >=2 correct cases, got {correct}"
+        );
+        assert!(
+            incorrect >= 2,
+            "eval suite {i} should have >=2 incorrect cases, got {incorrect}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Layer 6: each lesson has >=1 genuine near-miss (incorrect case that runs cleanly)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn layer6_each_lesson_has_genuine_near_miss() {
+    if rscript_absent() {
+        return;
+    }
+    let suites = load_all_eval_suites();
+    for (i, suite) in suites.iter().enumerate() {
+        let has_near_miss = suite.cases.iter().any(|case| {
+            case.expected == ExpectedVerdict::Incorrect && rscript_exits_zero(&case.submission)
+        });
+        assert!(
+            has_near_miss,
+            "eval suite {i} should have >=1 incorrect case that runs cleanly (genuine near-miss)"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Layer 7: lessons 2-5 solutions contain survey_data (self-contained)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn layer7_solutions_are_self_contained() {
+    let lessons = load_all_lessons();
+    // Lessons 2-5 (indices 1-4) must contain survey_data construction
+    for (i, lesson) in lessons.iter().enumerate().skip(1).take(4) {
+        let solution = lesson
+            .exercise
+            .solution
+            .as_ref()
+            .unwrap_or_else(|| panic!("lesson {i} should have a solution"));
+        assert!(
+            solution.contains("survey_data"),
+            "lesson {i} solution must contain survey_data construction (self-contained)"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Layer 8: each lesson has a non-empty textbook_reference
+// ---------------------------------------------------------------------------
+
+#[test]
+fn layer8_each_lesson_has_textbook_reference() {
+    let lessons = load_all_lessons();
+    for (i, lesson) in lessons.iter().enumerate() {
+        let ref_text = lesson
+            .textbook_reference
+            .as_ref()
+            .unwrap_or_else(|| panic!("lesson {i} should have a textbook_reference"));
+        assert!(
+            !ref_text.is_empty(),
+            "lesson {i} textbook_reference should be non-empty"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Layer 9: blendtutor run exits 0 with verdict=correct (wiremock stub)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn layer9_run_exits_zero_with_correct_verdict() {
+    if rscript_absent() {
+        return;
+    }
+    let server = MockServer::start().await;
+    mount_feedback(&server, true, "Nicely done — your solution is correct.").await;
+
+    // Use lesson 1 (seed_data) — simplest solution, no packages needed
+    let lesson_path = Path::new(COURSE_DIR).join(LESSON_FILES[0]);
+    let solution_path = Path::new(COURSE_DIR).join(SOLUTION_FILES[0]);
+
+    let args = vec![
+        "run".to_string(),
+        lesson_path.to_string_lossy().into_owned(),
+        "--code".to_string(),
+        solution_path.to_string_lossy().into_owned(),
+    ];
+
+    let uri = server.uri();
+    let output = tokio::task::spawn_blocking(move || blendtutor_output(args, uri))
+        .await
+        .expect("the blocking command task should join");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "run should exit 0 for a correct submission; stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        stdout.to_lowercase().contains("correct"),
+        "stdout should report a correct verdict, got: {stdout:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative 1: checks fail against WRONG submissions (check-pass-through cheat)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn negative_checks_fail_against_wrong_submissions() {
+    if rscript_absent() {
+        return;
+    }
+    // For each lesson, craft a WRONG submission and assert at least one check fails
+    let wrong_submissions: &[(&str, &str)] = &[
+        // Lesson 1: wrong dimensions (6 cols instead of 7)
+        (
+            "survey_data <- data.frame(respondent_id = 1:5, stress_1 = c(3,4,5,2,1))",
+            "stopifnot(identical(dim(survey_data), c(5L, 7L)))",
+        ),
+        // Lesson 2: copy-paste bug — reverses stress_5 instead of stress_6
+        (
+            "survey_data <- data.frame(respondent_id=1:5,stress_1=c(3,4,5,2,1),stress_2=c(2,3,4,5,1),stress_3=c(1,2,3,4,5),stress_4=c(5,4,3,2,1),stress_5=c(4,3,2,1,5),stress_6=c(1,2,3,4,5)); survey_data$stress_6_rev <- 6 - survey_data$stress_5",
+            "stopifnot(identical(survey_data$stress_6_rev, 6 - survey_data$stress_6))",
+        ),
+        // Lesson 3: wrong max_value (5 - x instead of 6 - x)
+        (
+            "survey_data <- data.frame(respondent_id=1:5,stress_1=c(3,4,5,2,1),stress_2=c(2,3,4,5,1),stress_3=c(1,2,3,4,5),stress_4=c(5,4,3,2,1),stress_5=c(4,3,2,1,5),stress_6=c(1,2,3,4,5)); reverse_score <- function(x) 5 - x",
+            "stopifnot(identical(reverse_score(c(1, 2, 3, 4, 5)), c(5, 4, 3, 2, 1)))",
+        ),
+        // Lesson 5: wrong decision (count > 3 instead of count >= 3)
+        (
+            "survey_data <- data.frame(respondent_id=1:5,stress_1=c(3,4,5,2,1),stress_2=c(2,3,4,5,1),stress_3=c(1,2,3,4,5),stress_4=c(5,4,3,2,1),stress_5=c(4,3,2,1,5),stress_6=c(1,2,3,4,5)); should_abstract <- function(count) count > 3",
+            "stopifnot(isTRUE(should_abstract(3)))",
+        ),
+    ];
+
+    for (i, (wrong, check)) in wrong_submissions.iter().enumerate() {
+        let program = format!("{wrong}\n{check}");
+        let output = StdCommand::new("Rscript")
+            .args(["--vanilla", "-e", &program])
+            .output()
+            .unwrap();
+        assert!(
+            !output.status.success(),
+            "lesson {i} check should FAIL against the WRONG submission (check-pass-through cheat)"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Negative 2+5: lesson 2 check references stress_6_rev (chapter-arc + solution-reuse)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn negative_lesson2_check_references_stress_6_rev() {
+    let lessons = load_all_lessons();
+    let lesson2 = &lessons[1];
+    let all_checks = lesson2.checks.join(" ");
+    assert!(
+        all_checks.contains("stress_6_rev"),
+        "lesson 2 checks must reference stress_6_rev (chapter-arc + solution-reuse guard)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative 4: lesson 4 solution uses purrr/dplyr (package-declared-not-consumed)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn negative_lesson4_solution_uses_purrr_dplyr() {
+    if purrr_dplyr_absent() {
+        return;
+    }
+    let lessons = load_all_lessons();
+    let lesson4 = &lessons[3];
+
+    // Lesson 4 declares packages: [purrr, dplyr]
+    assert!(
+        lesson4.packages.contains(&"purrr".to_string()),
+        "lesson 4 should declare purrr package"
+    );
+    assert!(
+        lesson4.packages.contains(&"dplyr".to_string()),
+        "lesson 4 should declare dplyr package"
+    );
+
+    // Solution must consume the packages — not just declare them
+    let solution = lesson4
+        .exercise
+        .solution
+        .as_ref()
+        .expect("lesson 4 should have a solution");
+    let uses_package = solution.contains("map(")
+        || solution.contains("bind_cols(")
+        || solution.contains("set_names(")
+        || solution.contains("|>")
+        || solution.contains("mutate(")
+        || solution.contains("across(");
+    assert!(
+        uses_package,
+        "lesson 4 solution must use purrr/dplyr (map, bind_cols, set_names, |>, mutate, across) — \
+         package-declared-not-consumed cheat"
+    );
+}

--- a/docs/evidence/73/e2e-list.log
+++ b/docs/evidence/73/e2e-list.log
@@ -1,0 +1,3 @@
+=== blendtutor list --format json ===
+[{"id":"seed-data","language":"r","title":"Seed Data","error":null},{"id":"copy-paste-trap","language":"r","title":"Copy-Paste Trap","error":null},{"id":"write-a-function","language":"r","title":"Write a Function","error":null},{"id":"map-over-columns","language":"r","title":"Map Over Columns","error":null},{"id":"rule-of-three","language":"r","title":"Rule of Three","error":null}]
+exit: 0

--- a/docs/evidence/73/e2e-rscript.log
+++ b/docs/evidence/73/e2e-rscript.log
@@ -1,0 +1,33 @@
+=== Rscript probes: solution + check execution ===
+--- Layer 3: 01_seed_data.R (solution only) ---
+exit: 0
+--- Layer 3: 02_copy_paste_trap.R (solution only) ---
+exit: 0
+--- Layer 3: 03_write_a_function.R (solution only) ---
+exit: 0
+--- Layer 3: 04_map_over_columns.R (solution only) ---
+exit: 0
+--- Layer 3: 05_rule_of_three.R (solution only) ---
+exit: 0
+
+=== Layer 4: solution + each check ===
+--- L1 check 1 ---
+exit: 0
+--- L1 check 2 ---
+exit: 0
+--- L2 check 1 ---
+exit: 0
+--- L2 check 2 ---
+exit: 0
+--- L3 check 1 ---
+exit: 0
+--- L3 check 2 ---
+exit: 0
+--- L4 check 1 ---
+exit: 0
+--- L4 check 2 ---
+exit: 0
+--- L5 check 1 ---
+exit: 0
+--- L5 check 2 ---
+exit: 0

--- a/docs/evidence/73/e2e-validate.log
+++ b/docs/evidence/73/e2e-validate.log
@@ -1,0 +1,16 @@
+=== blendtutor validate (all 5 lessons) ===
+--- validate 01_seed_data.yaml ---
+OK: "Seed Data" is a valid lesson
+exit: 0
+--- validate 02_copy_paste_trap.yaml ---
+OK: "Copy-Paste Trap" is a valid lesson
+exit: 0
+--- validate 03_write_a_function.yaml ---
+OK: "Write a Function" is a valid lesson
+exit: 0
+--- validate 04_map_over_columns.yaml ---
+OK: "Map Over Columns" is a valid lesson
+exit: 0
+--- validate 05_rule_of_three.yaml ---
+OK: "Rule of Three" is a valid lesson
+exit: 0

--- a/docs/evidence/73/test-suite.log
+++ b/docs/evidence/73/test-suite.log
@@ -1,0 +1,19 @@
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.15s
+     Running tests/write_less_code_r.rs (target/debug/deps/write_less_code_r-170a2c73000824aa)
+
+running 12 tests
+test layer5_eval_suites_have_minimum_cases ... ok
+test layer7_solutions_are_self_contained ... ok
+test layer8_each_lesson_has_textbook_reference ... ok
+test negative_lesson2_check_references_stress_6_rev ... ok
+test layer2_list_returns_five_r_lessons ... ok
+test layer1_validate_exits_zero_for_all_lessons ... ok
+test negative_lesson4_solution_uses_purrr_dplyr ... ok
+test negative_checks_fail_against_wrong_submissions ... ok
+test layer9_run_exits_zero_with_correct_verdict ... ok
+test layer6_each_lesson_has_genuine_near_miss ... ok
+test layer3_solutions_execute_cleanly ... ok
+test layer4_checks_pass_against_reference_solution ... ok
+
+test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.56s
+

--- a/examples/write-less-code-r/01_seed_data.R
+++ b/examples/write-less-code-r/01_seed_data.R
@@ -1,0 +1,9 @@
+survey_data <- data.frame(
+  respondent_id = 1:5,
+  stress_1 = c(3, 4, 5, 2, 1),
+  stress_2 = c(2, 3, 4, 5, 1),
+  stress_3 = c(1, 2, 3, 4, 5),
+  stress_4 = c(5, 4, 3, 2, 1),
+  stress_5 = c(4, 3, 2, 1, 5),
+  stress_6 = c(1, 2, 3, 4, 5)
+)

--- a/examples/write-less-code-r/01_seed_data.yaml
+++ b/examples/write-less-code-r/01_seed_data.yaml
@@ -1,0 +1,48 @@
+lesson_name: "Seed Data"
+language: R
+description: "Create the survey_data data frame that anchors the Write Less Code arc"
+textbook_reference: "Just Enough Software Engineering - Chapter 8: Write Less Code, Part II"
+
+exercise:
+  type: "function_writing"
+  prompt: |
+    Create a data frame called `survey_data` with 5 respondents and 6 stress
+    items (stress_1 through stress_6) measured on a 1-5 scale, plus a
+    respondent_id column.
+  code_template: |
+    survey_data <- data.frame(
+      respondent_id = 1:5,
+      # Add stress_1 through stress_6 columns here
+    )
+  solution: |
+    survey_data <- data.frame(
+      respondent_id = 1:5,
+      stress_1 = c(3, 4, 5, 2, 1),
+      stress_2 = c(2, 3, 4, 5, 1),
+      stress_3 = c(1, 2, 3, 4, 5),
+      stress_4 = c(5, 4, 3, 2, 1),
+      stress_5 = c(4, 3, 2, 1, 5),
+      stress_6 = c(1, 2, 3, 4, 5)
+    )
+  example_usage: |
+    dim(survey_data)  # 5 7
+    survey_data$stress_6  # 1 2 3 4 5
+  success_criteria: |
+    - survey_data has 5 rows and 7 columns
+    - stress_6 column contains c(1, 2, 3, 4, 5)
+  llm_evaluation_prompt: |
+    You are evaluating student code for a software engineering course.
+
+    Exercise: Create a data frame called `survey_data` with 5 respondents and 6
+    stress items (stress_1 through stress_6) on a 1-5 scale, plus respondent_id.
+
+    Student submitted this code:
+    {student_code}
+
+    Evaluate the code and call the respond_with_feedback function with your assessment.
+    Set is_correct to true if the code meets all requirements, false otherwise.
+    Provide brief, encouraging feedback (2-3 sentences) in feedback_message.
+
+checks:
+  - "stopifnot(identical(dim(survey_data), c(5L, 7L)))"
+  - "stopifnot(identical(survey_data$stress_6, c(1, 2, 3, 4, 5)))"

--- a/examples/write-less-code-r/02_copy_paste_trap.R
+++ b/examples/write-less-code-r/02_copy_paste_trap.R
@@ -1,0 +1,10 @@
+survey_data <- data.frame(
+  respondent_id = 1:5,
+  stress_1 = c(3, 4, 5, 2, 1),
+  stress_2 = c(2, 3, 4, 5, 1),
+  stress_3 = c(1, 2, 3, 4, 5),
+  stress_4 = c(5, 4, 3, 2, 1),
+  stress_5 = c(4, 3, 2, 1, 5),
+  stress_6 = c(1, 2, 3, 4, 5)
+)
+survey_data$stress_6_rev <- 6 - survey_data$stress_6

--- a/examples/write-less-code-r/02_copy_paste_trap.yaml
+++ b/examples/write-less-code-r/02_copy_paste_trap.yaml
@@ -1,0 +1,58 @@
+lesson_name: "Copy-Paste Trap"
+language: R
+description: "Reverse-score stress_6 — beware the copy-paste trap that reverses the wrong column"
+textbook_reference: "Just Enough Software Engineering - Chapter 8: Write Less Code, Part II"
+
+exercise:
+  type: "function_writing"
+  prompt: |
+    The stress_6 item is reverse-scored (5 = low stress). Create a new column
+    `stress_6_rev` by computing `6 - stress_6`.
+
+    Beware the copy-paste trap: if you copy-paste code from reversing another
+    column, you might forget to update the column name and reverse the wrong
+    one. Make sure stress_6_rev is derived from stress_6, not stress_5.
+  code_template: |
+    survey_data <- data.frame(
+      respondent_id = 1:5,
+      stress_1 = c(3, 4, 5, 2, 1),
+      stress_2 = c(2, 3, 4, 5, 1),
+      stress_3 = c(1, 2, 3, 4, 5),
+      stress_4 = c(5, 4, 3, 2, 1),
+      stress_5 = c(4, 3, 2, 1, 5),
+      stress_6 = c(1, 2, 3, 4, 5)
+    )
+    # Reverse-score stress_6 here
+  solution: |
+    survey_data <- data.frame(
+      respondent_id = 1:5,
+      stress_1 = c(3, 4, 5, 2, 1),
+      stress_2 = c(2, 3, 4, 5, 1),
+      stress_3 = c(1, 2, 3, 4, 5),
+      stress_4 = c(5, 4, 3, 2, 1),
+      stress_5 = c(4, 3, 2, 1, 5),
+      stress_6 = c(1, 2, 3, 4, 5)
+    )
+    survey_data$stress_6_rev <- 6 - survey_data$stress_6
+  example_usage: |
+    survey_data$stress_6_rev  # 5 4 3 2 1
+  success_criteria: |
+    - stress_6_rev equals 6 - stress_6
+    - stress_6_rev values are in range [1, 5]
+  llm_evaluation_prompt: |
+    You are evaluating student code for a software engineering course.
+
+    Exercise: Reverse-score stress_6 by creating stress_6_rev = 6 - stress_6.
+    The solution must reconstruct survey_data first (each check runs in a fresh
+    R session). Beware the copy-paste trap: reversing the wrong column.
+
+    Student submitted this code:
+    {student_code}
+
+    Evaluate the code and call the respond_with_feedback function with your assessment.
+    Set is_correct to true if the code meets all requirements, false otherwise.
+    Provide brief, encouraging feedback (2-3 sentences) in feedback_message.
+
+checks:
+  - "stopifnot(identical(survey_data$stress_6_rev, 6 - survey_data$stress_6))"
+  - "stopifnot(all(survey_data$stress_6_rev >= 1 & survey_data$stress_6_rev <= 5))"

--- a/examples/write-less-code-r/03_write_a_function.R
+++ b/examples/write-less-code-r/03_write_a_function.R
@@ -1,0 +1,10 @@
+survey_data <- data.frame(
+  respondent_id = 1:5,
+  stress_1 = c(3, 4, 5, 2, 1),
+  stress_2 = c(2, 3, 4, 5, 1),
+  stress_3 = c(1, 2, 3, 4, 5),
+  stress_4 = c(5, 4, 3, 2, 1),
+  stress_5 = c(4, 3, 2, 1, 5),
+  stress_6 = c(1, 2, 3, 4, 5)
+)
+reverse_score <- function(x) 6 - x

--- a/examples/write-less-code-r/03_write_a_function.yaml
+++ b/examples/write-less-code-r/03_write_a_function.yaml
@@ -1,0 +1,59 @@
+lesson_name: "Write a Function"
+language: R
+description: "Refactor the reverse-scoring pattern into a reusable function"
+textbook_reference: "Just Enough Software Engineering - Chapter 8: Write Less Code, Part II"
+
+exercise:
+  type: "function_writing"
+  prompt: |
+    Write a function called `reverse_score` that takes a numeric vector `x`
+    (on a 1-5 scale) and returns its reverse-scored version: `6 - x`.
+
+    Reconstruct `survey_data` first — each check runs in a fresh R session.
+    Then apply `reverse_score` to `survey_data$stress_6` to verify it works.
+  code_template: |
+    survey_data <- data.frame(
+      respondent_id = 1:5,
+      stress_1 = c(3, 4, 5, 2, 1),
+      stress_2 = c(2, 3, 4, 5, 1),
+      stress_3 = c(1, 2, 3, 4, 5),
+      stress_4 = c(5, 4, 3, 2, 1),
+      stress_5 = c(4, 3, 2, 1, 5),
+      stress_6 = c(1, 2, 3, 4, 5)
+    )
+    reverse_score <- function(x) {
+      # Your code here
+    }
+  solution: |
+    survey_data <- data.frame(
+      respondent_id = 1:5,
+      stress_1 = c(3, 4, 5, 2, 1),
+      stress_2 = c(2, 3, 4, 5, 1),
+      stress_3 = c(1, 2, 3, 4, 5),
+      stress_4 = c(5, 4, 3, 2, 1),
+      stress_5 = c(4, 3, 2, 1, 5),
+      stress_6 = c(1, 2, 3, 4, 5)
+    )
+    reverse_score <- function(x) 6 - x
+  example_usage: |
+    reverse_score(c(1, 2, 3, 4, 5))              # 5 4 3 2 1
+    reverse_score(survey_data$stress_6)           # 5 4 3 2 1
+  success_criteria: |
+    - reverse_score(c(1, 2, 3, 4, 5)) returns c(5, 4, 3, 2, 1)
+    - reverse_score(survey_data$stress_6) returns c(5, 4, 3, 2, 1)
+  llm_evaluation_prompt: |
+    You are evaluating student code for a software engineering course.
+
+    Exercise: Write a function `reverse_score(x)` that returns `6 - x` for a
+    1-5 scale numeric vector. Reconstruct survey_data first.
+
+    Student submitted this code:
+    {student_code}
+
+    Evaluate the code and call the respond_with_feedback function with your assessment.
+    Set is_correct to true if the code meets all requirements, false otherwise.
+    Provide brief, encouraging feedback (2-3 sentences) in feedback_message.
+
+checks:
+  - "stopifnot(identical(reverse_score(c(1, 2, 3, 4, 5)), c(5, 4, 3, 2, 1)))"
+  - "stopifnot(identical(reverse_score(survey_data$stress_6), c(5, 4, 3, 2, 1)))"

--- a/examples/write-less-code-r/04_map_over_columns.R
+++ b/examples/write-less-code-r/04_map_over_columns.R
@@ -1,0 +1,15 @@
+library(purrr)
+library(dplyr)
+
+survey_data <- data.frame(
+  respondent_id = 1:5,
+  stress_1 = c(3, 4, 5, 2, 1),
+  stress_2 = c(2, 3, 4, 5, 1),
+  stress_3 = c(1, 2, 3, 4, 5),
+  stress_4 = c(5, 4, 3, 2, 1),
+  stress_5 = c(4, 3, 2, 1, 5),
+  stress_6 = c(1, 2, 3, 4, 5)
+)
+stress_cols <- paste0("stress_", 1:6)
+survey_data <- survey_data |>
+  mutate(across(all_of(stress_cols), .fns = list(rev = ~ 6 - .x), .names = "{.col}_rev"))

--- a/examples/write-less-code-r/04_map_over_columns.yaml
+++ b/examples/write-less-code-r/04_map_over_columns.yaml
@@ -1,0 +1,69 @@
+lesson_name: "Map Over Columns"
+language: R
+description: "Use purrr and dplyr to reverse-score all stress columns at once"
+textbook_reference: "Just Enough Software Engineering - Chapter 8: Write Less Code, Part II"
+packages:
+  - purrr
+  - dplyr
+
+exercise:
+  type: "function_writing"
+  prompt: |
+    Use purrr and dplyr to reverse-score ALL six stress columns at once,
+    creating new `_rev` columns (stress_1_rev through stress_6_rev).
+
+    Reconstruct `survey_data` first — each check runs in a fresh R session.
+    Use `mutate` with `across` and the `reverse_score` pattern (`6 - .x`)
+    to create the `_rev` columns.
+  code_template: |
+    library(purrr)
+    library(dplyr)
+
+    survey_data <- data.frame(
+      respondent_id = 1:5,
+      stress_1 = c(3, 4, 5, 2, 1),
+      stress_2 = c(2, 3, 4, 5, 1),
+      stress_3 = c(1, 2, 3, 4, 5),
+      stress_4 = c(5, 4, 3, 2, 1),
+      stress_5 = c(4, 3, 2, 1, 5),
+      stress_6 = c(1, 2, 3, 4, 5)
+    )
+    # Use mutate + across to create _rev columns
+  solution: |
+    library(purrr)
+    library(dplyr)
+
+    survey_data <- data.frame(
+      respondent_id = 1:5,
+      stress_1 = c(3, 4, 5, 2, 1),
+      stress_2 = c(2, 3, 4, 5, 1),
+      stress_3 = c(1, 2, 3, 4, 5),
+      stress_4 = c(5, 4, 3, 2, 1),
+      stress_5 = c(4, 3, 2, 1, 5),
+      stress_6 = c(1, 2, 3, 4, 5)
+    )
+    stress_cols <- paste0("stress_", 1:6)
+    survey_data <- survey_data |>
+      mutate(across(all_of(stress_cols), .fns = list(rev = ~ 6 - .x), .names = "{.col}_rev"))
+  example_usage: |
+    names(survey_data)  # includes stress_1_rev ... stress_6_rev
+    survey_data$stress_6_rev  # 5 4 3 2 1
+  success_criteria: |
+    - stress_1_rev through stress_6_rev columns exist
+    - stress_6_rev equals 6 - stress_6
+  llm_evaluation_prompt: |
+    You are evaluating student code for a software engineering course.
+
+    Exercise: Use purrr and dplyr to reverse-score all six stress columns,
+    creating _rev columns. The solution must reconstruct survey_data first.
+
+    Student submitted this code:
+    {student_code}
+
+    Evaluate the code and call the respond_with_feedback function with your assessment.
+    Set is_correct to true if the code meets all requirements, false otherwise.
+    Provide brief, encouraging feedback (2-3 sentences) in feedback_message.
+
+checks:
+  - "stopifnot(all(c('stress_1_rev', 'stress_6_rev') %in% names(survey_data)))"
+  - "stopifnot(identical(survey_data$stress_6_rev, 6 - survey_data$stress_6))"

--- a/examples/write-less-code-r/05_rule_of_three.R
+++ b/examples/write-less-code-r/05_rule_of_three.R
@@ -1,0 +1,10 @@
+survey_data <- data.frame(
+  respondent_id = 1:5,
+  stress_1 = c(3, 4, 5, 2, 1),
+  stress_2 = c(2, 3, 4, 5, 1),
+  stress_3 = c(1, 2, 3, 4, 5),
+  stress_4 = c(5, 4, 3, 2, 1),
+  stress_5 = c(4, 3, 2, 1, 5),
+  stress_6 = c(1, 2, 3, 4, 5)
+)
+should_abstract <- function(count) count >= 3

--- a/examples/write-less-code-r/05_rule_of_three.yaml
+++ b/examples/write-less-code-r/05_rule_of_three.yaml
@@ -1,0 +1,66 @@
+lesson_name: "Rule of Three"
+language: R
+description: "Decide when to abstract repeated code into a function — the rule of three"
+textbook_reference: "Just Enough Software Engineering - Chapter 8: Write Less Code, Part II"
+
+exercise:
+  type: "function_writing"
+  prompt: |
+    The "rule of three" says: if you write the same code pattern three or more
+    times, abstract it into a function.
+
+    Write a function called `should_abstract` that takes a count of repetitions
+    and returns TRUE if the pattern should be abstracted (count >= 3), FALSE
+    otherwise.
+
+    Reconstruct `survey_data` first — each check runs in a fresh R session.
+    Then count the stress columns in `survey_data` to see if the rule of three
+    applies to the reverse-scoring pattern.
+  code_template: |
+    survey_data <- data.frame(
+      respondent_id = 1:5,
+      stress_1 = c(3, 4, 5, 2, 1),
+      stress_2 = c(2, 3, 4, 5, 1),
+      stress_3 = c(1, 2, 3, 4, 5),
+      stress_4 = c(5, 4, 3, 2, 1),
+      stress_5 = c(4, 3, 2, 1, 5),
+      stress_6 = c(1, 2, 3, 4, 5)
+    )
+    should_abstract <- function(count) {
+      # Your code here
+    }
+  solution: |
+    survey_data <- data.frame(
+      respondent_id = 1:5,
+      stress_1 = c(3, 4, 5, 2, 1),
+      stress_2 = c(2, 3, 4, 5, 1),
+      stress_3 = c(1, 2, 3, 4, 5),
+      stress_4 = c(5, 4, 3, 2, 1),
+      stress_5 = c(4, 3, 2, 1, 5),
+      stress_6 = c(1, 2, 3, 4, 5)
+    )
+    should_abstract <- function(count) count >= 3
+  example_usage: |
+    should_abstract(2)  # FALSE
+    should_abstract(3)  # TRUE
+    should_abstract(sum(grepl("stress", names(survey_data))))  # TRUE (6 stress cols)
+  success_criteria: |
+    - should_abstract(3) returns TRUE
+    - should_abstract(2) returns FALSE
+  llm_evaluation_prompt: |
+    You are evaluating student code for a software engineering course.
+
+    Exercise: Write a function `should_abstract(count)` that returns TRUE when
+    count >= 3 (the rule of three threshold for abstraction). Reconstruct
+    survey_data first.
+
+    Student submitted this code:
+    {student_code}
+
+    Evaluate the code and call the respond_with_feedback function with your assessment.
+    Set is_correct to true if the code meets all requirements, false otherwise.
+    Provide brief, encouraging feedback (2-3 sentences) in feedback_message.
+
+checks:
+  - "stopifnot(isTRUE(should_abstract(3)))"
+  - "stopifnot(!isTRUE(should_abstract(2)))"

--- a/examples/write-less-code-r/blendtutor.toml
+++ b/examples/write-less-code-r/blendtutor.toml
@@ -1,0 +1,22 @@
+# R example course derived from "Write Less Code, Part II" — a five-lesson arc
+# tracing the copy-paste trap → function → map → rule-of-three progression.
+# Each lesson file is paired with a sibling eval_<slug>.yaml suite.
+[[lessons]]
+id = "seed-data"
+path = "01_seed_data.yaml"
+
+[[lessons]]
+id = "copy-paste-trap"
+path = "02_copy_paste_trap.yaml"
+
+[[lessons]]
+id = "write-a-function"
+path = "03_write_a_function.yaml"
+
+[[lessons]]
+id = "map-over-columns"
+path = "04_map_over_columns.yaml"
+
+[[lessons]]
+id = "rule-of-three"
+path = "05_rule_of_three.yaml"

--- a/examples/write-less-code-r/eval_01_seed_data.yaml
+++ b/examples/write-less-code-r/eval_01_seed_data.yaml
@@ -1,0 +1,42 @@
+# Eval suite for 01_seed_data — 4 cases: 2 correct, 2 incorrect (1 near-miss).
+# The near-miss creates a data frame that runs cleanly but has wrong dimensions.
+cases:
+  # 1 — correct: full survey_data with 5 rows and 7 columns
+  - submission: |-
+      survey_data <- data.frame(
+        respondent_id = 1:5,
+        stress_1 = c(3, 4, 5, 2, 1),
+        stress_2 = c(2, 3, 4, 5, 1),
+        stress_3 = c(1, 2, 3, 4, 5),
+        stress_4 = c(5, 4, 3, 2, 1),
+        stress_5 = c(4, 3, 2, 1, 5),
+        stress_6 = c(1, 2, 3, 4, 5)
+      )
+    expected: correct
+  # 2 — correct: same data, different valid values
+  - submission: |-
+      survey_data <- data.frame(
+        respondent_id = 1:5,
+        stress_1 = c(5, 4, 3, 2, 1),
+        stress_2 = c(1, 2, 3, 4, 5),
+        stress_3 = c(2, 3, 4, 5, 1),
+        stress_4 = c(3, 4, 5, 1, 2),
+        stress_5 = c(4, 5, 1, 2, 3),
+        stress_6 = c(1, 2, 3, 4, 5)
+      )
+    expected: correct
+  # 3 — incorrect (near-miss): runs cleanly but only 6 columns (missing stress_6)
+  - submission: |-
+      survey_data <- data.frame(
+        respondent_id = 1:5,
+        stress_1 = c(3, 4, 5, 2, 1),
+        stress_2 = c(2, 3, 4, 5, 1),
+        stress_3 = c(1, 2, 3, 4, 5),
+        stress_4 = c(5, 4, 3, 2, 1),
+        stress_5 = c(4, 3, 2, 1, 5)
+      )
+    expected: incorrect
+  # 4 — incorrect: empty data frame
+  - submission: |-
+      survey_data <- data.frame()
+    expected: incorrect

--- a/examples/write-less-code-r/eval_02_copy_paste_trap.yaml
+++ b/examples/write-less-code-r/eval_02_copy_paste_trap.yaml
@@ -1,0 +1,54 @@
+# Eval suite for 02_copy_paste_trap — 4 cases: 2 correct, 2 incorrect (1 near-miss).
+# The near-miss is the copy-paste bug: reverses stress_5 instead of stress_6.
+cases:
+  # 1 — correct: reconstructs survey_data and reverses stress_6
+  - submission: |-
+      survey_data <- data.frame(
+        respondent_id = 1:5,
+        stress_1 = c(3, 4, 5, 2, 1),
+        stress_2 = c(2, 3, 4, 5, 1),
+        stress_3 = c(1, 2, 3, 4, 5),
+        stress_4 = c(5, 4, 3, 2, 1),
+        stress_5 = c(4, 3, 2, 1, 5),
+        stress_6 = c(1, 2, 3, 4, 5)
+      )
+      survey_data$stress_6_rev <- 6 - survey_data$stress_6
+    expected: correct
+  # 2 — correct: uses transform instead of $
+  - submission: |-
+      survey_data <- data.frame(
+        respondent_id = 1:5,
+        stress_1 = c(3, 4, 5, 2, 1),
+        stress_2 = c(2, 3, 4, 5, 1),
+        stress_3 = c(1, 2, 3, 4, 5),
+        stress_4 = c(5, 4, 3, 2, 1),
+        stress_5 = c(4, 3, 2, 1, 5),
+        stress_6 = c(1, 2, 3, 4, 5)
+      )
+      survey_data <- transform(survey_data, stress_6_rev = 6 - stress_6)
+    expected: correct
+  # 3 — incorrect (near-miss): copy-paste bug — reverses stress_5, not stress_6
+  - submission: |-
+      survey_data <- data.frame(
+        respondent_id = 1:5,
+        stress_1 = c(3, 4, 5, 2, 1),
+        stress_2 = c(2, 3, 4, 5, 1),
+        stress_3 = c(1, 2, 3, 4, 5),
+        stress_4 = c(5, 4, 3, 2, 1),
+        stress_5 = c(4, 3, 2, 1, 5),
+        stress_6 = c(1, 2, 3, 4, 5)
+      )
+      survey_data$stress_6_rev <- 6 - survey_data$stress_5
+    expected: incorrect
+  # 4 — incorrect: does not create stress_6_rev at all
+  - submission: |-
+      survey_data <- data.frame(
+        respondent_id = 1:5,
+        stress_1 = c(3, 4, 5, 2, 1),
+        stress_2 = c(2, 3, 4, 5, 1),
+        stress_3 = c(1, 2, 3, 4, 5),
+        stress_4 = c(5, 4, 3, 2, 1),
+        stress_5 = c(4, 3, 2, 1, 5),
+        stress_6 = c(1, 2, 3, 4, 5)
+      )
+    expected: incorrect

--- a/examples/write-less-code-r/eval_03_write_a_function.yaml
+++ b/examples/write-less-code-r/eval_03_write_a_function.yaml
@@ -1,0 +1,57 @@
+# Eval suite for 03_write_a_function — 4 cases: 2 correct, 2 incorrect (1 near-miss).
+# The near-miss uses 5 - x (wrong max_value) instead of 6 - x.
+cases:
+  # 1 — correct: standard reverse_score with survey_data
+  - submission: |-
+      survey_data <- data.frame(
+        respondent_id = 1:5,
+        stress_1 = c(3, 4, 5, 2, 1),
+        stress_2 = c(2, 3, 4, 5, 1),
+        stress_3 = c(1, 2, 3, 4, 5),
+        stress_4 = c(5, 4, 3, 2, 1),
+        stress_5 = c(4, 3, 2, 1, 5),
+        stress_6 = c(1, 2, 3, 4, 5)
+      )
+      reverse_score <- function(x) 6 - x
+    expected: correct
+  # 2 — correct: with explicit return
+  - submission: |-
+      survey_data <- data.frame(
+        respondent_id = 1:5,
+        stress_1 = c(3, 4, 5, 2, 1),
+        stress_2 = c(2, 3, 4, 5, 1),
+        stress_3 = c(1, 2, 3, 4, 5),
+        stress_4 = c(5, 4, 3, 2, 1),
+        stress_5 = c(4, 3, 2, 1, 5),
+        stress_6 = c(1, 2, 3, 4, 5)
+      )
+      reverse_score <- function(x) {
+        return(6 - x)
+      }
+    expected: correct
+  # 3 — incorrect (near-miss): wrong max_value — 5 - x instead of 6 - x
+  - submission: |-
+      survey_data <- data.frame(
+        respondent_id = 1:5,
+        stress_1 = c(3, 4, 5, 2, 1),
+        stress_2 = c(2, 3, 4, 5, 1),
+        stress_3 = c(1, 2, 3, 4, 5),
+        stress_4 = c(5, 4, 3, 2, 1),
+        stress_5 = c(4, 3, 2, 1, 5),
+        stress_6 = c(1, 2, 3, 4, 5)
+      )
+      reverse_score <- function(x) 5 - x
+    expected: incorrect
+  # 4 — incorrect: returns x unchanged
+  - submission: |-
+      survey_data <- data.frame(
+        respondent_id = 1:5,
+        stress_1 = c(3, 4, 5, 2, 1),
+        stress_2 = c(2, 3, 4, 5, 1),
+        stress_3 = c(1, 2, 3, 4, 5),
+        stress_4 = c(5, 4, 3, 2, 1),
+        stress_5 = c(4, 3, 2, 1, 5),
+        stress_6 = c(1, 2, 3, 4, 5)
+      )
+      reverse_score <- function(x) x
+    expected: incorrect

--- a/examples/write-less-code-r/eval_04_map_over_columns.yaml
+++ b/examples/write-less-code-r/eval_04_map_over_columns.yaml
@@ -1,0 +1,69 @@
+# Eval suite for 04_map_over_columns — 4 cases: 2 correct, 2 incorrect (1 near-miss).
+# The near-miss only reverses stress_1 (wrong columns) instead of all six.
+cases:
+  # 1 — correct: uses mutate + across with purrr/dplyr
+  - submission: |-
+      library(purrr)
+      library(dplyr)
+      survey_data <- data.frame(
+        respondent_id = 1:5,
+        stress_1 = c(3, 4, 5, 2, 1),
+        stress_2 = c(2, 3, 4, 5, 1),
+        stress_3 = c(1, 2, 3, 4, 5),
+        stress_4 = c(5, 4, 3, 2, 1),
+        stress_5 = c(4, 3, 2, 1, 5),
+        stress_6 = c(1, 2, 3, 4, 5)
+      )
+      stress_cols <- paste0("stress_", 1:6)
+      survey_data <- survey_data |>
+        mutate(across(all_of(stress_cols), .fns = list(rev = ~ 6 - .x), .names = "{.col}_rev"))
+    expected: correct
+  # 2 — correct: uses mutate with individual column operations
+  - submission: |-
+      library(dplyr)
+      survey_data <- data.frame(
+        respondent_id = 1:5,
+        stress_1 = c(3, 4, 5, 2, 1),
+        stress_2 = c(2, 3, 4, 5, 1),
+        stress_3 = c(1, 2, 3, 4, 5),
+        stress_4 = c(5, 4, 3, 2, 1),
+        stress_5 = c(4, 3, 2, 1, 5),
+        stress_6 = c(1, 2, 3, 4, 5)
+      )
+      survey_data <- survey_data |>
+        mutate(
+          stress_1_rev = 6 - stress_1,
+          stress_2_rev = 6 - stress_2,
+          stress_3_rev = 6 - stress_3,
+          stress_4_rev = 6 - stress_4,
+          stress_5_rev = 6 - stress_5,
+          stress_6_rev = 6 - stress_6
+        )
+    expected: correct
+  # 3 — incorrect (near-miss): wrong columns — only reverses stress_1
+  - submission: |-
+      library(dplyr)
+      survey_data <- data.frame(
+        respondent_id = 1:5,
+        stress_1 = c(3, 4, 5, 2, 1),
+        stress_2 = c(2, 3, 4, 5, 1),
+        stress_3 = c(1, 2, 3, 4, 5),
+        stress_4 = c(5, 4, 3, 2, 1),
+        stress_5 = c(4, 3, 2, 1, 5),
+        stress_6 = c(1, 2, 3, 4, 5)
+      )
+      survey_data <- survey_data |> mutate(stress_1_rev = 6 - stress_1)
+    expected: incorrect
+  # 4 — incorrect: does not create any _rev columns
+  - submission: |-
+      library(dplyr)
+      survey_data <- data.frame(
+        respondent_id = 1:5,
+        stress_1 = c(3, 4, 5, 2, 1),
+        stress_2 = c(2, 3, 4, 5, 1),
+        stress_3 = c(1, 2, 3, 4, 5),
+        stress_4 = c(5, 4, 3, 2, 1),
+        stress_5 = c(4, 3, 2, 1, 5),
+        stress_6 = c(1, 2, 3, 4, 5)
+      )
+    expected: incorrect

--- a/examples/write-less-code-r/eval_05_rule_of_three.yaml
+++ b/examples/write-less-code-r/eval_05_rule_of_three.yaml
@@ -1,0 +1,57 @@
+# Eval suite for 05_rule_of_three — 4 cases: 2 correct, 2 incorrect (1 near-miss).
+# The near-miss uses count > 3 (wrong decision) instead of count >= 3.
+cases:
+  # 1 — correct: standard rule of three with survey_data
+  - submission: |-
+      survey_data <- data.frame(
+        respondent_id = 1:5,
+        stress_1 = c(3, 4, 5, 2, 1),
+        stress_2 = c(2, 3, 4, 5, 1),
+        stress_3 = c(1, 2, 3, 4, 5),
+        stress_4 = c(5, 4, 3, 2, 1),
+        stress_5 = c(4, 3, 2, 1, 5),
+        stress_6 = c(1, 2, 3, 4, 5)
+      )
+      should_abstract <- function(count) count >= 3
+    expected: correct
+  # 2 — correct: with explicit if/else
+  - submission: |-
+      survey_data <- data.frame(
+        respondent_id = 1:5,
+        stress_1 = c(3, 4, 5, 2, 1),
+        stress_2 = c(2, 3, 4, 5, 1),
+        stress_3 = c(1, 2, 3, 4, 5),
+        stress_4 = c(5, 4, 3, 2, 1),
+        stress_5 = c(4, 3, 2, 1, 5),
+        stress_6 = c(1, 2, 3, 4, 5)
+      )
+      should_abstract <- function(count) {
+        if (count >= 3) TRUE else FALSE
+      }
+    expected: correct
+  # 3 — incorrect (near-miss): wrong decision — count > 3 instead of count >= 3
+  - submission: |-
+      survey_data <- data.frame(
+        respondent_id = 1:5,
+        stress_1 = c(3, 4, 5, 2, 1),
+        stress_2 = c(2, 3, 4, 5, 1),
+        stress_3 = c(1, 2, 3, 4, 5),
+        stress_4 = c(5, 4, 3, 2, 1),
+        stress_5 = c(4, 3, 2, 1, 5),
+        stress_6 = c(1, 2, 3, 4, 5)
+      )
+      should_abstract <- function(count) count > 3
+    expected: incorrect
+  # 4 — incorrect: always returns TRUE
+  - submission: |-
+      survey_data <- data.frame(
+        respondent_id = 1:5,
+        stress_1 = c(3, 4, 5, 2, 1),
+        stress_2 = c(2, 3, 4, 5, 1),
+        stress_3 = c(1, 2, 3, 4, 5),
+        stress_4 = c(5, 4, 3, 2, 1),
+        stress_5 = c(4, 3, 2, 1, 5),
+        stress_6 = c(1, 2, 3, 4, 5)
+      )
+      should_abstract <- function(count) TRUE
+    expected: incorrect


### PR DESCRIPTION
## Summary
Create R example course at `examples/write-less-code-r/` with 5 lessons + eval suites + manifest, mirroring the "Write Less Code, Part II" chapter arc: seed-data → copy-paste-trap → write-a-function → map-over-columns → rule-of-three.

## Issue
Closes #73

## ACs implemented
- [x] `blendtutor validate` exits 0 for all 5 lessons
- [x] `blendtutor list` returns 5 rows, all `language == "r"`
- [x] Each lesson's solution executes cleanly via `Rscript --vanilla -e`
- [x] Each check passes against the reference solution (load-bearing: `format!("{submission}\n{check}")` in fresh Rscript per check)
- [x] Each eval suite has >=4 cases, >=2 correct, >=2 incorrect, >=1 near-miss
- [x] Solutions are self-contained (reconstruct survey_data — no shared session between checks)
- [x] Each lesson has `textbook_reference` to chapter URL
- [x] `blendtutor run` exits 0 with verdict=correct (wiremock stub)

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested
- [x] Verification medium satisfied
- [x] Design intent respected
- [x] No scope creep

## Test plan
- [x] All tests pass (`cargo test -p blendtutor-cli --test write_less_code_r` — 12 tests)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] PR review findings resolved