### PR TITLE
feat(lesson): add gotchas field with bullet-point validation (#87)

### DIFF
--- a/crates/core/src/lesson.rs
+++ b/crates/core/src/lesson.rs
@@ -87,6 +87,14 @@ pub struct Exercise {
     /// in an expandable `<details>` panel. `Option` so every existing lesson
     /// stays valid; `Option` defaults to `None` without `#[serde(default)]`.
     pub hints: Option<String>,
+    /// Optional learner-facing gotchas: common pitfalls and mistakes, authored
+    /// as a Markdown bullet list (each non-empty line starts with `- ` or
+    /// `* `). The static-site build serializes them into the lesson JSON so the
+    /// in-browser runner renders them in an expandable `<details>` panel.
+    /// `Option` so every existing lesson stays valid; validated as bullets at
+    /// the parse boundary (§1.3.1) so malformed content never travels
+    /// downstream. `Option` defaults to `None` without `#[serde(default)]`.
+    pub gotchas: Option<String>,
     /// Optional example invocations.
     pub example_usage: Option<String>,
     /// Optional human-readable success criteria.
@@ -139,6 +147,15 @@ pub enum ValidationError {
     /// `{student_code}` placeholder, so a learner's submission could never be
     /// inserted into it.
     MissingStudentCodePlaceholder,
+    /// A field that must be bullet-formatted (each non-empty line starting with
+    /// `- ` or `* `) contains a non-empty line without a bullet prefix.
+    /// Parameterized by field name so AC-3 can reuse the variant for `hints`
+    /// without adding a new one. Rejected at the parse boundary (§1.3.1) so
+    /// malformed content never travels downstream.
+    InvalidBulletFormat {
+        /// The name of the field with malformed bullets (e.g. `"gotchas"`).
+        field: String,
+    },
 }
 
 impl fmt::Display for ValidationError {
@@ -150,6 +167,11 @@ impl fmt::Display for ValidationError {
                 "exercise.llm_evaluation_prompt must contain the literal \
                  {STUDENT_CODE_PLACEHOLDER} placeholder so the learner's \
                  submission can be inserted",
+            ),
+            ValidationError::InvalidBulletFormat { field } => write!(
+                f,
+                "exercise.{field} must be bullet-formatted: each non-empty line must \
+                 start with `- ` or `* `"
             ),
         }
     }
@@ -174,9 +196,10 @@ impl Lesson {
 
     /// Enforce the semantic rules that structure alone cannot.
     ///
-    /// Currently a single rule: the evaluation prompt must contain the
-    /// `{student_code}` placeholder. Split from the structural deserialize so
-    /// each name covers its body (§5.1).
+    /// Currently two rules: the evaluation prompt must contain the
+    /// `{student_code}` placeholder, and `exercise.gotchas` (if present) must
+    /// be bullet-formatted (each non-empty line starts with `- ` or `* `).
+    /// Split from the structural deserialize so each name covers its body (§5.1).
     fn validate_semantics(&self) -> Result<(), ValidationError> {
         if !self
             .exercise
@@ -184,6 +207,18 @@ impl Lesson {
             .contains(STUDENT_CODE_PLACEHOLDER)
         {
             return Err(ValidationError::MissingStudentCodePlaceholder);
+        }
+        if let Some(ref gotchas) = self.exercise.gotchas {
+            for line in gotchas.lines() {
+                if line.is_empty() {
+                    continue;
+                }
+                if !line.starts_with("- ") && !line.starts_with("* ") {
+                    return Err(ValidationError::InvalidBulletFormat {
+                        field: "gotchas".to_string(),
+                    });
+                }
+            }
         }
         Ok(())
     }
@@ -414,6 +449,139 @@ exercise:
             lesson.exercise.hints.is_none(),
             "a lesson without a hints key has none, got {:?}",
             lesson.exercise.hints
+        );
+    }
+
+    const LESSON_WITH_GOTCHAS_YAML: &str = r#"
+lesson_name: "Adder"
+language: R
+exercise:
+  prompt: "Write add_two(x, y)."
+  gotchas: |
+    - R uses '<-' for assignment, not '='.
+    - Functions return their last expression automatically.
+  llm_evaluation_prompt: "Grade this: {student_code}"
+"#;
+
+    #[test]
+    fn parse_reads_an_optional_gotchas_field() {
+        // Gotchas carry learner-facing pitfalls the browser renders in an
+        // expandable panel — mirroring `hints`. With `deny_unknown_fields`,
+        // `exercise.gotchas` must be modelled or it is rejected as a typo.
+        let lesson = Lesson::parse(LESSON_WITH_GOTCHAS_YAML)
+            .expect("a lesson may carry gotchas under exercise.gotchas");
+        assert_eq!(
+            lesson.exercise.gotchas.as_deref(),
+            Some(
+                "- R uses '<-' for assignment, not '='.\n- Functions return their last expression automatically.\n"
+            ),
+            "the gotchas text is read verbatim from exercise.gotchas"
+        );
+    }
+
+    #[test]
+    fn parse_defaults_gotchas_to_none_when_absent() {
+        // A lesson without a `gotchas` key has none — the field stays optional
+        // so every existing lesson remains valid, mirroring `hints`.
+        let lesson = Lesson::parse(VALID_YAML).expect("valid lesson should parse");
+        assert!(
+            lesson.exercise.gotchas.is_none(),
+            "a lesson without a gotchas key has none, got {:?}",
+            lesson.exercise.gotchas
+        );
+    }
+
+    const LESSON_WITH_MALFORMED_GOTCHAS_YAML: &str = r#"
+lesson_name: "Adder"
+language: R
+exercise:
+  prompt: "Write add_two(x, y)."
+  gotchas: "No bullet prefix here."
+  llm_evaluation_prompt: "Grade this: {student_code}"
+"#;
+
+    #[test]
+    fn parse_rejects_gotchas_with_non_bullet_lines() {
+        // Gotchas must be bullet-formatted (each non-empty line starts with
+        // `- ` or `* `). A prose gotchas string is rejected at the parse
+        // boundary (§1.3.1) so malformed content never travels downstream.
+        let err = Lesson::parse(LESSON_WITH_MALFORMED_GOTCHAS_YAML)
+            .expect_err("a gotchas without bullet prefixes is invalid");
+        assert!(
+            matches!(
+                err,
+                ValidationError::InvalidBulletFormat { ref field } if field == "gotchas"
+            ),
+            "expected InvalidBulletFormat for gotchas, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("gotchas"),
+            "error should name the gotchas field, got: {err}"
+        );
+    }
+
+    const LESSON_WITH_STAR_BULLETS_GOTCHAS_YAML: &str = r#"
+lesson_name: "Adder"
+language: R
+exercise:
+  prompt: "Write add_two(x, y)."
+  gotchas: |
+    * R uses '<-' for assignment.
+    * Functions return their last expression.
+  llm_evaluation_prompt: "Grade this: {student_code}"
+"#;
+
+    #[test]
+    fn parse_accepts_gotchas_with_star_bullets() {
+        // Star-prefixed bullets (`* `) are as valid as dash-prefixed (`- `),
+        // so an author may use either Markdown bullet style.
+        let lesson = Lesson::parse(LESSON_WITH_STAR_BULLETS_GOTCHAS_YAML)
+            .expect("star-bullet gotchas should parse");
+        assert!(
+            lesson.exercise.gotchas.is_some(),
+            "star-bullet gotchas should be read"
+        );
+    }
+
+    #[test]
+    fn parse_accepts_none_gotchas() {
+        // A lesson with no gotchas key has None — no non-empty lines to
+        // validate, so it passes validation trivially.
+        let lesson = Lesson::parse(VALID_YAML).expect("valid lesson should parse");
+        assert!(lesson.exercise.gotchas.is_none());
+    }
+
+    const LESSON_WITH_EMPTY_GOTCHAS_YAML: &str = r#"
+lesson_name: "Adder"
+language: R
+exercise:
+  prompt: "Write add_two(x, y)."
+  gotchas: ""
+  llm_evaluation_prompt: "Grade this: {student_code}"
+"#;
+
+    #[test]
+    fn parse_accepts_empty_gotchas() {
+        // An empty gotchas string has no non-empty lines to validate, so it
+        // passes validation — mirroring the None case.
+        let lesson = Lesson::parse(LESSON_WITH_EMPTY_GOTCHAS_YAML)
+            .expect("an empty gotchas string should parse");
+        assert_eq!(lesson.exercise.gotchas.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn parse_still_accepts_prose_hints_when_gotchas_validated() {
+        // Validation scope is gotchas ONLY — existing prose hints (not
+        // bullet-formatted) must still parse. The r-course/add_two.yaml
+        // fixture carries prose hints at line 18; loading it must succeed.
+        let path = Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/r-course/add_two.yaml"
+        ));
+        let lesson = read_lesson_file(path).expect("prose hints fixture should still parse");
+        assert!(
+            lesson.exercise.hints.is_some(),
+            "the fixture's prose hints should still be read"
         );
     }
 

--- a/crates/core/src/site/mod.rs
+++ b/crates/core/src/site/mod.rs
@@ -116,6 +116,12 @@ pub struct SiteLesson {
     /// `skip_serializing_if`) so the contract shape stays stable — mirroring the
     /// `solution: null` precedent from ADR-0008.
     pub hints: Option<String>,
+    /// Optional learner-facing gotchas (common pitfalls), rendered as an
+    /// expandable `<details>` panel in the browser. Always serialized (null
+    /// when absent, never dropped via `skip_serializing_if`) so the contract
+    /// shape stays stable — mirroring the `solution: null` and `hints: null`
+    /// precedents from ADR-0008.
+    pub gotchas: Option<String>,
 }
 
 impl SiteLesson {
@@ -134,6 +140,7 @@ impl SiteLesson {
             packages: lesson.packages.clone(),
             solution: lesson.exercise.solution.clone(),
             hints: lesson.exercise.hints.clone(),
+            gotchas: lesson.exercise.gotchas.clone(),
         }
     }
 }
@@ -569,6 +576,10 @@ mod tests {
             site_lesson.hints, lesson.exercise.hints,
             "hints ride the contract verbatim from exercise.hints"
         );
+        assert_eq!(
+            site_lesson.gotchas, lesson.exercise.gotchas,
+            "gotchas ride the contract verbatim from exercise.gotchas"
+        );
     }
 
     #[test]
@@ -698,6 +709,68 @@ mod tests {
         assert!(
             lesson.get("hints").is_some() && lesson["hints"].is_null(),
             "a missing hints serializes as null, never dropped: {lesson}"
+        );
+    }
+
+    #[test]
+    fn plan_site_serializes_gotchas_when_present() {
+        // gotchas is optional: a lesson that carries one must serialize the text
+        // verbatim into the per-lesson JSON so the browser runner can render it.
+        // We parse a lesson with bullet-formatted gotchas and pair it with a slug
+        // from the r-course fixture (the slug is just an identifier).
+        use crate::lesson::Lesson;
+        let yaml = r#"
+lesson_name: "Gotcha Lesson"
+language: R
+exercise:
+  prompt: "Write add_two(x, y)."
+  gotchas: |
+    - R uses '<-' for assignment, not '='.
+    - Functions return their last expression automatically.
+  llm_evaluation_prompt: "Grade this: {student_code}"
+"#;
+        let lesson = Lesson::parse(yaml).expect("a lesson with gotchas should parse");
+        let slug = r_course()[0].0.clone();
+        let lessons = [(slug, lesson)];
+        let site = plan(&lessons, BuildTarget::Webr).expect("plans");
+        let first: Value = serde_json::from_str(&file(&site, "lessons/0.json").contents)
+            .expect("the per-lesson JSON parses");
+        assert!(
+            first["gotchas"].is_string(),
+            "a lesson with gotchas serializes them as a JSON string, got: {first}"
+        );
+        assert!(
+            first["gotchas"].as_str().unwrap().contains("'<-'"),
+            "the gotchas text rides the contract verbatim: {first}"
+        );
+    }
+
+    #[test]
+    fn plan_site_serializes_a_missing_gotchas_as_json_null_not_dropped() {
+        // gotchas is optional: a lesson without one must still build, with the
+        // field present-but-null so the contract shape stays stable for the
+        // runner — never silently dropped (which a `skip_serializing_if` would
+        // do, breaking `lessons[i].gotchas`). course_basic's R lesson carries
+        // none. Mirrors the solution: null and hints: null precedents.
+        let r_lessons: Vec<(LessonSlug, Lesson)> = Course::open(Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/course_basic"
+        )))
+        .expect("course_basic opens")
+        .load_lessons()
+        .expect("course_basic lessons load")
+        .into_iter()
+        .filter(|(_, lesson)| lesson.language == Language::R)
+        .collect();
+        assert!(!r_lessons.is_empty(), "course_basic has an R lesson");
+
+        let site =
+            plan(&r_lessons, BuildTarget::Webr).expect("a gotchas-less R course still plans");
+        let lesson: Value =
+            serde_json::from_str(&file(&site, "lessons/0.json").contents).expect("parses");
+        assert!(
+            lesson.get("gotchas").is_some() && lesson["gotchas"].is_null(),
+            "a missing gotchas serializes as null, never dropped: {lesson}"
         );
     }
 

--- a/crates/core/tests/fixtures/lessons/gotcha_lesson.yaml
+++ b/crates/core/tests/fixtures/lessons/gotcha_lesson.yaml
@@ -1,0 +1,21 @@
+lesson_name: "Gotcha Lesson"
+language: R
+description: "A lesson with bullet-formatted gotchas"
+
+exercise:
+  type: "function_writing"
+  prompt: |
+    Write a function called 'add_two' that takes two numeric arguments
+    (x and y) and returns their sum.
+  code_template: |
+    add_two <- function(x, y) {
+
+    }
+  gotchas: |
+    - R uses '<-' for assignment, not '='.
+    - Functions return their last expression automatically.
+    - Vectorized operations apply element-wise.
+  llm_evaluation_prompt: |
+    Evaluate the student's submission:
+    {student_code}
+    Reply with feedback.


### PR DESCRIPTION
## Summary
Add `gotchas: Option<String>` to Exercise + SiteLesson, mirroring the existing `hints` field. Bullet-point format validation for `gotchas` (each non-empty line must start with `- ` or `* `). Validation scoped to `gotchas` only — `hints` validation deferred to AC-3.

Closes #87

## Changes
- `Exercise.gotchas: Option<String>` added to `lesson.rs` (mirrors `hints`)
- `SiteLesson.gotchas: Option<String>` added to `site/mod.rs` (always serialized, null when absent)
- `from_lesson` projects `exercise.gotchas` → `site_lesson.gotchas`
- `ValidationError::InvalidBulletFormat { field: String }` variant added (parameterized for AC-3 reuse)
- `validate_semantics` extended with bullet check on `gotchas` only
- New fixture `gotcha_lesson.yaml` with bullet-formatted gotchas

## Test results
- `cargo test -p blendtutor-core gotchas`: 9/9 pass
- `cargo test --workspace`: 134 unit + 55 integration = all pass, zero regressions
- `cargo fmt --check` + `cargo clippy --tests`: clean

## Key decisions
- Validation scoped to `gotchas` ONLY — existing prose `hints` at `r-course/add_two.yaml` must still parse
- `InvalidBulletFormat { field: String }` parameterized — AC-3 reuses for `hints` without new variant
- No `#[serde(default)]` — `Option<T>` defaults to `None` naturally
- No `#[serde(skip_serializing_if)]` — always serialized (null when absent)

## Plan Reference
- Plan: `.opencode/plans/hints-gotchas-split/plan.md`
- Slice: AC-1 — gotchas schema + bullet validation
- Dependencies: Blocks #88 (UI), #89 (content+tests)