### PR TITLE
feat(site): split hints and gotchas into separate expandable sections

### DIFF
--- a/crates/core/assets/shared/lesson-runner-core.js
+++ b/crates/core/assets/shared/lesson-runner-core.js
@@ -136,11 +136,39 @@ function setEditorContent(code) {
   }
 }
 
+// Parse bullet-point text into a <ul> with <li> elements. Each line starting
+// with "- " or "* " (after trimming leading whitespace) becomes a list item;
+// the marker is stripped and the remaining text is set via textContent (never
+// parsed as HTML — untrusted lesson content, the same threat model that keeps
+// lesson titles off HTML parsing). Returns null when no bullet lines are found,
+// so the caller can fall back to a <p> with textContent for plain-text content.
+function renderBullets(text) {
+  const bullets = text
+    .split("\n")
+    .filter((line) => {
+      const trimmed = line.trimStart();
+      return trimmed.startsWith("- ") || trimmed.startsWith("* ");
+    })
+    .map((line) => line.trimStart().slice(2).trim());
+  if (bullets.length === 0) {
+    return null;
+  }
+  const ul = document.createElement("ul");
+  for (const bullet of bullets) {
+    const li = document.createElement("li");
+    li.textContent = bullet;
+    ul.appendChild(li);
+  }
+  return ul;
+}
+
 // Render the lesson's hints as an expandable <details> panel after the prompt.
 // Creates the element only when hints is non-null and non-empty; removes any
-// existing panel when switching to a lesson without hints. Uses textContent
-// (never parsed as HTML) — hints are untrusted lesson content, the same threat
-// model that keeps lesson titles off HTML parsing.
+// existing panel when switching to a lesson without hints. Bullet-point content
+// ("- " or "* " prefixed lines) renders as <ul><li>; plain text falls back to a
+// <p> with textContent. Uses textContent (never parsed as HTML) — hints are
+// untrusted lesson content, the same threat model that keeps lesson titles off
+// HTML parsing.
 function renderHints(hints) {
   const existing = document.getElementById("lesson-hints");
   if (existing) {
@@ -150,12 +178,50 @@ function renderHints(hints) {
     const details = document.createElement("details");
     details.id = "lesson-hints";
     const summary = document.createElement("summary");
-    summary.textContent = "Hints & Gotchas";
+    summary.textContent = "Hints";
     details.appendChild(summary);
-    const body = document.createElement("p");
-    body.textContent = hints;
-    details.appendChild(body);
+    const ul = renderBullets(hints);
+    if (ul) {
+      details.appendChild(ul);
+    } else {
+      const body = document.createElement("p");
+      body.textContent = hints;
+      details.appendChild(body);
+    }
     promptEl.insertAdjacentElement("afterend", details);
+  }
+}
+
+// Render the lesson's gotchas as an expandable <details> panel, inserted after
+// the hints panel (or after the prompt when no hints panel exists). Same bullet
+// parsing and textContent security model as renderHints. Independently removes
+// stale DOM on lesson switch — a lesson without gotchas removes the panel from
+// the previous lesson.
+function renderGotchas(gotchas) {
+  const existing = document.getElementById("lesson-gotchas");
+  if (existing) {
+    existing.remove();
+  }
+  if (gotchas && gotchas.trim()) {
+    const details = document.createElement("details");
+    details.id = "lesson-gotchas";
+    const summary = document.createElement("summary");
+    summary.textContent = "Gotchas";
+    details.appendChild(summary);
+    const ul = renderBullets(gotchas);
+    if (ul) {
+      details.appendChild(ul);
+    } else {
+      const body = document.createElement("p");
+      body.textContent = gotchas;
+      details.appendChild(body);
+    }
+    const hintsEl = document.getElementById("lesson-hints");
+    if (hintsEl) {
+      hintsEl.insertAdjacentElement("afterend", details);
+    } else {
+      promptEl.insertAdjacentElement("afterend", details);
+    }
   }
 }
 
@@ -163,6 +229,7 @@ function renderLesson(lesson) {
   titleEl.textContent = lesson.title;
   promptEl.textContent = lesson.prompt;
   renderHints(lesson.hints);
+  renderGotchas(lesson.gotchas);
   setEditorContent(lesson.code_template ?? "");
   outputEl.textContent = "";
   setStatus("idle", "idle");

--- a/crates/core/assets/shared/styles.css
+++ b/crates/core/assets/shared/styles.css
@@ -177,9 +177,9 @@ footer.site-footer {
   margin-bottom: var(--bt-space-md);
 }
 
-/* Hints & Gotchas — expandable <details> panel rendered by lesson-runner-core.js
- * when a lesson carries hints. Created dynamically (no static element in the
- * HTML shell); removed when switching to a lesson without hints. Dark mode is
+/* Hints — expandable <details> panel rendered by lesson-runner-core.js when a
+ * lesson carries hints. Created dynamically (no static element in the HTML
+ * shell); removed when switching to a lesson without hints. Dark mode is
  * handled by the existing :root token overrides in the @media block. */
 #lesson-hints {
   margin-bottom: var(--bt-space-md);
@@ -197,6 +197,44 @@ footer.site-footer {
 
 #lesson-hints p {
   margin: var(--bt-space-sm) 0 0;
+  color: var(--bt-color-text-secondary);
+  line-height: var(--bt-line-height);
+}
+
+#lesson-hints ul {
+  margin: var(--bt-space-sm) 0 0;
+  padding-left: var(--bt-space-lg);
+  color: var(--bt-color-text-secondary);
+  line-height: var(--bt-line-height);
+}
+
+/* Gotchas — expandable <details> panel rendered by lesson-runner-core.js when a
+ * lesson carries gotchas. Created dynamically (no static element in the HTML
+ * shell); removed when switching to a lesson without gotchas. Dark mode is
+ * handled by the existing :root token overrides in the @media block. */
+#lesson-gotchas {
+  margin-bottom: var(--bt-space-md);
+  padding: var(--bt-space-sm) var(--bt-space-md);
+  border: 1px solid var(--bt-color-border);
+  border-radius: var(--bt-radius-md);
+  background: var(--bt-color-surface-code);
+}
+
+#lesson-gotchas summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--bt-color-text-secondary);
+}
+
+#lesson-gotchas p {
+  margin: var(--bt-space-sm) 0 0;
+  color: var(--bt-color-text-secondary);
+  line-height: var(--bt-line-height);
+}
+
+#lesson-gotchas ul {
+  margin: var(--bt-space-sm) 0 0;
+  padding-left: var(--bt-space-lg);
   color: var(--bt-color-text-secondary);
   line-height: var(--bt-line-height);
 }

--- a/crates/core/src/site/mod.rs
+++ b/crates/core/src/site/mod.rs
@@ -2029,6 +2029,130 @@ exercise:
         );
     }
 
+    #[test]
+    fn plan_site_runner_core_splits_hints_and_gotchas() {
+        // AC-2 (issue #88): Split hints and gotchas into separate expandable UI
+        // sections. The lesson runner core must have TWO separate functions —
+        // renderHints and renderGotchas — each creating its own <details> with a
+        // unique ID, parsing bullet lines into <ul><li>, using textContent (never
+        // innerHTML), and independently removing stale DOM. renderLesson must
+        // call both. The combined "Hints & Gotchas" panel is gone.
+        let webr = plan(&r_course(), BuildTarget::Webr).expect("plans");
+        let core = &file(&webr, "lesson-runner-core.js").contents;
+
+        // Clause 1: renderGotchas function exists (new — the split).
+        assert!(
+            core.contains("function renderGotchas("),
+            "lesson-runner-core.js must define a renderGotchas function"
+        );
+
+        // Clause 2: renderHints function still exists (now hints-only).
+        assert!(
+            core.contains("function renderHints("),
+            "lesson-runner-core.js must define a renderHints function"
+        );
+
+        // Clause 3: lesson.gotchas is referenced (the field is consumed).
+        assert!(
+            core.contains("lesson.gotchas"),
+            "lesson-runner-core.js must reference lesson.gotchas"
+        );
+
+        // Clause 4: unique ID "lesson-gotchas" for the gotchas details.
+        assert!(
+            core.contains(r#""lesson-gotchas""#),
+            "lesson-runner-core.js must set id=\"lesson-gotchas\" on the gotchas details"
+        );
+
+        // Clause 5: the combined "Hints & Gotchas" label is gone.
+        assert!(
+            !core.contains("Hints & Gotchas"),
+            "lesson-runner-core.js must NOT use the combined 'Hints & Gotchas' label"
+        );
+
+        // Clause 6: bullet parsing creates <ul> and <li> elements.
+        assert!(
+            core.contains(r#""ul""#),
+            "lesson-runner-core.js must create <ul> elements for bullet parsing"
+        );
+        assert!(
+            core.contains(r#""li""#),
+            "lesson-runner-core.js must create <li> elements for bullet parsing"
+        );
+
+        // Clause 7: bullet marker detection uses startsWith (for "- " or "* ").
+        assert!(
+            core.contains("startsWith"),
+            "lesson-runner-core.js must use startsWith for bullet marker detection"
+        );
+
+        // Clause 8: textContent is used for <li> text (not innerHTML).
+        // The existing !innerHTML invariant (plan_site_shells_load_codemirror_as_import
+        // clause 6) covers the negative case.
+        assert!(
+            core.contains("textContent"),
+            "lesson-runner-core.js must use textContent for bullet text"
+        );
+
+        // Clause 9: each function independently removes stale DOM (>= 2 .remove()).
+        let remove_count = core.matches(".remove()").count();
+        assert!(
+            remove_count >= 2,
+            "lesson-runner-core.js must have >= 2 .remove() calls (one per section), got {remove_count}"
+        );
+
+        // Clause 10: renderLesson calls both renderHints and renderGotchas.
+        assert!(
+            core.contains("renderHints(lesson.hints)"),
+            "renderLesson must call renderHints(lesson.hints)"
+        );
+        assert!(
+            core.contains("renderGotchas(lesson.gotchas)"),
+            "renderLesson must call renderGotchas(lesson.gotchas)"
+        );
+    }
+
+    #[test]
+    fn plan_site_styles_css_has_gotchas_panel_rules() {
+        // AC-2 (issue #88): The #lesson-gotchas <details> panel must be styled
+        // via var(--bt-*) tokens, parallel to #lesson-hints. Dark mode is
+        // handled by the existing :root token overrides in the @media block —
+        // no hardcoded hex literals in the gotchas rules.
+        let webr = plan(&r_course(), BuildTarget::Webr).expect("plans");
+        let css = &file(&webr, "styles.css").contents;
+
+        // Clause 1: #lesson-gotchas selector exists.
+        assert!(
+            css.contains("#lesson-gotchas"),
+            "styles.css must contain a #lesson-gotchas rule"
+        );
+
+        // Clause 2: the gotchas summary toggle has cursor: pointer.
+        let gotchas_pos = css
+            .find("#lesson-gotchas")
+            .expect("#lesson-gotchas rule exists");
+        let after_gotchas = &css[gotchas_pos..];
+        assert!(
+            after_gotchas.contains("cursor: pointer") || after_gotchas.contains("cursor:pointer"),
+            "styles.css must set cursor: pointer on the gotchas summary toggle"
+        );
+
+        // Clause 3: the gotchas rules use var(--bt-*) tokens (no hardcoded hex).
+        let brace = after_gotchas
+            .find('{')
+            .expect("#lesson-gotchas must have an opening brace");
+        let body_start = gotchas_pos + brace + 1;
+        let body_slice = &css[body_start..];
+        let close = body_slice
+            .find('}')
+            .expect("#lesson-gotchas block must close");
+        let gotchas_body = &css[body_start..body_start + close];
+        assert!(
+            gotchas_body.contains("var(--bt-"),
+            "#lesson-gotchas must use var(--bt-*) tokens, got: {gotchas_body}"
+        );
+    }
+
     /// Detect whether a `.cm-gutters` rule sets display:none or visibility:hidden.
     fn gutter_hidden(css: &str) -> bool {
         let mut rest = css;

--- a/docs/evidence/88/test-suite.log
+++ b/docs/evidence/88/test-suite.log
@@ -1,0 +1,356 @@
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
+     Running unittests src/main.rs (target/debug/deps/blendtutor-78897dbdb2b5c55f)
+
+running 9 tests
+test commands::eval::tests::sibling_suite_of_a_path_without_a_file_name_is_the_prefix_alone ... ok
+test commands::eval::tests::sibling_suite_keeps_a_bare_file_name_in_the_current_directory ... ok
+test commands::eval::tests::sibling_suite_prefixes_the_lesson_file_name_with_eval ... ok
+test output::tests::list_renders_an_empty_course_in_both_formats ... ok
+test output::tests::list_json_separates_found_rows_from_failed_rows ... ok
+test output::tests::list_human_matches_snapshot ... ok
+test output::tests::eval_human_matches_snapshot ... ok
+test output::tests::validate_human_matches_snapshot ... ok
+test output::tests::validate_human_invalid_matches_snapshot ... ok
+
+test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+
+     Running tests/build.rs (target/debug/deps/build-b1e5f10ad570ac6c)
+
+running 14 tests
+test build_refuses_a_language_target_mismatch_before_writing_anything ... ok
+test build_emits_lesson_json_with_packages_array ... ok
+test build_emits_empty_packages_array_when_lesson_has_no_packages ... ok
+test build_webr_ships_the_byok_fireworks_feedback_seam ... ok
+test build_webr_ships_the_byok_anthropic_feedback_seam ... ok
+test build_webr_ships_the_multi_provider_feedback_seam ... ok
+test build_webr_emits_a_deployable_r_lesson_site ... ok
+test corrupt_eval_report_fails_the_build_loudly ... ok
+test build_pyodide_emits_a_deployable_python_lesson_site ... ok
+test missing_report_builds_with_not_validated_page ... ok
+test eval_report_page_reflects_actual_accuracy ... ok
+test build_pyodide_ships_the_same_shared_feedback_seam ... ok
+test build_webr_styles_byok_feedback_panel ... ok
+test build_dark_mode_token_overrides ... ok
+
+test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.37s
+
+     Running tests/cli.rs (target/debug/deps/cli-e5fdfcb641f75fdc)
+
+running 2 tests
+test version_prints_crate_version ... ok
+test help_lists_subcommands ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running tests/cutover.rs (target/debug/deps/cutover-cf5a1576aef45451)
+
+running 2 tests
+test r_package_artifacts_are_absent_from_root ... ok
+test no_r_package_sources_are_tracked ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+
+     Running tests/eval.rs (target/debug/deps/eval-6d3a09b074180302)
+
+running 2 tests
+test eval_json_emits_per_case_verdicts_and_aggregate ... ok
+test eval_reports_aggregate_accuracy_and_per_case_results ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.27s
+
+     Running tests/hints_content.rs (target/debug/deps/hints_content-ec73f3b67ce288cb)
+
+running 8 tests
+test r_lesson_2_prompt_retains_stress_6 ... ok
+test python_lesson_2_prompt_retains_stress_6 ... ok
+test r_hints_satisfy_all_invariants ... ok
+test python_hints_satisfy_all_invariants ... ok
+test build_python_course_emits_non_null_hints ... ok
+test build_r_course_emits_non_null_hints ... ok
+test r_validate_each_lesson_exits_zero ... ok
+test python_validate_each_lesson_exits_zero ... ok
+
+test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+
+     Running tests/init.rs (target/debug/deps/init-c5e64538711fd323)
+
+running 2 tests
+test init_refuses_a_nonempty_target_leaving_it_untouched ... ok
+test init_scaffolds_a_ready_course_that_list_accepts ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+
+     Running tests/list.rs (target/debug/deps/list-082a03a2ff1c7a67)
+
+running 3 tests
+test list_on_a_directory_without_a_manifest_exits_nonzero ... ok
+test list_reports_each_lessons_id_language_and_title ... ok
+test list_reports_a_malformed_lesson_as_an_error_row_without_losing_the_good_ones ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running tests/new.rs (target/debug/deps/new-cd8cae3d7a5a8b81)
+
+running 3 tests
+test new_lesson_refuses_a_duplicate_id_without_clobbering ... ok
+test new_lesson_python_creates_a_lesson_that_validates_and_lists ... ok
+test new_lesson_r_creates_a_lesson_that_validates_and_lists ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+
+     Running tests/readme.rs (target/debug/deps/readme-01876217fcf2db51)
+
+running 1 test
+test readme_documents_the_cli_install_and_workflow ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running tests/run.rs (target/debug/deps/run-0820e0e778dd75c5)
+
+running 7 tests
+test run_missing_code_exits_one ... ok
+test run_provider_error_exits_one ... ok
+test run_format_json_stays_clean_under_logging ... ok
+test run_human_format_is_not_json ... ok
+test run_format_json_emits_one_typed_report ... ok
+test run_correct_code_reports_correct_and_exit_zero ... ok
+test run_incorrect_submission_exits_two_with_feedback ... ok
+
+test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.14s
+
+     Running tests/validate.rs (target/debug/deps/validate-9afd1ae7c7a72246)
+
+running 4 tests
+test validate_lesson_without_student_code_placeholder_exits_nonzero_naming_the_rule ... ok
+test validate_invalid_lesson_exits_nonzero_naming_problem ... ok
+test validate_valid_lesson_reports_ok_and_exit_zero ... ok
+test validate_json_emits_documented_object_with_exit_code_parity ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+
+     Running tests/write_less_code_python.rs (target/debug/deps/write_less_code_python-a6f079db8864f351)
+
+running 10 tests
+test lesson_2_prompt_contains_literal_stress_6 ... ok
+test eval_suites_have_correct_case_distribution ... ok
+test lesson_4_solution_uses_explicit_for_loop_not_list_comprehension ... ok
+test each_lesson_is_valid_python_with_student_code_and_textbook ... ok
+test checks_non_empty_and_specific ... ok
+test packages_bidirectional_pandas_iff_used ... ok
+test list_returns_five_python_lessons ... ok
+test validate_each_lesson_exits_zero ... ok
+test eval_suites_have_near_miss_that_runs_cleanly ... ok
+test run_solution_exits_zero_with_correct ... ok
+
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.89s
+
+     Running tests/write_less_code_r.rs (target/debug/deps/write_less_code_r-170a2c73000824aa)
+
+running 13 tests
+test layer8_each_lesson_has_textbook_reference ... ok
+test layer7_solutions_are_self_contained ... ok
+test layer5_eval_suites_have_minimum_cases ... ok
+test negative_lesson2_check_references_stress_6_rev ... ok
+test layer2_list_returns_five_r_lessons ... ok
+test layer1_validate_exits_zero_for_all_lessons ... ok
+test negative_lesson4_solution_uses_purrr_dplyr ... ok
+test layer9_run_exits_zero_with_correct_verdict ... ok
+test layer3_solutions_execute_cleanly ... ok
+test layer6_each_lesson_has_genuine_near_miss ... ok
+test negative_checks_fail_against_wrong_submissions ... ok
+test near_miss_submissions_fail_at_least_one_check ... ok
+test layer4_checks_pass_against_reference_solution ... ok
+
+test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.61s
+
+     Running unittests src/lib.rs (target/debug/deps/blendtutor_core-afe9e8a79b46e2b0)
+
+running 136 tests
+test course::tests::open_missing_manifest_is_a_read_error_not_a_parse_error ... ok
+test course::tests::manifest_error_display_and_source_distinguish_each_variant ... ok
+test eval::tests::aggregate_is_matched_over_total_and_zero_for_an_empty_suite ... ok
+test eval::tests::case_result_derives_matched_from_score_case ... ok
+test course::tests::manifest_parse_reads_each_entrys_id_and_path ... ok
+test course::tests::manifest_parse_rejects_unknown_key_so_author_typos_surface ... ok
+test eval::tests::eval_run_error_names_the_one_based_case_and_chains_its_source ... ok
+test course::tests::manifest_parse_rejects_a_path_escaping_the_course_directory ... ok
+test eval::tests::expected_verdict_serializes_to_its_canonical_token ... ok
+test eval::tests::from_token_maps_the_two_polarity_words_and_rejects_others ... ok
+test eval::tests::score_case_matches_same_polarity_and_rejects_the_opposite ... ok
+test eval::tests::scores_two_of_three_and_aggregates ... ok
+test eval::tests::structural_error_surfaces_the_underlying_parser_message ... ok
+test eval::tests::unknown_verdict_error_names_the_case_index_and_quotes_the_token ... ok
+test eval::tests::verdict_polarity_drops_the_feedback_message ... ok
+test eval::tests::parse_eval_suite_surfaces_unknown_verdict_with_its_case_index_and_token ... ok
+test course::tests::discover_summarizes_each_lesson_with_its_slug_language_and_title ... ok
+test eval::tests::parse_rejects_unknown_key_so_author_typos_surface ... ok
+test grade::tests::a_submission_whose_interpreter_cannot_launch_makes_checks_notrun ... ok
+test course::tests::load_lessons_returns_every_lesson_in_full_and_in_author_order ... ok
+test grade::tests::checks_are_classified_element_wise_in_order ... ok
+test grade::tests::a_submission_that_exits_nonzero_makes_every_check_notrun ... ok
+test grade::tests::a_check_whose_interpreter_cannot_launch_is_a_fail ... ok
+test course::tests::discovery_error_display_and_source_surface_the_underlying_load_failure ... ok
+test grade::tests::no_checks_runs_nothing_and_returns_empty ... ok
+test grade::tests::select_runner_dispatches_a_python_lesson_to_the_python_runner ... ok
+test grade::tests::select_runner_dispatches_an_r_lesson_to_the_r_runner ... ok
+test grade::tests::select_runner_threads_packages_to_python_runner ... ok
+test course::tests::load_lessons_fails_on_the_first_broken_lesson_rather_than_dropping_it ... ok
+test course::tests::discover_reports_a_malformed_lesson_as_an_error_row_keeping_the_good_ones ... ok
+test lesson::tests::load_error_display_and_source_surface_the_cause ... ok
+test lesson::tests::lesson_id_displays_its_value ... ok
+test lesson::tests::parse_accepts_valid_lesson ... ok
+test lesson::tests::parse_defaults_hints_to_none_when_absent ... ok
+test lesson::tests::parse_accepts_none_gotchas ... ok
+test lesson::tests::lesson_json_roundtrip_preserves_value ... ok
+test lesson::tests::parse_accepts_empty_gotchas ... ok
+test lesson::tests::parse_defaults_solution_to_none_when_absent ... ok
+test lesson::tests::parse_defaults_packages_to_empty_when_absent ... ok
+test lesson::tests::parse_accepts_gotchas_with_star_bullets ... ok
+test lesson::tests::parse_defaults_checks_to_empty_when_absent ... ok
+test lesson::tests::parse_reads_an_optional_gotchas_field ... ok
+test lesson::tests::parse_reads_an_optional_reference_solution ... ok
+test lesson::tests::parse_rejects_gotchas_with_non_bullet_lines ... ok
+test lesson::tests::parse_defaults_gotchas_to_none_when_absent ... ok
+test lesson::tests::parse_rejects_prompt_missing_student_code_placeholder ... ok
+test lesson::tests::parse_reads_packages_as_ordered_strings ... ok
+test lesson::tests::parse_reads_an_optional_hints_field ... ok
+test lesson::tests::read_lesson_file_missing_path_is_a_read_error_not_a_validation_error ... ok
+test lesson::tests::parse_rejects_missing_required_field_naming_it ... ok
+test lesson::tests::parse_rejects_unknown_exercise_type ... ok
+test lesson::tests::parse_rejects_unknown_language ... ok
+test lesson::tests::parse_reads_checks_as_ordered_code_strings ... ok
+test lesson::tests::parse_still_accepts_prose_hints_when_gotchas_validated ... ok
+test llm::feedback::tests::completion_errors_map_to_the_completion_kind ... ok
+test llm::feedback::tests::feedback_maps_to_the_matching_verdict_variant ... ok
+test lesson::tests::parse_rejects_unknown_field_so_author_typos_surface ... ok
+test llm::prompt::tests::neutralize_rewrites_every_structural_token ... ok
+test llm::feedback::tests::extraction_failures_map_to_the_extraction_kind ... ok
+test llm::prompt::tests::neutralize_marker_introduces_no_structural_token ... ok
+test lesson::tests::read_lesson_file_loads_and_parses_the_ported_fixture ... ok
+test llm::prompt::tests::render_check_distinguishes_the_three_outcomes ... ok
+test llm::prompt::tests::render_check_neutralizes_a_token_in_the_outcome_detail ... ok
+test llm::provider::tests::each_provider_has_a_recognizable_default_model ... ok
+test llm::provider::tests::each_provider_names_its_own_key_var ... ok
+test llm::prompt::tests::render_checks_labels_each_outcome_with_its_check_in_order ... ok
+test llm::provider::tests::each_provider_targets_its_own_api_host ... ok
+test llm::prompt::tests::render_checks_renders_no_line_for_a_check_without_an_outcome ... ok
+test llm::provider::tests::fireworks_is_the_default_provider ... ok
+test run::tests::json_splits_the_verdict_into_a_string_tag_and_feedback ... ok
+test run::tests::run_error_labels_each_stage_and_exposes_its_source ... ok
+test lesson::tests::read_lesson_file_invalid_contents_is_a_validation_error ... ok
+test llm::prompt::tests::render_checks_never_drops_a_verdict_when_outcomes_exceed_checks ... ok
+test runner::python::tests::interpreter_includes_with_flags_for_packages ... ok
+test runner::python::tests::interpreter_omits_with_flags_when_packages_empty ... ok
+test run::tests::run_report_json_roundtrip_preserves_value ... ok
+test run::tests::json_tags_an_incorrect_verdict_distinctly ... ok
+test runner::tests::from_capture_keeps_streams_distinct_and_passes_exit_through ... ok
+test runner::tests::runner_error_displays_its_stage_and_exposes_the_io_source ... ok
+test scaffold::tests::add_lesson_error_display_and_source_distinguish_each_variant ... ok
+test scaffold::tests::is_valid_slug_accepts_word_chars_hyphens_and_underscores_but_nothing_else ... ok
+test scaffold::tests::plan_lists_the_starter_files_as_pure_data ... ok
+test scaffold::tests::add_lesson_refuses_a_non_course_directory_without_leaving_an_orphan ... ok
+test scaffold::tests::lesson_template_produces_a_valid_python_lesson ... ok
+test scaffold::tests::lesson_template_produces_a_valid_r_lesson ... ok
+test scaffold::tests::is_empty_target_surfaces_a_non_notfound_error_rather_than_reading_it_as_empty ... ok
+test scaffold::tests::scaffold_error_display_and_source_distinguish_each_variant ... ok
+test site::tests::build_target_display_names_each_runtime ... ok
+test site::tests::build_target_language_maps_each_runtime_to_its_language ... ok
+test site::tests::eval_report_error_displays_each_variant_and_chains_its_source ... ok
+test site::tests::eval_results_html_not_validated_renders_an_explicit_marker ... ok
+test site::tests::eval_results_html_validated_renders_the_accuracy_and_validated_marker ... ok
+test site::tests::eval_summary_from_report_json_rejects_a_malformed_report ... ok
+test scaffold::tests::scaffold_course_refuses_a_broken_symlink_target_instead_of_a_cryptic_write_error ... ok
+test site::tests::eval_summary_from_report_json_rejects_an_out_of_range_accuracy ... ok
+test site::tests::eval_summary_from_report_json_takes_the_accuracy_as_is ... ok
+test scaffold::tests::the_scaffolded_lesson_eval_and_manifest_parse_with_production_parsers ... ok
+test scaffold::tests::scaffold_course_refuses_a_nonempty_target_before_writing_anything ... ok
+test site::tests::plan_error_language_mismatch_displays_the_clash_with_no_nested_source ... ok
+test site::tests::plan_site_cm6_editor_ux_extensions_configured ... ok
+test site::tests::plan_site_cm6_cursor_visible_in_dark_mode ... ok
+test site::tests::plan_site_assembles_the_shared_byok_feedback_backend ... ok
+test site::tests::plan_site_carries_the_same_shared_core_and_shim_across_both_targets ... ok
+test scaffold::tests::scaffold_course_accepts_an_existing_empty_directory ... ok
+test scaffold::tests::scaffold_course_creates_the_target_directory_when_absent ... ok
+test scaffold::tests::add_lesson_refuses_an_unsafe_id_before_writing_anything ... ok
+test site::tests::plan_site_pyodide_assembles_the_shell_runner_core_shim_and_one_json_per_lesson ... ok
+test scaffold::tests::add_lesson_refuses_a_duplicate_without_clobbering_or_double_registering ... ok
+test site::tests::plan_site_serializes_a_missing_gotchas_as_json_null_not_dropped ... ok
+test site::tests::plan_site_runner_core_renders_hints_as_expandable_details ... ok
+test site::tests::plan_site_runner_core_splits_hints_and_gotchas ... ok
+test site::tests::plan_site_serializes_a_missing_hints_as_json_null_not_dropped ... ok
+test site::tests::plan_site_refuses_an_r_course_built_for_the_pyodide_target ... ok
+test site::tests::plan_site_serializes_a_missing_solution_as_json_null_not_dropped ... ok
+test site::tests::plan_site_serializes_gotchas_when_present ... ok
+test scaffold::tests::add_lesson_writes_the_file_and_registers_it_so_the_course_lists_it ... ok
+test scaffold::tests::scaffold_course_writes_every_planned_file_verbatim ... ok
+test site::tests::plan_site_serializes_packages_as_array_even_when_empty ... ok
+test site::tests::plan_site_folds_the_eval_results_page_for_each_state ... ok
+test site::tests::plan_site_shells_differ_only_by_three_known_diffs ... ok
+test site::tests::plan_site_serializes_each_lesson_to_the_browser_contract ... ok
+test site::tests::plan_site_shells_contain_semantic_regions ... ok
+test site::tests::plan_site_shells_have_correct_head_load_order ... ok
+test site::tests::plan_site_serializes_hints_when_present ... ok
+test site::tests::plan_site_styles_css_has_gotchas_panel_rules ... ok
+test site::tests::plan_site_shells_have_link_and_no_inline_style ... ok
+test tests::display_names_the_command_and_the_unimplemented_state ... ok
+test site::tests::plan_site_styles_css_has_hints_panel_rules ... ok
+test site::tests::plan_site_webr_assembles_the_shell_runner_shim_and_one_json_per_lesson ... ok
+test site::tests::plan_site_styles_css_declares_tokens_and_uses_them ... ok
+test site::tests::plan_site_shells_load_codemirror_as_import ... ok
+test site::tests::site_lesson_from_lesson_projects_each_contract_field ... ok
+test site::tests::plan_site_styles_css_is_present_for_both_targets ... ok
+test site::tests::write_site_writes_every_planned_file_to_disk ... ok
+test site::tests::plan_site_emits_vendored_codemirror_bundle ... ok
+test site::tests::plan_site_workspace_styles_use_tokens_and_status_renders_as_pill ... ok
+
+test result: ok. 136 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+
+     Running tests/eval.rs (target/debug/deps/eval-ec86ef06241a5f95)
+
+running 2 tests
+test rejects_unknown_verdict_naming_the_offending_case ... ok
+test parses_ten_fireworks_vitals_cases_into_typed_suite ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running tests/grade.rs (target/debug/deps/grade-53a9b289dbbe82fb)
+
+running 3 tests
+test python_lesson_selects_python_runner ... ok
+test submission_error_is_notrun_not_fail ... ok
+test r_runner_reports_per_check_pass_fail ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.25s
+
+     Running tests/llm.rs (target/debug/deps/llm-919eedfbc5f220b8)
+
+running 9 tests
+test build_prompt_neutralizes_injected_delimiter ... ok
+test build_prompt_is_deterministic_offline ... ok
+test fireworks_empty_key_errs_before_request ... ok
+test build_prompt_renders_delimited_code_and_labeled_sections ... ok
+test request_feedback_correct_verdict ... ok
+test anthropic_missing_key_errs_before_request ... ok
+test fireworks_missing_key_errs_before_request ... ok
+test fireworks_present_key_reaches_server ... ok
+test request_feedback_incorrect_verdict_and_missing_field_errors ... ok
+
+test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+
+     Running tests/runner.rs (target/debug/deps/runner-2f4059e7e610a19d)
+
+running 5 tests
+test python_captures_streams_distinctly ... ok
+test captures_stdout_stderr_exit_separately ... ok
+test runs_in_isolated_temp_dir_cleaned_up ... ok
+test python_infinite_loop_times_out ... ok
+test timeout_kills_process_tree_under_natural_runtime ... ok
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.02s
+
+   Doc-tests blendtutor_core
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+


### PR DESCRIPTION
## Summary
Replace the single "Hints & Gotchas" expandable panel with two separate `<details>` sections: "Hints" and "Gotchas". Each renders bullet-point content (`- ` or `* ` prefixed lines) as `<ul><li>` elements with `textContent` (never `innerHTML`). Plain-text content falls back to `<p>` with `textContent`. Null/empty fields → section not rendered. Gotchas section inserted after hints section.

## Issue
Closes #88

## ACs implemented
- [x] `renderHints(hints)` creates `<details id="lesson-hints">` with summary "Hints"
- [x] `renderGotchas(gotchas)` creates `<details id="lesson-gotchas">` with summary "Gotchas"
- [x] Bullet lines (`- ` or `* ` prefix) render as `<ul><li>` with marker stripped
- [x] `<li>` text via `textContent` (never `innerHTML`)
- [x] Each section independently handles null/empty + `.remove()` stale DOM
- [x] Gotchas section inserted after hints section
- [x] CSS `#lesson-gotchas` rules with `var(--bt-*)` tokens
- [x] `renderLesson` calls both renderHints and renderGotchas

## Test plan
- [x] All tests pass (`cargo test --workspace`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --tests` clean
- [x] PR review findings resolved

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested (no "Hints & Gotchas" combined label)
- [x] Verification medium satisfied (code — string assertions on planned file contents)
- [x] Design intent respected
- [x] No scope creep