### PR TITLE
fix(ui): increase cursor visibility in dark mode for accessibility

### DIFF
--- a/crates/cli/tests/build.rs
+++ b/crates/cli/tests/build.rs
@@ -1506,16 +1506,16 @@ fn build_dark_mode_token_overrides() {
         .filter(|(name, _)| name.starts_with("--bt-color-"))
         .collect();
 
-    // Clause 3: All 20 tokens from light :root declared in dark :root
+    // Clause 3: All 21 tokens from light :root declared in dark :root
     assert_eq!(
         light_tokens.len(),
-        20,
-        "light :root must have exactly 20 --bt-color-* tokens"
+        21,
+        "light :root must have exactly 21 --bt-color-* tokens"
     );
     assert_eq!(
         dark_tokens.len(),
-        20,
-        "dark :root must have exactly 20 --bt-color-* tokens"
+        21,
+        "dark :root must have exactly 21 --bt-color-* tokens"
     );
     for (name, _) in &light_tokens {
         assert!(

--- a/crates/core/assets/shared/styles.css
+++ b/crates/core/assets/shared/styles.css
@@ -78,6 +78,10 @@
   --bt-color-syntax-variable: #000;
   --bt-color-syntax-function: #30a;
   --bt-color-syntax-operator: #000;
+
+  /* Cursor — dark on light background (same as CM6 default black). The
+   * dark-mode override sets this to #ffffff for maximum contrast. */
+  --bt-color-cursor: #1a1a1a;
 }
 
 /* ── Semantic region rules ─────────────────────────────────────── */
@@ -502,7 +506,7 @@ footer.site-footer {
 }
 
 /* ── Dark mode ────────────────────────────────────────────────────
- * Overrides all 20 --bt-color-* tokens inside @media (prefers-color-scheme: dark)
+ * Overrides all 21 --bt-color-* tokens inside @media (prefers-color-scheme: dark)
  * for WCAG AA contrast (4.5:1 text, 3:1 UI/large text). No non-color tokens.
  * The :root block is extracted by the test via brace-counting on the @media
  * selector, then brace-counting again on :root within the media block body.
@@ -542,6 +546,11 @@ footer.site-footer {
     --bt-color-syntax-variable: #d4d4d4;
     --bt-color-syntax-function: #dcdcaa;
     --bt-color-syntax-operator: #d4d4d4;
+
+    /* Cursor — pure white for maximum contrast against the dark surface-code
+     * background. The previous value (text-primary gray) was visible but
+     * faint at 1.2px width; pure white at 2px is clearly visible. */
+    --bt-color-cursor: #ffffff;
   }
 
   /* Idle pill text: surface provides sufficient contrast on dark status-idle */
@@ -575,8 +584,15 @@ footer.site-footer {
    * background. Uses .cm-editor prefix to match CM6's base-theme specificity
    * (0,2,0) — a bare .cm-cursor (0,1,0) would lose to CM6's injected rule.
    * styles.css loads after CM6's injected style tag (CM6 inserts as
-   * firstChild of head), so equal specificity resolves in our favor. */
+   * firstChild of head), so equal specificity resolves in our favor.
+   *
+   * v2: cursor widened to 2px (from CM6 default 1.2px) and color set to
+   * pure white via --bt-color-cursor for accessibility — the previous
+   * text-primary gray at 1.2px was visible but faint. margin-left adjusted
+   * to -1px to center the wider cursor on the insertion point. */
   .cm-editor .cm-cursor {
-    border-left-color: var(--bt-color-text-primary);
+    border-left-color: var(--bt-color-cursor);
+    border-left-width: 2px;
+    margin-left: -1px;
   }
 }

--- a/crates/core/src/site/mod.rs
+++ b/crates/core/src/site/mod.rs
@@ -1928,8 +1928,13 @@ exercise:
         // Clause 4: cursor width is 2px (wider than CM6 default 1.2px).
         // The wider cursor is more visible at the cost of slightly less
         // precision — acceptable for accessibility.
+        //
+        // The substring "width: 2px" is specific: it matches
+        // "border-left-width: 2px" but NOT "border-left-width: 1.2px"
+        // (the CM6 default). A naive contains("2px") would falsely pass
+        // on 1.2px since "1.2px" contains "2px".
         assert!(
-            cursor_body.contains("border-left-width") && cursor_body.contains("2px"),
+            cursor_body.contains("width: 2px"),
             ".cm-cursor dark-mode rule must set border-left-width: 2px \
              (CM6 default 1.2px is too faint — widened for accessibility)"
         );

--- a/crates/core/src/site/mod.rs
+++ b/crates/core/src/site/mod.rs
@@ -1853,10 +1853,18 @@ exercise:
         // override inside the @media (prefers-color-scheme: dark) block, the
         // cursor stays black and is invisible on the dark surface-code background.
         //
-        // 3 clauses pin the fix:
+        // v2: the initial fix (PR #83) set the cursor to --bt-color-text-primary
+        // (#e0e0e0) at CM6's default 1.2px width. Users reported it was still
+        // faint. v2 widens to 2px and uses pure white (#ffffff) via a dedicated
+        // --bt-color-cursor token for maximum contrast.
+        //
+        // 5 clauses pin the fix:
         //   1. The @media block contains a .cm-editor .cm-cursor rule
         //   2. The rule sets border-left-color (overriding CM6's default black)
         //   3. The border-left-color is NOT black (must be a light value)
+        //   4. The rule sets border-left-width: 2px (wider than CM6 default 1.2px)
+        //   5. The cursor color uses --bt-color-cursor, defined as #ffffff in the
+        //      dark-mode :root block (high-contrast pure white)
         let webr = plan(&r_course(), BuildTarget::Webr).expect("plans");
         let css = &file(&webr, "styles.css").contents;
 
@@ -1915,6 +1923,30 @@ exercise:
             !cursor_body.contains("black"),
             ".cm-cursor border-left-color must NOT be black \
              (invisible on dark surface-code background)"
+        );
+
+        // Clause 4: cursor width is 2px (wider than CM6 default 1.2px).
+        // The wider cursor is more visible at the cost of slightly less
+        // precision — acceptable for accessibility.
+        assert!(
+            cursor_body.contains("border-left-width") && cursor_body.contains("2px"),
+            ".cm-cursor dark-mode rule must set border-left-width: 2px \
+             (CM6 default 1.2px is too faint — widened for accessibility)"
+        );
+
+        // Clause 5: cursor color uses --bt-color-cursor token, which is defined
+        // as #ffffff (pure white) in the dark-mode :root block. This is the
+        // high-contrast color — #e0e0e0 (the previous value via
+        // --bt-color-text-primary) was visible but faint.
+        assert!(
+            cursor_body.contains("var(--bt-color-cursor)"),
+            ".cm-cursor dark-mode rule must use var(--bt-color-cursor) \
+             (dedicated high-contrast cursor token, not --bt-color-text-primary)"
+        );
+        assert!(
+            media_body.contains("--bt-color-cursor: #ffffff"),
+            "dark-mode :root must define --bt-color-cursor: #ffffff \
+             (pure white for maximum contrast against #2d2d2d background)"
         );
     }
 


### PR DESCRIPTION
Makes the CodeMirror 6 editor cursor more visible in dark mode. Previous fix (PR #83) made it visible but still faint. Increases contrast and width for accessibility.

## Changes
- Added `--bt-color-cursor` design token to both light (`#1a1a1a`) and dark (`#ffffff`) `:root` blocks
- Dark mode cursor rule now uses `var(--bt-color-cursor)` (pure white) instead of `var(--bt-color-text-primary)` (`#e0e0e0` — light gray, faint)
- Widened cursor from CM6 default 1.2px to 2px via `border-left-width: 2px`
- Adjusted `margin-left: -1px` to center the wider cursor on the insertion point
- Light mode unaffected — cursor rule is inside `@media (prefers-color-scheme: dark)` block

## Test plan
- [x] Extended `plan_site_cm6_cursor_visible_in_dark_mode` test with 2 new clauses (5 total):
  - Clause 4: cursor width is 2px (wider than CM6 default 1.2px)
  - Clause 5: cursor color uses `--bt-color-cursor` token, defined as `#ffffff` in dark `:root`
- [x] Updated `build_dark_mode_token_overrides` test: token count 20 → 21
- [x] All 241 workspace tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --tests` clean