### PR TITLE
feat(docs): deploy example sites via Pages workflow (#76)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,6 +67,15 @@ jobs:
           rm -rf docs/book/book/api
           cp -R target/doc docs/book/book/api
 
+      # AC-6 (#76) — build example course sites (webr + pyodide) into the Pages
+      # artifact so the deployed docs include live, runnable example lessons.
+      # Each site nests under /examples/{r,python}/, mirroring the /api nesting.
+      - name: Build R example site (webR)
+        run: cargo run --release -p blendtutor-cli -- build examples/write-less-code-r --target webr -o docs/book/book/examples/r
+
+      - name: Build Python example site (Pyodide)
+        run: cargo run --release -p blendtutor-cli -- build examples/write-less-code-python --target pyodide -o docs/book/book/examples/python
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5
         with:

--- a/README.md
+++ b/README.md
@@ -135,6 +135,21 @@ the site is cross-origin isolated on Pages without any header configuration.
 (Pyodide-only sites boot on the main thread and do not require this, but the shim
 ships for both targets and is harmless when unused.)
 
+### Live example sites
+
+Two example courses — derived from the "Write Less Code" lesson arc — are built
+and deployed alongside the docs on GitHub Pages:
+
+- **[R example site (webR)](https://mcmullarkey.github.io/blendtutor/examples/r/)**
+  — five R lessons booting webR in the browser.
+- **[Python example site (Pyodide)](https://mcmullarkey.github.io/blendtutor/examples/python/)**
+  — five Python lessons booting Pyodide in the browser.
+
+Each site includes an
+[eval-results page](https://mcmullarkey.github.io/blendtutor/examples/r/eval-results.html)
+([Python](https://mcmullarkey.github.io/blendtutor/examples/python/eval-results.html))
+showing the grading-prompt accuracy recorded by `blendtutor eval`.
+
 ## License
 
 MIT License — see the `LICENSE` file for details.

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -3,4 +3,5 @@
 [Introduction](./introduction.md)
 
 - [Architecture](./architecture.md)
+- [Example sites](./examples.md)
 - [API reference](./api-reference.md)

--- a/docs/book/src/examples.md
+++ b/docs/book/src/examples.md
@@ -1,0 +1,28 @@
+# Example sites
+
+Two example courses — derived from the "Write Less Code" lesson arc — are built
+and deployed alongside this book on GitHub Pages. Each is a fully runnable
+browser site: learners edit code in the browser, submit, and get instant AI
+feedback with no install required.
+
+## R example site (webR)
+
+- **[R example site](./examples/r/index.html)** — five R lessons booting
+  [webR](https://docs.r-wasm.org/webr/) in the browser.
+- **[R eval results](./examples/r/eval-results.html)** — grading-prompt accuracy
+  recorded by `blendtutor eval`.
+
+## Python example site (Pyodide)
+
+- **[Python example site](./examples/python/index.html)** — five Python lessons
+  booting [Pyodide](https://pyodide.org/) in the browser.
+- **[Python eval results](./examples/python/eval-results.html)** —
+  grading-prompt accuracy recorded by `blendtutor eval`.
+
+## How they are built
+
+The Docs CI workflow (`.github/workflows/docs.yml`) runs `blendtutor build` for
+each example course after assembling the mdBook + rustdoc artifact, nesting the
+output under `/examples/{r,python}/` so a single Pages deploy serves the book,
+the API reference, and both example sites. `scripts/check-docs.sh` mirrors this
+locally and asserts the required files are present.

--- a/docs/evidence/76/check-docs.log
+++ b/docs/evidence/76/check-docs.log
@@ -1,0 +1,17 @@
+docs: building API reference (rustdoc, -D warnings) …
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.26s
+   Generated /Users/carbonite/Documents/coding/portfolio/worktree-issue-76/target/doc/blendtutor/index.html and 1 other file
+docs: building narrative site (mdBook) …
+ INFO Book building has started
+ INFO Running the html backend
+ INFO HTML book written to `/Users/carbonite/Documents/coding/portfolio/worktree-issue-76/docs/book/book`
+docs: assembling merged site (docs/book/book + /api) …
+docs: building example sites (webr + pyodide) …
+    Finished `release` profile [optimized] target(s) in 0.15s
+     Running `target/release/blendtutor build examples/write-less-code-r --target webr -o docs/book/book/examples/r`
+built 5 lesson(s) for webr into docs/book/book/examples/r
+    Finished `release` profile [optimized] target(s) in 0.07s
+     Running `target/release/blendtutor build examples/write-less-code-python --target pyodide -o docs/book/book/examples/python`
+built 5 lesson(s) for pyodide into docs/book/book/examples/python
+docs: verifying failure propagation (missing course path) …
+docs: OK — merged site at docs/book/book (book at /, API at /api, examples at /examples/{r,python})

--- a/docs/evidence/76/example-sites-evidence.log
+++ b/docs/evidence/76/example-sites-evidence.log
@@ -1,0 +1,88 @@
+=== R example site file listing ===
+total 1528
+drwxr-xr-x@ 12 carbonite  staff     384 Jul 13 20:00 .
+drwxr-xr-x@  4 carbonite  staff     128 Jul 13 20:00 ..
+-rw-r--r--@  1 carbonite  staff  693348 Jul 13 20:00 codemirror.js
+-rw-r--r--@  1 carbonite  staff    5407 Jul 13 20:00 coi-serviceworker.js
+-rw-r--r--@  1 carbonite  staff     335 Jul 13 20:00 eval-results.html
+-rw-r--r--@  1 carbonite  staff   25716 Jul 13 20:00 feedback.js
+-rw-r--r--@  1 carbonite  staff    1899 Jul 13 20:00 index.html
+-rw-r--r--@  1 carbonite  staff   11606 Jul 13 20:00 lesson-runner-core.js
+-rw-r--r--@  1 carbonite  staff    1986 Jul 13 20:00 lesson-runner.js
+drwxr-xr-x@  7 carbonite  staff     224 Jul 13 20:00 lessons
+-rw-r--r--@  1 carbonite  staff     101 Jul 13 20:00 lessons.json
+-rw-r--r--@  1 carbonite  staff   18430 Jul 13 20:00 styles.css
+
+=== R lessons/ ===
+total 40
+drwxr-xr-x@  7 carbonite  staff   224 Jul 13 20:00 .
+drwxr-xr-x@ 12 carbonite  staff   384 Jul 13 20:00 ..
+-rw-r--r--@  1 carbonite  staff   778 Jul 13 20:00 0.json
+-rw-r--r--@  1 carbonite  staff  1234 Jul 13 20:00 1.json
+-rw-r--r--@  1 carbonite  staff  1190 Jul 13 20:00 2.json
+-rw-r--r--@  1 carbonite  staff  1925 Jul 13 20:00 3.json
+-rw-r--r--@  1 carbonite  staff  1313 Jul 13 20:00 4.json
+
+=== R eval-results.html (validated marker) ===
+<body data-eval-status="validated">
+
+=== R lesson-runner.js (webr boot check) ===
+9
+
+=== Python example site file listing ===
+total 1528
+drwxr-xr-x@ 12 carbonite  staff     384 Jul 13 20:00 .
+drwxr-xr-x@  4 carbonite  staff     128 Jul 13 20:00 ..
+-rw-r--r--@  1 carbonite  staff  693348 Jul 13 20:00 codemirror.js
+-rw-r--r--@  1 carbonite  staff    5407 Jul 13 20:00 coi-serviceworker.js
+-rw-r--r--@  1 carbonite  staff     335 Jul 13 20:00 eval-results.html
+-rw-r--r--@  1 carbonite  staff   25716 Jul 13 20:00 feedback.js
+-rw-r--r--@  1 carbonite  staff    2212 Jul 13 20:00 index.html
+-rw-r--r--@  1 carbonite  staff   11606 Jul 13 20:00 lesson-runner-core.js
+-rw-r--r--@  1 carbonite  staff    2487 Jul 13 20:00 lesson-runner.js
+drwxr-xr-x@  7 carbonite  staff     224 Jul 13 20:00 lessons
+-rw-r--r--@  1 carbonite  staff     101 Jul 13 20:00 lessons.json
+-rw-r--r--@  1 carbonite  staff   18430 Jul 13 20:00 styles.css
+
+=== Python lessons/ ===
+total 40
+drwxr-xr-x@  7 carbonite  staff   224 Jul 13 20:00 .
+drwxr-xr-x@ 12 carbonite  staff   384 Jul 13 20:00 ..
+-rw-r--r--@  1 carbonite  staff  1350 Jul 13 20:00 0.json
+-rw-r--r--@  1 carbonite  staff  1443 Jul 13 20:00 1.json
+-rw-r--r--@  1 carbonite  staff   642 Jul 13 20:00 2.json
+-rw-r--r--@  1 carbonite  staff  1805 Jul 13 20:00 3.json
+-rw-r--r--@  1 carbonite  staff  1231 Jul 13 20:00 4.json
+
+=== Python eval-results.html (validated marker) ===
+<body data-eval-status="validated">
+
+=== Python lesson-runner.js (pyodide boot check) ===
+10
+
+=== docs.yml build commands ===
+74:        run: cargo run --release -p blendtutor-cli -- build examples/write-less-code-r --target webr -o docs/book/book/examples/r
+77:        run: cargo run --release -p blendtutor-cli -- build examples/write-less-code-python --target pyodide -o docs/book/book/examples/python
+
+=== README.md example links ===
+143:- **[R example site (webR)](https://mcmullarkey.github.io/blendtutor/examples/r/)**
+145:- **[Python example site (Pyodide)](https://mcmullarkey.github.io/blendtutor/examples/python/)**
+149:[eval-results page](https://mcmullarkey.github.io/blendtutor/examples/r/eval-results.html)
+150:([Python](https://mcmullarkey.github.io/blendtutor/examples/python/eval-results.html))
+
+=== SUMMARY.md examples entry ===
+# Summary
+
+[Introduction](./introduction.md)
+
+- [Architecture](./architecture.md)
+- [Example sites](./examples.md)
+- [API reference](./api-reference.md)
+
+=== Built mdBook examples.html rendered links ===
+2
+2
+
+=== Failure propagation test ===
+Testing: cargo run -- build /nonexistent/course --target webr ...
+PASS: build correctly failed with non-zero exit (exit code: 1)

--- a/docs/evidence/76/fmt-clippy.log
+++ b/docs/evidence/76/fmt-clippy.log
@@ -1,0 +1,6 @@
+=== cargo fmt --check ===
+exit: 0
+
+=== cargo clippy --all-targets -- -D warnings ===
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.16s
+exit: 0

--- a/docs/evidence/76/test-suite.log
+++ b/docs/evidence/76/test-suite.log
@@ -1,0 +1,215 @@
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.12s
+────────────
+ Nextest run ID a1a7b0a1-aa98-4e36-8729-783131389e9c with nextest profile: default
+    Starting 209 tests across 18 binaries
+        PASS [   0.328s] (  1/209) blendtutor-cli::build build_refuses_a_language_target_mismatch_before_writing_anything
+        PASS [   0.334s] (  2/209) blendtutor-cli::build build_emits_lesson_json_with_packages_array
+        PASS [   0.336s] (  3/209) blendtutor-cli::build build_emits_empty_packages_array_when_lesson_has_no_packages
+        PASS [   0.339s] (  4/209) blendtutor-cli::build build_webr_ships_the_byok_fireworks_feedback_seam
+        PASS [   0.339s] (  5/209) blendtutor-cli::build build_webr_ships_the_multi_provider_feedback_seam
+        PASS [   0.342s] (  6/209) blendtutor-cli::build build_webr_ships_the_byok_anthropic_feedback_seam
+        PASS [   0.344s] (  7/209) blendtutor-cli::build build_webr_emits_a_deployable_r_lesson_site
+        PASS [   0.345s] (  8/209) blendtutor-cli::build build_pyodide_emits_a_deployable_python_lesson_site
+        PASS [   0.350s] (  9/209) blendtutor-cli::build build_pyodide_ships_the_same_shared_feedback_seam
+        PASS [   0.017s] ( 10/209) blendtutor-cli::cli help_lists_subcommands
+        PASS [   0.015s] ( 11/209) blendtutor-cli::cli version_prints_crate_version
+        PASS [   0.024s] ( 12/209) blendtutor-cli::build corrupt_eval_report_fails_the_build_loudly
+        PASS [   0.024s] ( 13/209) blendtutor-cli::build eval_report_page_reflects_actual_accuracy
+        PASS [   0.361s] ( 14/209) blendtutor-cli::build build_dark_mode_token_overrides
+        PASS [   0.030s] ( 15/209) blendtutor-cli::build missing_report_builds_with_not_validated_page
+        PASS [   0.040s] ( 16/209) blendtutor-cli::build build_webr_styles_byok_feedback_panel
+        PASS [   0.016s] ( 17/209) blendtutor-cli::init init_refuses_a_nonempty_target_leaving_it_untouched
+        PASS [   0.032s] ( 18/209) blendtutor-cli::cutover r_package_artifacts_are_absent_from_root
+        PASS [   0.021s] ( 19/209) blendtutor-cli::init init_scaffolds_a_ready_course_that_list_accepts
+        PASS [   0.019s] ( 20/209) blendtutor-cli::list list_reports_a_malformed_lesson_as_an_error_row_without_losing_the_good_ones
+        PASS [   0.021s] ( 21/209) blendtutor-cli::list list_on_a_directory_without_a_manifest_exits_nonzero
+        PASS [   0.019s] ( 22/209) blendtutor-cli::list list_reports_each_lessons_id_language_and_title
+        PASS [   0.009s] ( 23/209) blendtutor-cli::readme readme_documents_the_cli_install_and_workflow
+        PASS [   0.059s] ( 24/209) blendtutor-cli::cutover no_r_package_sources_are_tracked
+        PASS [   0.033s] ( 25/209) blendtutor-cli::new new_lesson_r_creates_a_lesson_that_validates_and_lists
+        PASS [   0.038s] ( 26/209) blendtutor-cli::new new_lesson_python_creates_a_lesson_that_validates_and_lists
+        PASS [   0.031s] ( 27/209) blendtutor-cli::new new_lesson_refuses_a_duplicate_id_without_clobbering
+        PASS [   0.019s] ( 28/209) blendtutor-cli::validate validate_invalid_lesson_exits_nonzero_naming_problem
+        PASS [   0.021s] ( 29/209) blendtutor-cli::run run_missing_code_exits_one
+        PASS [   0.026s] ( 30/209) blendtutor-cli::validate validate_lesson_without_student_code_placeholder_exits_nonzero_naming_the_rule
+        PASS [   0.041s] ( 31/209) blendtutor-cli::validate validate_json_emits_documented_object_with_exit_code_parity
+        PASS [   0.026s] ( 32/209) blendtutor-cli::validate validate_valid_lesson_reports_ok_and_exit_zero
+        PASS [   0.015s] ( 33/209) blendtutor-cli::write_less_code_python checks_non_empty_and_specific
+        PASS [   0.013s] ( 34/209) blendtutor-cli::write_less_code_python each_lesson_is_valid_python_with_student_code_and_textbook
+        PASS [   0.015s] ( 35/209) blendtutor-cli::write_less_code_python eval_suites_have_correct_case_distribution
+        PASS [   0.012s] ( 36/209) blendtutor-cli::write_less_code_python lesson_2_prompt_contains_literal_stress_6
+        PASS [   0.012s] ( 37/209) blendtutor-cli::write_less_code_python lesson_4_solution_uses_explicit_for_loop_not_list_comprehension
+        PASS [   0.020s] ( 38/209) blendtutor-cli::write_less_code_python list_returns_five_python_lessons
+        PASS [   0.013s] ( 39/209) blendtutor-cli::write_less_code_python packages_bidirectional_pandas_iff_used
+        PASS [   0.200s] ( 40/209) blendtutor-cli::run run_correct_code_reports_correct_and_exit_zero
+        PASS [   0.206s] ( 41/209) blendtutor-cli::run run_format_json_emits_one_typed_report
+        PASS [   0.207s] ( 42/209) blendtutor-cli::run run_human_format_is_not_json
+        PASS [   0.206s] ( 43/209) blendtutor-cli::run run_incorrect_submission_exits_two_with_feedback
+        PASS [   0.227s] ( 44/209) blendtutor-cli::run run_format_json_stays_clean_under_logging
+        PASS [   0.027s] ( 45/209) blendtutor-cli::write_less_code_r layer2_list_returns_five_r_lessons
+        PASS [   0.050s] ( 46/209) blendtutor-cli::write_less_code_python validate_each_lesson_exits_zero
+        PASS [   0.236s] ( 47/209) blendtutor-cli::run run_provider_error_exits_one
+        PASS [   0.020s] ( 48/209) blendtutor-cli::write_less_code_r layer5_eval_suites_have_minimum_cases
+        PASS [   0.067s] ( 49/209) blendtutor-cli::write_less_code_r layer1_validate_exits_zero_for_all_lessons
+        PASS [   0.016s] ( 50/209) blendtutor-cli::write_less_code_r layer7_solutions_are_self_contained
+        PASS [   0.017s] ( 51/209) blendtutor-cli::write_less_code_r layer8_each_lesson_has_textbook_reference
+        PASS [   0.524s] ( 52/209) blendtutor-cli::eval eval_reports_aggregate_accuracy_and_per_case_results
+        PASS [   0.022s] ( 53/209) blendtutor-cli::write_less_code_r negative_lesson2_check_references_stress_6_rev
+        PASS [   0.556s] ( 54/209) blendtutor-cli::eval eval_json_emits_per_case_verdicts_and_aggregate
+        PASS [   0.022s] ( 55/209) blendtutor-cli::bin/blendtutor commands::eval::tests::sibling_suite_keeps_a_bare_file_name_in_the_current_directory
+        PASS [   0.018s] ( 56/209) blendtutor-cli::bin/blendtutor commands::eval::tests::sibling_suite_of_a_path_without_a_file_name_is_the_prefix_alone
+        PASS [   0.013s] ( 57/209) blendtutor-cli::bin/blendtutor commands::eval::tests::sibling_suite_prefixes_the_lesson_file_name_with_eval
+        PASS [   0.036s] ( 58/209) blendtutor-cli::bin/blendtutor output::tests::eval_human_matches_snapshot
+        PASS [   0.033s] ( 59/209) blendtutor-cli::bin/blendtutor output::tests::list_human_matches_snapshot
+        PASS [   0.014s] ( 60/209) blendtutor-cli::bin/blendtutor output::tests::list_json_separates_found_rows_from_failed_rows
+        PASS [   0.013s] ( 61/209) blendtutor-cli::bin/blendtutor output::tests::list_renders_an_empty_course_in_both_formats
+        PASS [   0.038s] ( 62/209) blendtutor-cli::bin/blendtutor output::tests::validate_human_invalid_matches_snapshot
+        PASS [   0.041s] ( 63/209) blendtutor-cli::bin/blendtutor output::tests::validate_human_matches_snapshot
+        PASS [   0.018s] ( 64/209) blendtutor-core course::tests::discover_reports_a_malformed_lesson_as_an_error_row_keeping_the_good_ones
+        PASS [   0.017s] ( 65/209) blendtutor-core course::tests::discover_summarizes_each_lesson_with_its_slug_language_and_title
+        PASS [   0.017s] ( 66/209) blendtutor-core course::tests::discovery_error_display_and_source_surface_the_underlying_load_failure
+        PASS [   0.013s] ( 67/209) blendtutor-core course::tests::load_lessons_fails_on_the_first_broken_lesson_rather_than_dropping_it
+        PASS [   0.020s] ( 68/209) blendtutor-core course::tests::load_lessons_returns_every_lesson_in_full_and_in_author_order
+        PASS [   0.013s] ( 69/209) blendtutor-core course::tests::manifest_error_display_and_source_distinguish_each_variant
+        PASS [   0.019s] ( 70/209) blendtutor-core course::tests::manifest_parse_reads_each_entrys_id_and_path
+        PASS [   0.016s] ( 71/209) blendtutor-core course::tests::manifest_parse_rejects_a_path_escaping_the_course_directory
+        PASS [   0.013s] ( 72/209) blendtutor-core course::tests::manifest_parse_rejects_unknown_key_so_author_typos_surface
+        PASS [   0.013s] ( 73/209) blendtutor-core course::tests::open_missing_manifest_is_a_read_error_not_a_parse_error
+        PASS [   0.015s] ( 74/209) blendtutor-core eval::tests::aggregate_is_matched_over_total_and_zero_for_an_empty_suite
+        PASS [   0.012s] ( 75/209) blendtutor-core eval::tests::case_result_derives_matched_from_score_case
+        PASS [   0.019s] ( 76/209) blendtutor-core eval::tests::eval_run_error_names_the_one_based_case_and_chains_its_source
+        PASS [   0.016s] ( 77/209) blendtutor-core eval::tests::expected_verdict_serializes_to_its_canonical_token
+        PASS [   0.013s] ( 78/209) blendtutor-core eval::tests::from_token_maps_the_two_polarity_words_and_rejects_others
+        PASS [   0.013s] ( 79/209) blendtutor-core eval::tests::parse_eval_suite_surfaces_unknown_verdict_with_its_case_index_and_token
+        PASS [   0.014s] ( 80/209) blendtutor-core eval::tests::parse_rejects_unknown_key_so_author_typos_surface
+        PASS [   0.016s] ( 81/209) blendtutor-core eval::tests::score_case_matches_same_polarity_and_rejects_the_opposite
+        PASS [   0.013s] ( 82/209) blendtutor-core eval::tests::scores_two_of_three_and_aggregates
+        PASS [   0.782s] ( 83/209) blendtutor-cli::write_less_code_r layer9_run_exits_zero_with_correct_verdict
+        PASS [   0.017s] ( 84/209) blendtutor-core eval::tests::structural_error_surfaces_the_underlying_parser_message
+        PASS [   0.015s] ( 85/209) blendtutor-core eval::tests::unknown_verdict_error_names_the_case_index_and_quotes_the_token
+        PASS [   0.011s] ( 86/209) blendtutor-core eval::tests::verdict_polarity_drops_the_feedback_message
+        PASS [   0.014s] ( 87/209) blendtutor-core grade::tests::a_check_whose_interpreter_cannot_launch_is_a_fail
+        PASS [   0.014s] ( 88/209) blendtutor-core grade::tests::a_submission_that_exits_nonzero_makes_every_check_notrun
+        PASS [   0.012s] ( 89/209) blendtutor-core grade::tests::a_submission_whose_interpreter_cannot_launch_makes_checks_notrun
+        PASS [   0.011s] ( 90/209) blendtutor-core grade::tests::checks_are_classified_element_wise_in_order
+        PASS [   0.015s] ( 91/209) blendtutor-core grade::tests::no_checks_runs_nothing_and_returns_empty
+        PASS [   0.015s] ( 92/209) blendtutor-core grade::tests::select_runner_dispatches_a_python_lesson_to_the_python_runner
+        PASS [   0.596s] ( 93/209) blendtutor-cli::write_less_code_r negative_lesson4_solution_uses_purrr_dplyr
+        PASS [   0.010s] ( 94/209) blendtutor-core grade::tests::select_runner_threads_packages_to_python_runner
+        PASS [   0.015s] ( 95/209) blendtutor-core grade::tests::select_runner_dispatches_an_r_lesson_to_the_r_runner
+        PASS [   0.016s] ( 96/209) blendtutor-core lesson::tests::lesson_id_displays_its_value
+        PASS [   0.011s] ( 97/209) blendtutor-core lesson::tests::load_error_display_and_source_surface_the_cause
+        PASS [   0.014s] ( 98/209) blendtutor-core lesson::tests::lesson_json_roundtrip_preserves_value
+        PASS [   0.013s] ( 99/209) blendtutor-core lesson::tests::parse_accepts_valid_lesson
+        PASS [   0.013s] (100/209) blendtutor-core lesson::tests::parse_defaults_packages_to_empty_when_absent
+        PASS [   0.014s] (101/209) blendtutor-core lesson::tests::parse_defaults_checks_to_empty_when_absent
+        PASS [   0.012s] (102/209) blendtutor-core lesson::tests::parse_defaults_solution_to_none_when_absent
+        PASS [   0.015s] (103/209) blendtutor-core lesson::tests::parse_reads_checks_as_ordered_code_strings
+        PASS [   0.016s] (104/209) blendtutor-core lesson::tests::parse_reads_an_optional_reference_solution
+        PASS [   0.015s] (105/209) blendtutor-core lesson::tests::parse_reads_packages_as_ordered_strings
+        PASS [   0.011s] (106/209) blendtutor-core lesson::tests::parse_rejects_missing_required_field_naming_it
+        PASS [   0.012s] (107/209) blendtutor-core lesson::tests::parse_rejects_prompt_missing_student_code_placeholder
+        PASS [   0.012s] (108/209) blendtutor-core lesson::tests::parse_rejects_unknown_exercise_type
+        PASS [   0.010s] (109/209) blendtutor-core lesson::tests::parse_rejects_unknown_field_so_author_typos_surface
+        PASS [   0.012s] (110/209) blendtutor-core lesson::tests::parse_rejects_unknown_language
+        PASS [   0.015s] (111/209) blendtutor-core lesson::tests::read_lesson_file_invalid_contents_is_a_validation_error
+        PASS [   0.014s] (112/209) blendtutor-core lesson::tests::read_lesson_file_loads_and_parses_the_ported_fixture
+        PASS [   0.016s] (113/209) blendtutor-core lesson::tests::read_lesson_file_missing_path_is_a_read_error_not_a_validation_error
+        PASS [   0.016s] (114/209) blendtutor-core llm::feedback::tests::completion_errors_map_to_the_completion_kind
+        PASS [   0.016s] (115/209) blendtutor-core llm::feedback::tests::extraction_failures_map_to_the_extraction_kind
+        PASS [   0.012s] (116/209) blendtutor-core llm::feedback::tests::feedback_maps_to_the_matching_verdict_variant
+        PASS [   0.010s] (117/209) blendtutor-core llm::prompt::tests::neutralize_marker_introduces_no_structural_token
+        PASS [   0.012s] (118/209) blendtutor-core llm::prompt::tests::render_check_distinguishes_the_three_outcomes
+        PASS [   0.014s] (119/209) blendtutor-core llm::prompt::tests::neutralize_rewrites_every_structural_token
+        PASS [   0.018s] (120/209) blendtutor-core llm::prompt::tests::render_check_neutralizes_a_token_in_the_outcome_detail
+        PASS [   0.015s] (121/209) blendtutor-core llm::prompt::tests::render_checks_labels_each_outcome_with_its_check_in_order
+        PASS [   0.017s] (122/209) blendtutor-core llm::prompt::tests::render_checks_never_drops_a_verdict_when_outcomes_exceed_checks
+        PASS [   0.012s] (123/209) blendtutor-core llm::prompt::tests::render_checks_renders_no_line_for_a_check_without_an_outcome
+        PASS [   0.010s] (124/209) blendtutor-core llm::provider::tests::each_provider_names_its_own_key_var
+        PASS [   0.014s] (125/209) blendtutor-core llm::provider::tests::each_provider_has_a_recognizable_default_model
+        PASS [   0.009s] (126/209) blendtutor-core llm::provider::tests::each_provider_targets_its_own_api_host
+        PASS [   0.012s] (127/209) blendtutor-core llm::provider::tests::fireworks_is_the_default_provider
+        PASS [   0.014s] (128/209) blendtutor-core run::tests::json_tags_an_incorrect_verdict_distinctly
+        PASS [   0.018s] (129/209) blendtutor-core run::tests::json_splits_the_verdict_into_a_string_tag_and_feedback
+        PASS [   0.011s] (130/209) blendtutor-core run::tests::run_error_labels_each_stage_and_exposes_its_source
+        PASS [   0.010s] (131/209) blendtutor-core run::tests::run_report_json_roundtrip_preserves_value
+        PASS [   0.011s] (132/209) blendtutor-core runner::python::tests::interpreter_includes_with_flags_for_packages
+        PASS [   0.012s] (133/209) blendtutor-core runner::python::tests::interpreter_omits_with_flags_when_packages_empty
+        PASS [   0.016s] (134/209) blendtutor-core runner::tests::runner_error_displays_its_stage_and_exposes_the_io_source
+        PASS [   0.018s] (135/209) blendtutor-core runner::tests::from_capture_keeps_streams_distinct_and_passes_exit_through
+        PASS [   0.013s] (136/209) blendtutor-core scaffold::tests::add_lesson_error_display_and_source_distinguish_each_variant
+        PASS [   0.012s] (137/209) blendtutor-core scaffold::tests::add_lesson_refuses_a_duplicate_without_clobbering_or_double_registering
+        PASS [   0.013s] (138/209) blendtutor-core scaffold::tests::add_lesson_refuses_a_non_course_directory_without_leaving_an_orphan
+        PASS [   0.014s] (139/209) blendtutor-core scaffold::tests::add_lesson_refuses_an_unsafe_id_before_writing_anything
+        PASS [   0.013s] (140/209) blendtutor-core scaffold::tests::is_empty_target_surfaces_a_non_notfound_error_rather_than_reading_it_as_empty
+        PASS [   0.011s] (141/209) blendtutor-core scaffold::tests::is_valid_slug_accepts_word_chars_hyphens_and_underscores_but_nothing_else
+        PASS [   0.018s] (142/209) blendtutor-core scaffold::tests::add_lesson_writes_the_file_and_registers_it_so_the_course_lists_it
+        PASS [   0.010s] (143/209) blendtutor-core scaffold::tests::lesson_template_produces_a_valid_python_lesson
+        PASS [   0.010s] (144/209) blendtutor-core scaffold::tests::plan_lists_the_starter_files_as_pure_data
+        PASS [   0.014s] (145/209) blendtutor-core scaffold::tests::lesson_template_produces_a_valid_r_lesson
+        PASS [   0.009s] (146/209) blendtutor-core scaffold::tests::scaffold_course_refuses_a_broken_symlink_target_instead_of_a_cryptic_write_error
+        PASS [   0.014s] (147/209) blendtutor-core scaffold::tests::scaffold_course_accepts_an_existing_empty_directory
+        PASS [   0.012s] (148/209) blendtutor-core scaffold::tests::scaffold_course_creates_the_target_directory_when_absent
+        PASS [   0.013s] (149/209) blendtutor-core scaffold::tests::scaffold_course_refuses_a_nonempty_target_before_writing_anything
+        PASS [   0.014s] (150/209) blendtutor-core scaffold::tests::scaffold_error_display_and_source_distinguish_each_variant
+        PASS [   0.019s] (151/209) blendtutor-core scaffold::tests::scaffold_course_writes_every_planned_file_verbatim
+        PASS [   0.012s] (152/209) blendtutor-core site::tests::build_target_display_names_each_runtime
+        PASS [   0.017s] (153/209) blendtutor-core scaffold::tests::the_scaffolded_lesson_eval_and_manifest_parse_with_production_parsers
+        PASS [   0.015s] (154/209) blendtutor-core site::tests::build_target_language_maps_each_runtime_to_its_language
+        PASS [   0.015s] (155/209) blendtutor-core site::tests::eval_report_error_displays_each_variant_and_chains_its_source
+        PASS [   0.016s] (156/209) blendtutor-core site::tests::eval_results_html_not_validated_renders_an_explicit_marker
+        PASS [   0.016s] (157/209) blendtutor-core site::tests::eval_results_html_validated_renders_the_accuracy_and_validated_marker
+        PASS [   0.017s] (158/209) blendtutor-core site::tests::eval_summary_from_report_json_rejects_a_malformed_report
+        PASS [   0.014s] (159/209) blendtutor-core site::tests::eval_summary_from_report_json_rejects_an_out_of_range_accuracy
+        PASS [   0.015s] (160/209) blendtutor-core site::tests::eval_summary_from_report_json_takes_the_accuracy_as_is
+        PASS [   0.014s] (161/209) blendtutor-core site::tests::plan_error_language_mismatch_displays_the_clash_with_no_nested_source
+        PASS [   0.015s] (162/209) blendtutor-core site::tests::plan_site_assembles_the_shared_byok_feedback_backend
+        PASS [   0.016s] (163/209) blendtutor-core site::tests::plan_site_carries_the_same_shared_core_and_shim_across_both_targets
+        PASS [   0.015s] (164/209) blendtutor-core site::tests::plan_site_cm6_editor_ux_extensions_configured
+        PASS [   0.017s] (165/209) blendtutor-core site::tests::plan_site_folds_the_eval_results_page_for_each_state
+        PASS [   0.024s] (166/209) blendtutor-core site::tests::plan_site_emits_vendored_codemirror_bundle
+        PASS [   0.018s] (167/209) blendtutor-core site::tests::plan_site_pyodide_assembles_the_shell_runner_core_shim_and_one_json_per_lesson
+        PASS [   0.017s] (168/209) blendtutor-core site::tests::plan_site_refuses_an_r_course_built_for_the_pyodide_target
+        PASS [   0.020s] (169/209) blendtutor-core site::tests::plan_site_serializes_a_missing_solution_as_json_null_not_dropped
+        PASS [   0.021s] (170/209) blendtutor-core site::tests::plan_site_serializes_each_lesson_to_the_browser_contract
+        PASS [   0.022s] (171/209) blendtutor-core site::tests::plan_site_serializes_packages_as_array_even_when_empty
+        PASS [   0.019s] (172/209) blendtutor-core site::tests::plan_site_shells_contain_semantic_regions
+        PASS [   0.017s] (173/209) blendtutor-core site::tests::plan_site_shells_differ_only_by_three_known_diffs
+        PASS [   0.020s] (174/209) blendtutor-core site::tests::plan_site_shells_have_correct_head_load_order
+        PASS [   0.021s] (175/209) blendtutor-core site::tests::plan_site_shells_have_link_and_no_inline_style
+        PASS [   0.021s] (176/209) blendtutor-core site::tests::plan_site_shells_load_codemirror_as_import
+        PASS [   0.017s] (177/209) blendtutor-core site::tests::plan_site_styles_css_declares_tokens_and_uses_them
+        PASS [   0.020s] (178/209) blendtutor-core site::tests::plan_site_styles_css_is_present_for_both_targets
+        PASS [   0.015s] (179/209) blendtutor-core site::tests::plan_site_webr_assembles_the_shell_runner_shim_and_one_json_per_lesson
+        PASS [   0.020s] (180/209) blendtutor-core site::tests::site_lesson_from_lesson_projects_each_contract_field
+        PASS [   0.022s] (181/209) blendtutor-core site::tests::write_site_writes_every_planned_file_to_disk
+        PASS [   0.036s] (182/209) blendtutor-core site::tests::plan_site_workspace_styles_use_tokens_and_status_renders_as_pill
+        PASS [   0.017s] (183/209) blendtutor-core tests::display_names_the_command_and_the_unimplemented_state
+        PASS [   0.018s] (184/209) blendtutor-core::eval parses_ten_fireworks_vitals_cases_into_typed_suite
+        PASS [   0.015s] (185/209) blendtutor-core::eval rejects_unknown_verdict_naming_the_offending_case
+        PASS [   0.017s] (186/209) blendtutor-core::grade python_lesson_selects_python_runner
+        PASS [   0.016s] (187/209) blendtutor-core::llm anthropic_missing_key_errs_before_request
+        PASS [   0.016s] (188/209) blendtutor-core::llm build_prompt_is_deterministic_offline
+        PASS [   0.017s] (189/209) blendtutor-core::llm build_prompt_neutralizes_injected_delimiter
+        PASS [   0.034s] (190/209) blendtutor-core::llm build_prompt_renders_delimited_code_and_labeled_sections
+        PASS [   0.014s] (191/209) blendtutor-core::llm fireworks_empty_key_errs_before_request
+        PASS [   0.020s] (192/209) blendtutor-core::llm fireworks_missing_key_errs_before_request
+        PASS [   0.035s] (193/209) blendtutor-core::llm fireworks_present_key_reaches_server
+        PASS [   0.033s] (194/209) blendtutor-core::llm request_feedback_correct_verdict
+        PASS [   0.200s] (195/209) blendtutor-core::grade submission_error_is_notrun_not_fail
+        PASS [   0.032s] (196/209) blendtutor-core::llm request_feedback_incorrect_verdict_and_missing_field_errors
+        PASS [   0.073s] (197/209) blendtutor-core::runner python_captures_streams_distinctly
+        PASS [   1.669s] (198/209) blendtutor-cli::write_less_code_r layer3_solutions_execute_cleanly
+        PASS [   1.665s] (199/209) blendtutor-cli::write_less_code_r negative_checks_fail_against_wrong_submissions
+        PASS [   1.721s] (200/209) blendtutor-cli::write_less_code_r layer6_each_lesson_has_genuine_near_miss
+        PASS [   0.216s] (201/209) blendtutor-core::runner captures_stdout_stderr_exit_separately
+        PASS [   0.193s] (202/209) blendtutor-core::runner runs_in_isolated_temp_dir_cleaned_up
+        PASS [   0.519s] (203/209) blendtutor-core::grade r_runner_reports_per_check_pass_fail
+        PASS [   1.963s] (204/209) blendtutor-cli::write_less_code_python run_solution_exits_zero_with_correct
+        PASS [   2.049s] (205/209) blendtutor-cli::write_less_code_python eval_suites_have_near_miss_that_runs_cleanly
+        PASS [   0.545s] (206/209) blendtutor-core::runner python_infinite_loop_times_out
+        PASS [   2.333s] (207/209) blendtutor-cli::write_less_code_r near_miss_submissions_fail_at_least_one_check
+        PASS [   2.392s] (208/209) blendtutor-cli::write_less_code_r layer4_checks_pass_against_reference_solution
+        PASS [   3.039s] (209/209) blendtutor-core::runner timeout_kills_process_tree_under_natural_runtime
+────────────
+     Summary [   5.365s] 209 tests run: 209 passed, 0 skipped

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Build the combined documentation site locally and assert it satisfies the
-# docs slice (#3): mdBook narrative + rustdoc API merged into one Pages artifact.
+# docs slice (#3) and the example-sites slice (#76): mdBook narrative + rustdoc
+# API + example course sites (webr + pyodide) merged into one Pages artifact.
 #
-# This is the slice's executable spec — the same predicates CI enforces, runnable
-# by hand:
+# This is the slice's executable spec — the same predicates CI enforces,
+# runnable by hand:
 #   scripts/check-docs.sh
 #
 # It mirrors .github/workflows/docs.yml's build + assemble steps. CI keeps those
@@ -51,6 +52,48 @@ test -f "$book_out/index.html" \
 test -f "$book_out/api/blendtutor_core/index.html" \
   || { echo "docs: API index not nested under /api" >&2; exit 1; }
 
+# AC-6 (#76) — build example course sites (webr + pyodide) alongside the docs.
+# Mirrors the two `cargo run` steps in docs.yml so the local check exercises the
+# same build path CI uses. Each site nests into the Pages artifact at
+# $book_out/examples/{r,python}/, mirroring the /api nesting above.
+echo "docs: building example sites (webr + pyodide) …"
+cargo run --release -p blendtutor-cli -- build examples/write-less-code-r \
+  --target webr -o "$book_out/examples/r"
+cargo run --release -p blendtutor-cli -- build examples/write-less-code-python \
+  --target pyodide -o "$book_out/examples/python"
+
+# AC-6 — assert each example site has the required files: index.html,
+# lesson-runner.js, lessons/0.json (at least one lesson built), eval-results.html.
+for target_dir in "$book_out/examples/r" "$book_out/examples/python"; do
+  for fname in index.html lesson-runner.js eval-results.html; do
+    test -f "$target_dir/$fname" \
+      || { echo "docs: missing $target_dir/$fname" >&2; exit 1; }
+  done
+  test -f "$target_dir/lessons/0.json" \
+    || { echo "docs: missing $target_dir/lessons/0.json (no lessons built)" >&2; exit 1; }
+  # Both eval-results.html must carry the validated marker (AC-5 eval reports).
+  grep -q 'data-eval-status="validated"' "$target_dir/eval-results.html" \
+    || { echo "docs: $target_dir/eval-results.html missing validated marker" >&2; exit 1; }
+done
+
+# AC-6 — cross-target boot check: R site boots webR (not pyodide), Python site
+# boots Pyodide (not webr). Catches copy-paste duplication where both sites ship
+# the same runtime adapter.
+grep -qi "webr" "$book_out/examples/r/lesson-runner.js" \
+  || { echo "docs: R lesson-runner.js missing 'webr' (cross-target boot check)" >&2; exit 1; }
+grep -qi "pyodide" "$book_out/examples/python/lesson-runner.js" \
+  || { echo "docs: Python lesson-runner.js missing 'pyodide' (cross-target boot check)" >&2; exit 1; }
+
+# AC-6 — failure propagation: a build with a missing course path must fail.
+# set -euo pipefail ensures cargo's non-zero exit propagates; this negative test
+# pins that contract so a future change that swallows the exit code fails here.
+echo "docs: verifying failure propagation (missing course path) …"
+if cargo run --release -p blendtutor-cli -- build /nonexistent/course \
+  --target webr -o /tmp/bt-check-docs-fail 2>/dev/null; then
+  echo "docs: build with missing course path should have failed" >&2
+  exit 1
+fi
+
 # AC3 (local proxy) — the deploy workflow wires both builds into a Pages deploy.
 # The live deploy leg is CI-only; here we assert the workflow is present and
 # references each required step so a missing-deploy regression fails locally.
@@ -63,4 +106,33 @@ for needle in 'mdbook build' 'cargo doc --no-deps' \
     || { echo "docs: $workflow missing required step: $needle" >&2; exit 1; }
 done
 
-echo "docs: OK — merged site at $book_out (book at /, API at /api)"
+# AC-6 — docs.yml contains both cargo run build commands with correct
+# target/path pairing (webr→r, pyodide→python).
+for needle in \
+  'build examples/write-less-code-r --target webr' \
+  'build examples/write-less-code-python --target pyodide'; do
+  grep -q "$needle" "$workflow" \
+    || { echo "docs: $workflow missing build command: $needle" >&2; exit 1; }
+done
+
+# AC-6 — README.md links to both example sites.
+for needle in 'examples/r/' 'examples/python/'; do
+  grep -q "$needle" README.md \
+    || { echo "docs: README.md missing link to $needle" >&2; exit 1; }
+done
+
+# AC-6 — SUMMARY.md links to the examples page.
+grep -q 'examples' docs/book/src/SUMMARY.md \
+  || { echo "docs: SUMMARY.md missing examples page" >&2; exit 1; }
+
+# AC-6 — built mdBook HTML contains rendered links (not just source). mdBook
+# renders docs/book/src/examples.md → docs/book/book/examples.html; the rendered
+# HTML must contain the example-site links, not just the markdown source.
+test -f "$book_out/examples.html" \
+  || { echo "docs: built mdBook missing examples.html (page not in SUMMARY.md?)" >&2; exit 1; }
+grep -q 'examples/r/' "$book_out/examples.html" \
+  || { echo "docs: built mdBook examples.html missing rendered link to examples/r/" >&2; exit 1; }
+grep -q 'examples/python/' "$book_out/examples.html" \
+  || { echo "docs: built mdBook examples.html missing rendered link to examples/python/" >&2; exit 1; }
+
+echo "docs: OK — merged site at $book_out (book at /, API at /api, examples at /examples/{r,python})"


### PR DESCRIPTION
## Summary
Extend docs.yml + check-docs.sh to build webr/pyodide example sites alongside mdBook/rustdoc. Cross-target boot check (R→webr, Python→pyodide). README + mdBook links. Eval badge validated.

## Issue
Closes #76

## ACs implemented
- [x] `scripts/check-docs.sh` exits 0 AND fails when course path missing
- [x] `docs/book/book/examples/r/` exists with index.html, lesson-runner.js, lessons/0.json, eval-results.html
- [x] `docs/book/book/examples/python/` exists with same files
- [x] Both `eval-results.html` contain `data-eval-status="validated"`
- [x] R `lesson-runner.js` contains "webr" (cross-target boot check)
- [x] Python `lesson-runner.js` contains "pyodide" (cross-target boot check)
- [x] README.md links to both example sites
- [x] `docs/book/src/SUMMARY.md` links to both example sites
- [x] Built mdBook HTML contains rendered links (not just source)
- [x] `docs.yml` contains both `cargo run` build commands with correct target/path pairing
- [ ] Rodney against live Pages URLs confirms both sites serve content (post-merge — CI deploys then rodney probes live URLs)

## Self-Review
- [x] All ACs exercised by tests (check-docs.sh is the executable spec)
- [x] Predicates match spec (11-point compound predicate)
- [x] Negative case tested (failure propagation: missing course path must fail)
- [x] Verification medium satisfied (code: check-docs.sh + grep; rodney: deferred to post-merge live Pages)
- [x] Design intent respected (§3 nest into existing Pages artifact, §4 each file one responsibility)
- [x] No scope creep

## Test plan
- [x] `scripts/check-docs.sh` passes locally (build + all assertions)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo nextest run` — 209 tests pass
- [x] E2E evidence at `docs/evidence/76/`