### PR TITLE
feat(examples): add hints content to all example lessons

### DIFF
--- a/crates/cli/tests/hints_content.rs
+++ b/crates/cli/tests/hints_content.rs
@@ -1,0 +1,286 @@
+//! Integration tests for succinct prompts + expandable hints across both
+//! example courses.
+//!
+//! Validates that every lesson in `examples/write-less-code-python/` and
+//! `examples/write-less-code-r/`:
+//!   1. Validates cleanly (`blendtutor validate` exits 0)
+//!   2. Carries a non-empty `hints` field of at least 100 characters
+//!   3. Hints contain at least one structural marker (gotcha, tip, etc.)
+//!   4. Hints do not leak the reference solution (anti-spoiler)
+//!   5. Hints are not a copy of the prompt (non-dupe)
+//!   6. Copy-paste-trap lessons retain the literal `stress_6` in the prompt
+//!   7. The `{student_code}` placeholder is retained in `llm_evaluation_prompt`
+//!
+//! Plus a build gate: `blendtutor build` on each course emits lesson JSON
+//! whose `hints` field is non-null.
+
+mod common;
+
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use blendtutor_core::lesson::{Lesson, read_lesson_file};
+use serde_json::Value;
+
+/// The Python example course directory, relative to the CLI crate.
+const PYTHON_COURSE_DIR: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../examples/write-less-code-python"
+);
+
+/// The R example course directory, relative to the CLI crate.
+const R_COURSE_DIR: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../examples/write-less-code-r"
+);
+
+/// The 5 lesson file names (shared by both courses in manifest order).
+const LESSON_FILES: &[&str] = &[
+    "01_seed_data.yaml",
+    "02_copy_paste_trap.yaml",
+    "03_write_a_function.yaml",
+    "04_map_over_columns.yaml",
+    "05_rule_of_three.yaml",
+];
+
+/// Structural markers that hints must contain at least one of.
+const STRUCTURAL_MARKERS: &[&str] = &[
+    "gotcha",
+    "watch out",
+    "common mistake",
+    "troubleshoot",
+    "tip",
+    "note",
+    "important",
+    "remember",
+    "hint",
+];
+
+/// Minimum length for hints content.
+const MIN_HINTS_LEN: usize = 100;
+
+fn lesson_path(course_dir: &str, filename: &str) -> PathBuf {
+    Path::new(course_dir).join(filename)
+}
+
+fn load_lesson(course_dir: &str, filename: &str) -> Lesson {
+    read_lesson_file(&lesson_path(course_dir, filename))
+        .unwrap_or_else(|e| panic!("lesson {filename} should parse: {e}"))
+}
+
+/// Assert all hints-content invariants for a single lesson.
+fn assert_hints_invariants(course_name: &str, idx: usize, filename: &str, lesson: &Lesson) {
+    let hints = lesson
+        .exercise
+        .hints
+        .as_deref()
+        .unwrap_or_else(|| panic!("{course_name} lesson {idx} ({filename}) should have hints"));
+
+    // Invariant 2a: hints non-empty.
+    assert!(
+        !hints.trim().is_empty(),
+        "{course_name} lesson {idx} ({filename}) hints should be non-empty"
+    );
+
+    // Invariant 2b: hints at least 100 characters.
+    assert!(
+        hints.len() >= MIN_HINTS_LEN,
+        "{course_name} lesson {idx} ({filename}) hints should be >= {MIN_HINTS_LEN} chars, got {}: {hints:?}",
+        hints.len()
+    );
+
+    // Invariant 3: at least one structural marker.
+    let lower = hints.to_lowercase();
+    let has_marker = STRUCTURAL_MARKERS.iter().any(|m| lower.contains(m));
+    assert!(
+        has_marker,
+        "{course_name} lesson {idx} ({filename}) hints should contain a structural marker \
+         (one of: {STRUCTURAL_MARKERS:?}), got: {hints:?}"
+    );
+
+    // Invariant 4: solution not leaked into hints (anti-spoiler).
+    if let Some(solution) = lesson.exercise.solution.as_deref() {
+        // Check a distinctive fragment of the solution (first non-trivial line)
+        // rather than the whole block, since hints may reference variable names.
+        let solution_fragments: Vec<&str> = solution
+            .lines()
+            .filter(|l| {
+                let t = l.trim();
+                !t.is_empty()
+                    && !t.starts_with('#')
+                    && !t.starts_with("import ")
+                    && !t.starts_with("library(")
+                    && !t.starts_with("survey_data <- data.frame")
+                    && !t.starts_with("survey_data = pd.DataFrame")
+            })
+            .collect();
+        for frag in &solution_fragments {
+            let frag_trimmed = frag.trim();
+            // Skip very short fragments (variable names, single tokens) that
+            // hints legitimately reference.
+            if frag_trimmed.len() < 15 {
+                continue;
+            }
+            assert!(
+                !hints.contains(frag_trimmed),
+                "{course_name} lesson {idx} ({filename}) hints must not leak solution code \
+                 fragment: {frag_trimmed:?}"
+            );
+        }
+    }
+
+    // Invariant 5: hints are not a copy of the prompt (non-dupe).
+    assert!(
+        !hints.contains(&lesson.exercise.prompt),
+        "{course_name} lesson {idx} ({filename}) hints must not be a copy of the prompt"
+    );
+
+    // Invariant 7: {student_code} placeholder retained in llm_evaluation_prompt.
+    assert!(
+        lesson
+            .exercise
+            .llm_evaluation_prompt
+            .contains("{student_code}"),
+        "{course_name} lesson {idx} ({filename}) should retain the {{student_code}} placeholder"
+    );
+}
+
+// ─── Python course: validate + hints invariants ──────────────────────────────
+
+#[test]
+fn python_validate_each_lesson_exits_zero() {
+    for filename in LESSON_FILES {
+        let path = lesson_path(PYTHON_COURSE_DIR, filename);
+        Command::cargo_bin("blendtutor")
+            .unwrap()
+            .arg("validate")
+            .arg(&path)
+            .assert()
+            .success();
+    }
+}
+
+#[test]
+fn python_hints_satisfy_all_invariants() {
+    for (idx, filename) in LESSON_FILES.iter().enumerate() {
+        let lesson = load_lesson(PYTHON_COURSE_DIR, filename);
+        assert_hints_invariants("Python", idx, filename, &lesson);
+    }
+}
+
+#[test]
+fn python_lesson_2_prompt_retains_stress_6() {
+    let lesson = load_lesson(PYTHON_COURSE_DIR, LESSON_FILES[1]);
+    assert!(
+        lesson.exercise.prompt.contains("stress_6"),
+        "Python lesson 2 prompt should retain the literal 'stress_6': {:?}",
+        lesson.exercise.prompt
+    );
+}
+
+// ─── R course: validate + hints invariants ───────────────────────────────────
+
+#[test]
+fn r_validate_each_lesson_exits_zero() {
+    for filename in LESSON_FILES {
+        let path = lesson_path(R_COURSE_DIR, filename);
+        Command::cargo_bin("blendtutor")
+            .unwrap()
+            .arg("validate")
+            .arg(&path)
+            .assert()
+            .success();
+    }
+}
+
+#[test]
+fn r_hints_satisfy_all_invariants() {
+    for (idx, filename) in LESSON_FILES.iter().enumerate() {
+        let lesson = load_lesson(R_COURSE_DIR, filename);
+        assert_hints_invariants("R", idx, filename, &lesson);
+    }
+}
+
+#[test]
+fn r_lesson_2_prompt_retains_stress_6() {
+    let lesson = load_lesson(R_COURSE_DIR, LESSON_FILES[1]);
+    assert!(
+        lesson.exercise.prompt.contains("stress_6"),
+        "R lesson 2 prompt should retain the literal 'stress_6': {:?}",
+        lesson.exercise.prompt
+    );
+}
+
+// ─── Build gate: lesson JSON carries non-null hints ──────────────────────────
+
+/// Run `build --target <target> <course> -o <out>` via the built binary.
+fn build(target: &str, course: &str, out: &Path) -> std::process::Output {
+    Command::cargo_bin("blendtutor")
+        .unwrap()
+        .arg("build")
+        .arg("--target")
+        .arg(target)
+        .arg(course)
+        .arg("-o")
+        .arg(out)
+        .output()
+        .unwrap()
+}
+
+/// Assert every lesson JSON in a built site carries a non-null `hints` field.
+fn assert_built_lessons_carry_hints(out: &Path, course_name: &str) {
+    for i in 0..LESSON_FILES.len() {
+        let json_path = out.join(format!("lessons/{i}.json"));
+        let text = std::fs::read_to_string(&json_path)
+            .unwrap_or_else(|e| panic!("{course_name} lessons/{i}.json should exist: {e}"));
+        let lesson: Value = serde_json::from_str(&text)
+            .unwrap_or_else(|e| panic!("{course_name} lessons/{i}.json should parse: {e}"));
+        assert!(
+            lesson.get("hints").is_some(),
+            "{course_name} lesson {i} JSON must carry a 'hints' key (not absent): {lesson}"
+        );
+        assert!(
+            !lesson["hints"].is_null(),
+            "{course_name} lesson {i} JSON hints must be non-null: {lesson}"
+        );
+        let hints_str = lesson["hints"].as_str().unwrap_or_else(|| {
+            panic!("{course_name} lesson {i} JSON hints should be a string: {lesson}")
+        });
+        assert!(
+            !hints_str.is_empty(),
+            "{course_name} lesson {i} JSON hints should be non-empty: {lesson}"
+        );
+    }
+}
+
+#[test]
+fn build_python_course_emits_non_null_hints() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("site");
+
+    let output = build("pyodide", PYTHON_COURSE_DIR, &out);
+    assert!(
+        output.status.success(),
+        "Python build should exit 0, got {:?}; stderr={:?}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_built_lessons_carry_hints(&out, "Python");
+}
+
+#[test]
+fn build_r_course_emits_non_null_hints() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("site");
+
+    let output = build("webr", R_COURSE_DIR, &out);
+    assert!(
+        output.status.success(),
+        "R build should exit 0, got {:?}; stderr={:?}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_built_lessons_carry_hints(&out, "R");
+}

--- a/examples/write-less-code-python/01_seed_data.yaml
+++ b/examples/write-less-code-python/01_seed_data.yaml
@@ -6,9 +6,8 @@ textbook_reference: "Just Enough Software Engineering - Chapter 8: Write Less Co
 exercise:
   type: "function_writing"
   prompt: |
-    Create a pandas DataFrame called `survey_data` with 5 respondents and
-    columns `respondent_id`, `stress_1` through `stress_6`. Each stress
-    column should contain integer values between 1 and 5.
+    Create a pandas DataFrame `survey_data` with 5 respondents, a
+    `respondent_id` column, and `stress_1` through `stress_6` (integers 1-5).
 
     The submission is correct if ALL of these are true:
     - Creates a variable named `survey_data`
@@ -23,6 +22,14 @@ exercise:
     - Wrong number of rows (not 5)
     - Missing respondent_id column
     - Has a syntax error
+  hints: |
+    Common mistake: forgetting a column or misspelling it. You need all six
+    stress columns (stress_1 through stress_6) plus respondent_id — 7 columns
+    total. Watch out for passing lists of unequal length to the DataFrame
+    constructor; pandas raises a ValueError. Tip: verify with
+    `survey_data.shape` which should print (5, 7). Remember that integer
+    values like [3, 4, 2, 5, 3] are stored as int64 automatically — no
+    explicit dtype needed.
   code_template: |
     import pandas as pd
 

--- a/examples/write-less-code-python/02_copy_paste_trap.yaml
+++ b/examples/write-less-code-python/02_copy_paste_trap.yaml
@@ -6,14 +6,17 @@ textbook_reference: "Just Enough Software Engineering - Chapter 8: Write Less Co
 exercise:
   type: "function_writing"
   prompt: |
-    A colleague copy-pasted code to reverse the `stress_6` column but
-    forgot to actually reverse it — they assigned `stress_6` to itself
-    instead of `stress_6[::-1]`. Fix the bug so `stress_6_rev` contains
-    the reversed values of the `stress_6` column from `survey_data`.
-
-    The survey_data DataFrame is provided. Create `stress_6_rev` as a
-    numpy array (or list) containing the values of `stress_6` in
-    reverse order.
+    A colleague copy-pasted code to reverse `stress_6` but assigned it to
+    itself instead of `stress_6[::-1]`. Fix the bug so `stress_6_rev`
+    contains the reversed values of the `stress_6` column from
+    `survey_data` as a numpy array or list.
+  hints: |
+    Gotcha: the bug is on the line `stress_6_rev = survey_data['stress_6'].values`
+    — it copies without reversing. To reverse a numpy array or list, append
+    `[::-1]`. Watch out for confusing `.values` (returns a numpy array) with
+    the Series itself — both support slicing, but the check asserts on
+    `stress_6_rev[0]` and `stress_6_rev[-1]`. Tip: the first element of the
+    reversed array should be 5 (the last value of stress_6).
   code_template: |
     import pandas as pd
 

--- a/examples/write-less-code-python/03_write_a_function.yaml
+++ b/examples/write-less-code-python/03_write_a_function.yaml
@@ -6,8 +6,16 @@ textbook_reference: "Just Enough Software Engineering - Chapter 8: Write Less Co
 exercise:
   type: "function_writing"
   prompt: |
-    Write a function called `mean_stress` that takes a pandas DataFrame
-    and a column name, and returns the mean of that column.
+    Write a function `mean_stress(df, col)` that returns the mean of a
+    DataFrame column.
+  hints: |
+    Tip: pandas Series have a `.mean()` method — no need to sum and divide
+    manually. Common mistake: forgetting to `return` the result (a function
+    without a return statement returns None in Python). Watch out for
+    using `df.col` instead of `df[col]` — dot-access breaks when the column
+    name contains spaces or matches a DataFrame attribute. Remember that
+    `.mean()` returns a float, so `mean_stress(df, 's')` on [1, 2, 3] gives
+    2.0, not 2.
   code_template: |
     import pandas as pd
 

--- a/examples/write-less-code-python/04_map_over_columns.yaml
+++ b/examples/write-less-code-python/04_map_over_columns.yaml
@@ -6,15 +6,9 @@ textbook_reference: "Just Enough Software Engineering - Chapter 8: Write Less Co
 exercise:
   type: "function_writing"
   prompt: |
-    Write a function called `normalize_columns` that takes a pandas
-    DataFrame and a list of column names, and normalizes each column
-    to the range [0, 1] using min-max normalization.
-
-    Use an explicit for loop to iterate over the columns. Do NOT use
-    a list comprehension.
-
-    Min-max normalization formula:
-    normalized = (value - min) / (max - min)
+    Write `normalize_columns(df, columns)` that normalizes each column to
+    [0, 1] via min-max normalization: `(value - min) / (max - min)`. Use an
+    explicit `for` loop — NOT a list comprehension.
 
     The submission is correct if ALL of these are true:
     - The function is named `normalize_columns`
@@ -28,6 +22,15 @@ exercise:
     - It does not normalize correctly
     - It has a syntax error
     - It does not return the DataFrame
+  hints: |
+    Gotcha: if a column has all identical values, `max - min` is zero and
+    you get a division-by-zero error. Guard with an `if col_max == col_min`
+    check and set those values to 0.0. Common mistake: forgetting to
+    `return df` at the end — the function must return the modified
+    DataFrame, not None. Watch out for using a list comprehension like
+    `[df[c] = ... for c in columns]` — the exercise requires an explicit
+    for loop. Tip: min-max normalization maps the minimum to 0.0 and the
+    maximum to 1.0.
   code_template: |
     import pandas as pd
 

--- a/examples/write-less-code-python/05_rule_of_three.yaml
+++ b/examples/write-less-code-python/05_rule_of_three.yaml
@@ -6,12 +6,18 @@ textbook_reference: "Just Enough Software Engineering - Chapter 8: Write Less Co
 exercise:
   type: "function_writing"
   prompt: |
-    A colleague wrote three nearly identical blocks of code to compute
-    the mean of `stress_1`, `stress_2`, and `stress_3` columns from a
-    DataFrame. Apply the Rule of Three: refactor the repeated code into
-    a single function called `compute_column_means` that takes a
-    DataFrame and a list of column names, and returns a dictionary
-    mapping each column name to its mean.
+    Apply the Rule of Three: refactor repeated column-mean computations into
+    `compute_column_means(df, columns)` returning a dict mapping each column
+    name to its mean.
+  hints: |
+    Tip: the Rule of Three says abstract a pattern once it appears three or
+    more times — here, calling `.mean()` on stress_1, stress_2, stress_3
+    separately. Common mistake: returning a list instead of a dict — the
+    function must map column names to means (e.g., `{'a': 2.0, 'b': 5.0}`).
+    Watch out for forgetting to iterate: a dict comprehension works, but
+    so does an explicit loop assigning each column's mean into a results
+    dict. Remember that `.mean()` returns a float, so the dict values will
+    be floats like 2.0, not integers.
   code_template: |
     import pandas as pd
 

--- a/examples/write-less-code-r/01_seed_data.yaml
+++ b/examples/write-less-code-r/01_seed_data.yaml
@@ -6,9 +6,15 @@ textbook_reference: "Just Enough Software Engineering - Chapter 8: Write Less Co
 exercise:
   type: "function_writing"
   prompt: |
-    Create a data frame called `survey_data` with 5 respondents and 6 stress
-    items (stress_1 through stress_6) measured on a 1-5 scale, plus a
-    respondent_id column.
+    Create a data frame `survey_data` with 5 respondents, `respondent_id`,
+    and `stress_1` through `stress_6` (integers on a 1-5 scale).
+  hints: |
+    Tip: R's `data.frame()` takes named arguments — each `stress_N = c(...)`
+    becomes a column. Common mistake: using different-length vectors; R
+    recycles silently, which can hide bugs. Watch out for forgetting
+    `respondent_id` — you need 7 columns total (respondent_id + six stress
+    items). Remember that `1:5` generates the sequence c(1, 2, 3, 4, 5).
+    Verify with `dim(survey_data)` which should print `5 7`.
   code_template: |
     survey_data <- data.frame(
       respondent_id = 1:5,

--- a/examples/write-less-code-r/02_copy_paste_trap.yaml
+++ b/examples/write-less-code-r/02_copy_paste_trap.yaml
@@ -6,12 +6,18 @@ textbook_reference: "Just Enough Software Engineering - Chapter 8: Write Less Co
 exercise:
   type: "function_writing"
   prompt: |
-    The stress_6 item is reverse-scored (5 = low stress). Create a new column
-    `stress_6_rev` by computing `6 - stress_6`.
-
-    Beware the copy-paste trap: if you copy-paste code from reversing another
-    column, you might forget to update the column name and reverse the wrong
-    one. Make sure stress_6_rev is derived from stress_6, not stress_5.
+    The `stress_6` item is reverse-scored (5 = low stress). Create
+    `stress_6_rev` by computing `6 - stress_6`. Beware the copy-paste
+    trap: if you copy from reversing another column, you might reverse the
+    wrong one — make sure `stress_6_rev` derives from `stress_6`.
+  hints: |
+    Gotcha: reverse-scoring means flipping the scale so that a high raw
+    score becomes low. For a 1-5 scale, the formula is `6 - value` (so 1
+    becomes 5, 5 becomes 1). Common mistake: copy-pasting code that
+    references `stress_5` instead of `stress_6` — always double-check the
+    column name. Watch out for assigning to the wrong column: the new
+    column must be `stress_6_rev`, not `stress_5_rev`. Tip: verify with
+    `survey_data$stress_6_rev` which should be `5 4 3 2 1`.
   code_template: |
     survey_data <- data.frame(
       respondent_id = 1:5,

--- a/examples/write-less-code-r/03_write_a_function.yaml
+++ b/examples/write-less-code-r/03_write_a_function.yaml
@@ -6,11 +6,18 @@ textbook_reference: "Just Enough Software Engineering - Chapter 8: Write Less Co
 exercise:
   type: "function_writing"
   prompt: |
-    Write a function called `reverse_score` that takes a numeric vector `x`
-    (on a 1-5 scale) and returns its reverse-scored version: `6 - x`.
-
-    Reconstruct `survey_data` first — each check runs in a fresh R session.
-    Then apply `reverse_score` to `survey_data$stress_6` to verify it works.
+    Write a function `reverse_score(x)` that returns `6 - x` for a numeric
+    vector on a 1-5 scale. Reconstruct `survey_data` first — each check runs
+    in a fresh R session.
+  hints: |
+    Tip: R functions return their last evaluated expression automatically —
+    no explicit `return()` needed. Common mistake: using `{ }` braces
+    without a final expression, which returns NULL. Watch out for vector
+    operations: `6 - x` works element-wise on vectors, so
+    `reverse_score(c(1, 2, 3, 4, 5))` returns `5 4 3 2 1`. Remember that
+    the function must be named exactly `reverse_score` (with underscore,
+    not camelCase). The check reconstructs survey_data before calling your
+    function, so include that construction in your submission.
   code_template: |
     survey_data <- data.frame(
       respondent_id = 1:5,

--- a/examples/write-less-code-r/04_map_over_columns.yaml
+++ b/examples/write-less-code-r/04_map_over_columns.yaml
@@ -10,11 +10,9 @@ exercise:
   type: "function_writing"
   prompt: |
     Use purrr and dplyr to reverse-score ALL six stress columns at once,
-    creating new `_rev` columns (stress_1_rev through stress_6_rev).
-
-    Reconstruct `survey_data` first — each check runs in a fresh R session.
-    Use `mutate` with `across` and the `reverse_score` pattern (`6 - .x`)
-    to create the `_rev` columns.
+    creating `stress_1_rev` through `stress_6_rev`. Reconstruct
+    `survey_data` first — each check runs in a fresh R session. Use
+    `mutate` with `across` and the `reverse_score` pattern (`6 - .x`).
 
     The submission is correct if ALL of these are true:
     - Reconstructs `survey_data` with respondent_id and stress_1 through stress_6
@@ -27,6 +25,15 @@ exercise:
     - Does not create any `_rev` columns
     - Has a syntax error
     - Does not reconstruct survey_data
+  hints: |
+    Gotcha: `across()` needs `.names = "{.col}_rev"` to name the output
+    columns correctly — without it, the new columns overwrite the originals.
+    Common mistake: reversing only some columns. You need all six
+    (stress_1_rev through stress_6_rev). Watch out for the `.fns` argument:
+    use `~ 6 - .x` (a formula) or `function(x) 6 - x`. Tip: build a
+    character vector of the stress column names programmatically (e.g.,
+    with `paste0`) and pass it to `all_of()` inside `across`. Remember to
+    pipe with `|>` or `%>%` and reassign the result back to `survey_data`.
   code_template: |
     library(purrr)
     library(dplyr)

--- a/examples/write-less-code-r/05_rule_of_three.yaml
+++ b/examples/write-less-code-r/05_rule_of_three.yaml
@@ -6,16 +6,19 @@ textbook_reference: "Just Enough Software Engineering - Chapter 8: Write Less Co
 exercise:
   type: "function_writing"
   prompt: |
-    The "rule of three" says: if you write the same code pattern three or more
-    times, abstract it into a function.
-
-    Write a function called `should_abstract` that takes a count of repetitions
-    and returns TRUE if the pattern should be abstracted (count >= 3), FALSE
-    otherwise.
-
+    Write `should_abstract(count)` that returns TRUE if a pattern repeated
+    `count` times should be abstracted (count >= 3), FALSE otherwise.
     Reconstruct `survey_data` first — each check runs in a fresh R session.
-    Then count the stress columns in `survey_data` to see if the rule of three
-    applies to the reverse-scoring pattern.
+  hints: |
+    Tip: the Rule of Three says abstract a code pattern into a function once
+    it appears three or more times. Common mistake: using `count > 3`
+    instead of `count >= 3` — the threshold is inclusive, so exactly three
+    repetitions should return TRUE. Watch out for returning numeric instead
+    of logical: `count >= 3` returns TRUE/FALSE in R, but `ifelse` or
+    explicit `as.logical()` is unnecessary. Remember that R functions
+    return their last expression, so a one-liner returning `count >= 3`
+    suffices — no explicit `return()` needed. The check reconstructs
+    survey_data to count stress columns (there are 6, so the rule applies).
   code_template: |
     survey_data <- data.frame(
       respondent_id = 1:5,


### PR DESCRIPTION
## Summary
Add `hints` field content to all 10 example lesson YAMLs (5 Python + 5 R), with integration tests validating invariants (non-empty, ≥100 chars, structural markers, no solution leakage, non-dupe, stress_6 retained, {student_code} placeholder, build gate for non-null hints in JSON).

Builds on PR #85 which added the `hints` field to the lesson schema + expandable UI.

## Test file
`crates/cli/tests/hints_content.rs` — 8 test functions covering:
- Validate each lesson exits 0 (Python + R)
- Hints satisfy all invariants (Python + R)
- Copy-paste-trap lesson retains `stress_6` literal (Python + R)
- Build gate: lesson JSON carries non-null hints (Python + R)

## Verification
- [x] `cargo test -p blendtutor-cli --test hints_content` passes
- [x] `cargo test -p blendtutor-cli` — no regressions