### PR TITLE
fix(ui): add caret-color + !important for dark mode cursor visibility

### DIFF
--- a/crates/core/assets/shared/styles.css
+++ b/crates/core/assets/shared/styles.css
@@ -614,23 +614,38 @@ footer.site-footer {
     outline-color: rgba(255, 255, 255, 0.2);
   }
 
-  /* Cursor — CM6's default cursor is borderLeft: 1.2px solid black. The
-   * &dark .cm-cursor override in CM6's base theme only fires when the editor
-   * has the cm-dark class (set via EditorView.darkTheme), which this app
-   * does NOT use — dark mode is driven by prefers-color-scheme. Without this
-   * rule the cursor stays black and is invisible on the dark surface-code
-   * background. Uses .cm-editor prefix to match CM6's base-theme specificity
-   * (0,2,0) — a bare .cm-cursor (0,1,0) would lose to CM6's injected rule.
-   * styles.css loads after CM6's injected style tag (CM6 inserts as
-   * firstChild of head), so equal specificity resolves in our favor.
-   *
-   * v2: cursor widened to 2px (from CM6 default 1.2px) and color set to
-   * pure white via --bt-color-cursor for accessibility — the previous
-   * text-primary gray at 1.2px was visible but faint. margin-left adjusted
-   * to -1px to center the wider cursor on the insertion point. */
-  .cm-editor .cm-cursor {
-    border-left-color: var(--bt-color-cursor);
-    border-left-width: 2px;
-    margin-left: -1px;
-  }
+   /* Cursor — CM6's default cursor is borderLeft: 1.2px solid black. The
+    * &dark .cm-cursor override in CM6's base theme only fires when the editor
+    * has the cm-dark class (set via EditorView.darkTheme), which this app
+    * does NOT use — dark mode is driven by prefers-color-scheme. Without this
+    * rule the cursor stays black and is invisible on the dark surface-code
+    * background.
+    *
+    * v2: cursor widened to 2px (from CM6 default 1.2px) and color set to
+    * pure white via --bt-color-cursor for accessibility — the previous
+    * text-primary gray at 1.2px was visible but faint. margin-left adjusted
+    * to -1px to center the wider cursor on the insertion point.
+    *
+    * v3: !important added to all three declarations. CM6's injected default
+    * styles were winning by source order or specificity in the live example
+    * pages, leaving the cursor faint gray despite the override. The
+    * .cm-editor.cm-focused .cm-cursor selector is added alongside .cm-editor
+    * .cm-cursor to cover the focused state at the same specificity. This is
+    * an accessibility fix — !important is justified to guarantee the cursor
+    * is visible regardless of CM6's internal style injection order.
+    *
+    * caret-color is set on .cm-content so the native contenteditable caret
+    * (which renders as faint gray in dark mode) is also white. Without this,
+    * the native caret is visible in addition to or instead of CM6's drawn
+    * cursor, producing a faint gray line. */
+   .cm-editor.cm-focused .cm-cursor,
+   .cm-editor .cm-cursor {
+     border-left-color: var(--bt-color-cursor) !important;
+     border-left-width: 2px !important;
+     margin-left: -1px !important;
+   }
+
+   .cm-content {
+     caret-color: var(--bt-color-cursor);
+   }
 }

--- a/crates/core/src/site/mod.rs
+++ b/crates/core/src/site/mod.rs
@@ -1858,13 +1858,22 @@ exercise:
         // faint. v2 widens to 2px and uses pure white (#ffffff) via a dedicated
         // --bt-color-cursor token for maximum contrast.
         //
-        // 5 clauses pin the fix:
+        // v3: !important added to all cursor declarations because CM6's injected
+        // default styles were winning by source order or specificity in the live
+        // example pages. A .cm-editor.cm-focused .cm-cursor selector is added
+        // alongside .cm-editor .cm-cursor to cover the focused state. A
+        // caret-color rule on .cm-content ensures the native contenteditable
+        // caret is also white in dark mode (it renders faint gray by default).
+        //
+        // 7 clauses pin the fix:
         //   1. The @media block contains a .cm-editor .cm-cursor rule
         //   2. The rule sets border-left-color (overriding CM6's default black)
         //   3. The border-left-color is NOT black (must be a light value)
         //   4. The rule sets border-left-width: 2px (wider than CM6 default 1.2px)
         //   5. The cursor color uses --bt-color-cursor, defined as #ffffff in the
         //      dark-mode :root block (high-contrast pure white)
+        //   6. The cursor rule uses !important (overrides CM6's injected styles)
+        //   7. A .cm-content rule sets caret-color (native caret also white)
         let webr = plan(&r_course(), BuildTarget::Webr).expect("plans");
         let css = &file(&webr, "styles.css").contents;
 
@@ -1952,6 +1961,63 @@ exercise:
             media_body.contains("--bt-color-cursor: #ffffff"),
             "dark-mode :root must define --bt-color-cursor: #ffffff \
              (pure white for maximum contrast against #2d2d2d background)"
+        );
+
+        // Clause 6: cursor rule uses !important on all declarations. CM6's
+        // injected default styles were winning by source order or specificity
+        // in the live example pages, leaving the cursor faint gray. !important
+        // guarantees the override wins regardless of CM6's internal style
+        // injection order. This is an accessibility fix — the justification
+        // for !important is that an invisible cursor is a usability blocker.
+        assert!(
+            cursor_body.contains("!important"),
+            ".cm-cursor dark-mode rule must use !important \
+             (CM6 injected styles win by source order without it)"
+        );
+
+        // Clause 7: a .cm-content rule sets caret-color in the dark-mode block.
+        // The native contenteditable caret renders as faint gray in dark mode;
+        // setting caret-color to the cursor token makes it white. Without this,
+        // the native caret is visible in addition to or instead of CM6's drawn
+        // cursor, producing a faint gray line.
+        //
+        // The .cm-content selector may appear in comment text before the actual
+        // rule. We skip comment mentions by requiring that only whitespace
+        // separates the selector from its opening brace.
+        assert!(
+            media_body.contains("caret-color"),
+            "dark-mode @media block must set caret-color on .cm-content \
+             (native contenteditable caret is faint gray without it)"
+        );
+        let content_selector = ".cm-content";
+        let mut search_from = 0;
+        let content_body: &str = loop {
+            let pos = media_body[search_from..]
+                .find(content_selector)
+                .expect("@media dark block must contain a .cm-content rule");
+            let abs_pos = search_from + pos;
+            let after = &media_body[abs_pos + content_selector.len()..];
+            let brace_offset = after.find('{').expect(".cm-content rule has opening brace");
+            // If only whitespace separates selector from {, this is the rule
+            // (not a comment mention where other text intervenes).
+            if after[..brace_offset].trim().is_empty() {
+                let body_raw = &after[brace_offset + 1..];
+                let close = body_raw
+                    .find('}')
+                    .expect(".cm-content rule has closing brace");
+                break &body_raw[..close];
+            }
+            search_from = abs_pos + content_selector.len();
+        };
+        assert!(
+            content_body.contains("caret-color"),
+            ".cm-content dark-mode rule must set caret-color \
+             (native caret must be white in dark mode)"
+        );
+        assert!(
+            content_body.contains("var(--bt-color-cursor)"),
+            ".cm-content caret-color must use var(--bt-color-cursor) \
+             (same high-contrast token as the drawn cursor)"
         );
     }
 


### PR DESCRIPTION
## Summary
Previous cursor fix (PR #93) changed CSS but cursor still faint in live pages. Root cause: CM6 default styles winning specificity + missing caret-color for native caret. Adds !important to cursor rules + caret-color on .cm-content in dark mode.

## Issue
Fixes cursor visibility regression in dark mode (follow-up to PR #93).

## Changes
- **CSS** (`crates/core/assets/shared/styles.css`):
  - Added `!important` to all three `.cm-cursor` declarations (border-left-color, border-left-width, margin-left)
  - Added `.cm-editor.cm-focused .cm-cursor` selector alongside `.cm-editor .cm-cursor` to cover focused state
  - Added `caret-color: var(--bt-color-cursor)` on `.cm-content` so native contenteditable caret is also white
- **Test** (`crates/core/src/site/mod.rs`):
  - Clause 6: asserts `!important` present in cursor rule
  - Clause 7: asserts `.cm-content` rule sets `caret-color` using `var(--bt-color-cursor)`
  - Robust selector extraction skips comment mentions of `.cm-content`

## Test plan
- [x] All 236 tests pass (`cargo test --workspace`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --tests` clean
- [ ] PR review findings resolved