### PR TITLE
fix(ui): set cursor color via CM6 theme extension

### DIFF
--- a/crates/core/assets/shared/lesson-runner-core.js
+++ b/crates/core/assets/shared/lesson-runner-core.js
@@ -72,6 +72,7 @@ const cursorTheme = EditorView.theme({
   ".cm-cursor": {
     borderLeftColor: "var(--bt-color-cursor, #ffffff)",
     borderLeftWidth: "2px",
+    marginLeft: "-1px",
   },
   ".cm-content": {
     caretColor: "var(--bt-color-cursor, #ffffff)",

--- a/crates/core/assets/shared/lesson-runner-core.js
+++ b/crates/core/assets/shared/lesson-runner-core.js
@@ -53,6 +53,31 @@ const tokHighlightStyle = HighlightStyle.define([
   { tag: tags.operator, class: "tok-operator" },
 ]);
 
+// CM6 theme extension for cursor visibility (v4). Previous CSS-only fixes in
+// styles.css (!important + caret-color, PRs #93/#94) did not work in the live
+// browser despite correct CSS on the deployed site — CM6's injected base-theme
+// styles were winning the cascade. EditorView.theme() injects styles via CM6's
+// own style-module system at a higher precedence than the base theme,
+// bypassing the external CSS cascade entirely.
+//
+// Uses var(--bt-color-cursor) so the cursor adapts to light/dark mode:
+//   - light: #1a1a1a (dark cursor on light background)
+//   - dark:  #ffffff (white cursor on dark background)
+// The fallback #ffffff ensures visibility if the variable is undefined.
+//
+// No &dark selector: the editor does NOT use EditorView.darkTheme — dark mode
+// is driven by prefers-color-scheme, so &dark would never match. The CSS
+// variable resolves correctly via the @media block in styles.css.
+const cursorTheme = EditorView.theme({
+  ".cm-cursor": {
+    borderLeftColor: "var(--bt-color-cursor, #ffffff)",
+    borderLeftWidth: "2px",
+  },
+  ".cm-content": {
+    caretColor: "var(--bt-color-cursor, #ffffff)",
+  },
+});
+
 // Build the full CM6 extension array for a given language — a PURE function
 // (§2.1, §5.1): given a language, returns the Extension[] with no side effects.
 // start() calls it once when mounting the EditorView. The array composes:
@@ -61,6 +86,7 @@ const tokHighlightStyle = HighlightStyle.define([
 //   - lineNumbers() for the gutter,
 //   - highlightActiveLine() for the active-line background,
 //   - bracketMatching() for bracket-pair highlighting (.cm-matchingBracket),
+//   - cursorTheme for cursor color/width (bypasses CSS cascade — see above),
 //   - keymap.of([indentWithTab]) so Tab indents/dedents inside the editor
 //     (NOT browser focus traversal — sneaky-pass #3: importing indentWithTab
 //     alone is insufficient; it must be composed via keymap.of),
@@ -81,6 +107,7 @@ function editorExtensions(language) {
     lineNumbers(),
     highlightActiveLine(),
     bracketMatching(),
+    cursorTheme,
     EditorView.contentAttributes.of({ spellcheck: "false" }),
     keymap.of([indentWithTab]),
   ];

--- a/crates/core/assets/shared/styles.css
+++ b/crates/core/assets/shared/styles.css
@@ -614,38 +614,4 @@ footer.site-footer {
     outline-color: rgba(255, 255, 255, 0.2);
   }
 
-   /* Cursor — CM6's default cursor is borderLeft: 1.2px solid black. The
-    * &dark .cm-cursor override in CM6's base theme only fires when the editor
-    * has the cm-dark class (set via EditorView.darkTheme), which this app
-    * does NOT use — dark mode is driven by prefers-color-scheme. Without this
-    * rule the cursor stays black and is invisible on the dark surface-code
-    * background.
-    *
-    * v2: cursor widened to 2px (from CM6 default 1.2px) and color set to
-    * pure white via --bt-color-cursor for accessibility — the previous
-    * text-primary gray at 1.2px was visible but faint. margin-left adjusted
-    * to -1px to center the wider cursor on the insertion point.
-    *
-    * v3: !important added to all three declarations. CM6's injected default
-    * styles were winning by source order or specificity in the live example
-    * pages, leaving the cursor faint gray despite the override. The
-    * .cm-editor.cm-focused .cm-cursor selector is added alongside .cm-editor
-    * .cm-cursor to cover the focused state at the same specificity. This is
-    * an accessibility fix — !important is justified to guarantee the cursor
-    * is visible regardless of CM6's internal style injection order.
-    *
-    * caret-color is set on .cm-content so the native contenteditable caret
-    * (which renders as faint gray in dark mode) is also white. Without this,
-    * the native caret is visible in addition to or instead of CM6's drawn
-    * cursor, producing a faint gray line. */
-   .cm-editor.cm-focused .cm-cursor,
-   .cm-editor .cm-cursor {
-     border-left-color: var(--bt-color-cursor) !important;
-     border-left-width: 2px !important;
-     margin-left: -1px !important;
-   }
-
-   .cm-content {
-     caret-color: var(--bt-color-cursor);
-   }
 }

--- a/crates/core/src/site/mod.rs
+++ b/crates/core/src/site/mod.rs
@@ -2022,6 +2022,85 @@ exercise:
     }
 
     #[test]
+    fn plan_site_runner_core_sets_cursor_color_via_cm6_theme() {
+        // v4 cursor fix: CSS-only overrides in styles.css (!important +
+        // caret-color, PRs #93/#94) did not work in the live browser despite
+        // correct CSS on the deployed site. CM6's injected base-theme styles
+        // were winning the cascade. The fix moves cursor styling into a CM6
+        // EditorView.theme() extension, which injects styles via CM6's own
+        // style-module system at a higher precedence than the base theme.
+        //
+        // 6 clauses pin the fix:
+        //   1. EditorView.theme() is called to create a theme extension
+        //   2. The theme targets .cm-cursor with borderLeftColor
+        //   3. The borderLeftColor uses var(--bt-color-cursor) (adapts to
+        //      light/dark via the CSS variable defined in styles.css)
+        //   4. The theme sets borderLeftWidth: 2px (wider than CM6 default)
+        //   5. The theme targets .cm-content with caretColor (native caret)
+        //   6. The theme extension is added to the editorExtensions array
+        let webr = plan(&r_course(), BuildTarget::Webr).expect("plans");
+        let core = &file(&webr, "lesson-runner-core.js").contents;
+
+        // Clause 1: EditorView.theme() is called — creates a CM6 theme
+        // extension rather than relying on external CSS.
+        assert!(
+            core.contains("EditorView.theme("),
+            "lesson-runner-core.js must call EditorView.theme() to create a \
+             cursor theme extension (CSS-only overrides did not work in live \
+             browser — CM6 base-theme styles won the cascade)"
+        );
+
+        // Clause 2: the theme targets .cm-cursor with borderLeftColor.
+        // CM6's base theme sets borderLeft: "1.2px solid black" — we must
+        // override the borderLeftColor to a light value for dark mode.
+        assert!(
+            core.contains("borderLeftColor"),
+            "lesson-runner-core.js cursor theme must set borderLeftColor on \
+             .cm-cursor (CM6 default is black — invisible on dark background)"
+        );
+
+        // Clause 3: borderLeftColor uses var(--bt-color-cursor) so the cursor
+        // adapts to light/dark mode via the CSS variable defined in
+        // styles.css (light: #1a1a1a, dark: #ffffff). The fallback #ffffff
+        // ensures visibility if the variable is undefined.
+        assert!(
+            core.contains("var(--bt-color-cursor, #ffffff)"),
+            "lesson-runner-core.js cursor theme must use \
+             var(--bt-color-cursor, #ffffff) for borderLeftColor \
+             (adapts to light/dark via CSS variable, fallback ensures \
+             visibility)"
+        );
+
+        // Clause 4: cursor width is 2px (wider than CM6 default 1.2px).
+        assert!(
+            core.contains("borderLeftWidth") && core.contains("\"2px\""),
+            "lesson-runner-core.js cursor theme must set borderLeftWidth: \
+             \"2px\" (CM6 default 1.2px is too faint — widened for \
+             accessibility)"
+        );
+
+        // Clause 5: the theme targets .cm-content with caretColor. The
+        // native contenteditable caret renders as faint gray in dark mode;
+        // setting caretColor makes it match the drawn cursor.
+        assert!(
+            core.contains("caretColor"),
+            "lesson-runner-core.js cursor theme must set caretColor on \
+             .cm-content (native contenteditable caret is faint gray \
+             without it)"
+        );
+
+        // Clause 6: the theme extension is added to the editorExtensions
+        // array. A theme defined but not wired into the extensions array
+        // would have no effect (sneaky-pass: defined but not composed).
+        assert!(
+            core.contains("cursorTheme"),
+            "lesson-runner-core.js must add cursorTheme to the \
+             editorExtensions array (a theme defined but not wired has no \
+             effect)"
+        );
+    }
+
+    #[test]
     fn plan_site_runner_core_renders_hints_as_expandable_details() {
         // The lesson runner core must render `lesson.hints` as an expandable
         // <details> element when the hints field is non-null and non-empty,

--- a/crates/core/src/site/mod.rs
+++ b/crates/core/src/site/mod.rs
@@ -1844,184 +1844,6 @@ exercise:
     }
 
     #[test]
-    fn plan_site_cm6_cursor_visible_in_dark_mode() {
-        // Bug fix: the CM6 editor cursor is invisible in dark mode. CM6's base
-        // theme sets the cursor border to black (borderLeft: 1.2px solid black).
-        // The &dark .cm-cursor override only fires when the editor has the
-        // cm-dark class (via EditorView.darkTheme), which this app does NOT use
-        // — dark mode is driven by prefers-color-scheme. Without an explicit
-        // override inside the @media (prefers-color-scheme: dark) block, the
-        // cursor stays black and is invisible on the dark surface-code background.
-        //
-        // v2: the initial fix (PR #83) set the cursor to --bt-color-text-primary
-        // (#e0e0e0) at CM6's default 1.2px width. Users reported it was still
-        // faint. v2 widens to 2px and uses pure white (#ffffff) via a dedicated
-        // --bt-color-cursor token for maximum contrast.
-        //
-        // v3: !important added to all cursor declarations because CM6's injected
-        // default styles were winning by source order or specificity in the live
-        // example pages. A .cm-editor.cm-focused .cm-cursor selector is added
-        // alongside .cm-editor .cm-cursor to cover the focused state. A
-        // caret-color rule on .cm-content ensures the native contenteditable
-        // caret is also white in dark mode (it renders faint gray by default).
-        //
-        // 7 clauses pin the fix:
-        //   1. The @media block contains a .cm-editor .cm-cursor rule
-        //   2. The rule sets border-left-color (overriding CM6's default black)
-        //   3. The border-left-color is NOT black (must be a light value)
-        //   4. The rule sets border-left-width: 2px (wider than CM6 default 1.2px)
-        //   5. The cursor color uses --bt-color-cursor, defined as #ffffff in the
-        //      dark-mode :root block (high-contrast pure white)
-        //   6. The cursor rule uses !important (overrides CM6's injected styles)
-        //   7. A .cm-content rule sets caret-color (native caret also white)
-        let webr = plan(&r_course(), BuildTarget::Webr).expect("plans");
-        let css = &file(&webr, "styles.css").contents;
-
-        // Extract the @media (prefers-color-scheme: dark) block body via brace
-        // counting. Search for the selector WITH the opening brace to skip
-        // comment mentions of "@media (prefers-color-scheme: dark)" that appear
-        // in the file header and section comments (those lack the trailing " {").
-        let media_selector = "@media (prefers-color-scheme: dark) {";
-        let media_start =
-            css.find(media_selector).expect("@media dark block exists") + media_selector.len();
-        let media_after = &css[media_start..];
-
-        // Brace-count from inside the @media block (depth starts at 1).
-        let mut depth = 1i32;
-        let mut media_end = 0;
-        for (i, ch) in media_after.char_indices() {
-            match ch {
-                '{' => depth += 1,
-                '}' => {
-                    depth -= 1;
-                    if depth == 0 {
-                        media_end = i;
-                        break;
-                    }
-                }
-                _ => {}
-            }
-        }
-        let media_body = &media_after[..media_end];
-
-        // Clause 1: .cm-editor .cm-cursor rule exists inside the @media block.
-        // Searching for the full selector ".cm-editor .cm-cursor" avoids
-        // matching comment text that mentions .cm-cursor or .cm-editor
-        // individually.
-        let selector = ".cm-editor .cm-cursor";
-        let pos = media_body
-            .find(selector)
-            .expect("@media dark block must contain a .cm-editor .cm-cursor rule");
-        let after_selector = &media_body[pos + selector.len()..];
-        let brace = after_selector
-            .find('{')
-            .expect(".cm-cursor rule has opening brace");
-        let body = &after_selector[brace + 1..];
-        let close = body.find('}').expect(".cm-cursor rule has closing brace");
-        let cursor_body = &body[..close];
-
-        // Clause 2: the rule sets border-left-color.
-        assert!(
-            cursor_body.contains("border-left-color"),
-            ".cm-cursor dark-mode rule must set border-left-color \
-             (CM6 default is black — invisible on dark background)"
-        );
-
-        // Clause 3: border-left-color is NOT black.
-        assert!(
-            !cursor_body.contains("black"),
-            ".cm-cursor border-left-color must NOT be black \
-             (invisible on dark surface-code background)"
-        );
-
-        // Clause 4: cursor width is 2px (wider than CM6 default 1.2px).
-        // The wider cursor is more visible at the cost of slightly less
-        // precision — acceptable for accessibility.
-        //
-        // The substring "width: 2px" is specific: it matches
-        // "border-left-width: 2px" but NOT "border-left-width: 1.2px"
-        // (the CM6 default). A naive contains("2px") would falsely pass
-        // on 1.2px since "1.2px" contains "2px".
-        assert!(
-            cursor_body.contains("width: 2px"),
-            ".cm-cursor dark-mode rule must set border-left-width: 2px \
-             (CM6 default 1.2px is too faint — widened for accessibility)"
-        );
-
-        // Clause 5: cursor color uses --bt-color-cursor token, which is defined
-        // as #ffffff (pure white) in the dark-mode :root block. This is the
-        // high-contrast color — #e0e0e0 (the previous value via
-        // --bt-color-text-primary) was visible but faint.
-        assert!(
-            cursor_body.contains("var(--bt-color-cursor)"),
-            ".cm-cursor dark-mode rule must use var(--bt-color-cursor) \
-             (dedicated high-contrast cursor token, not --bt-color-text-primary)"
-        );
-        assert!(
-            media_body.contains("--bt-color-cursor: #ffffff"),
-            "dark-mode :root must define --bt-color-cursor: #ffffff \
-             (pure white for maximum contrast against #2d2d2d background)"
-        );
-
-        // Clause 6: cursor rule uses !important on all declarations. CM6's
-        // injected default styles were winning by source order or specificity
-        // in the live example pages, leaving the cursor faint gray. !important
-        // guarantees the override wins regardless of CM6's internal style
-        // injection order. This is an accessibility fix — the justification
-        // for !important is that an invisible cursor is a usability blocker.
-        assert!(
-            cursor_body.contains("!important"),
-            ".cm-cursor dark-mode rule must use !important \
-             (CM6 injected styles win by source order without it)"
-        );
-
-        // Clause 7: a .cm-content rule sets caret-color in the dark-mode block.
-        // The native contenteditable caret renders as faint gray in dark mode;
-        // setting caret-color to the cursor token makes it white. Without this,
-        // the native caret is visible in addition to or instead of CM6's drawn
-        // cursor, producing a faint gray line.
-        //
-        // The .cm-content selector may appear in comment text before the actual
-        // rule. We skip comment mentions by requiring that only whitespace
-        // separates the selector from its opening brace.
-        assert!(
-            media_body.contains("caret-color"),
-            "dark-mode @media block must set caret-color on .cm-content \
-             (native contenteditable caret is faint gray without it)"
-        );
-        let content_selector = ".cm-content";
-        let mut search_from = 0;
-        let content_body: &str = loop {
-            let pos = media_body[search_from..]
-                .find(content_selector)
-                .expect("@media dark block must contain a .cm-content rule");
-            let abs_pos = search_from + pos;
-            let after = &media_body[abs_pos + content_selector.len()..];
-            let brace_offset = after.find('{').expect(".cm-content rule has opening brace");
-            // If only whitespace separates selector from {, this is the rule
-            // (not a comment mention where other text intervenes).
-            if after[..brace_offset].trim().is_empty() {
-                let body_raw = &after[brace_offset + 1..];
-                let close = body_raw
-                    .find('}')
-                    .expect(".cm-content rule has closing brace");
-                break &body_raw[..close];
-            }
-            search_from = abs_pos + content_selector.len();
-        };
-        assert!(
-            content_body.contains("caret-color"),
-            ".cm-content dark-mode rule must set caret-color \
-             (native caret must be white in dark mode)"
-        );
-        assert!(
-            content_body.contains("var(--bt-color-cursor)"),
-            ".cm-content caret-color must use var(--bt-color-cursor) \
-             (same high-contrast token as the drawn cursor)"
-        );
-    }
-
-    #[test]
     fn plan_site_runner_core_sets_cursor_color_via_cm6_theme() {
         // v4 cursor fix: CSS-only overrides in styles.css (!important +
         // caret-color, PRs #93/#94) did not work in the live browser despite
@@ -2030,14 +1852,15 @@ exercise:
         // EditorView.theme() extension, which injects styles via CM6's own
         // style-module system at a higher precedence than the base theme.
         //
-        // 6 clauses pin the fix:
+        // 7 clauses pin the fix:
         //   1. EditorView.theme() is called to create a theme extension
         //   2. The theme targets .cm-cursor with borderLeftColor
         //   3. The borderLeftColor uses var(--bt-color-cursor) (adapts to
         //      light/dark via the CSS variable defined in styles.css)
         //   4. The theme sets borderLeftWidth: 2px (wider than CM6 default)
-        //   5. The theme targets .cm-content with caretColor (native caret)
-        //   6. The theme extension is added to the editorExtensions array
+        //   5. The theme sets marginLeft: -1px (centers the wider cursor)
+        //   6. The theme targets .cm-content with caretColor (native caret)
+        //   7. The theme extension is added to the editorExtensions array
         let webr = plan(&r_course(), BuildTarget::Webr).expect("plans");
         let core = &file(&webr, "lesson-runner-core.js").contents;
 
@@ -2079,7 +1902,16 @@ exercise:
              accessibility)"
         );
 
-        // Clause 5: the theme targets .cm-content with caretColor. The
+        // Clause 5: the theme sets marginLeft to center the wider cursor on
+        // the insertion point. CM6's default cursor is 1.2px with
+        // marginLeft: -0.6px; at 2px width the cursor must shift to -1px
+        // to stay centered.
+        assert!(
+            core.contains("marginLeft"),
+            "lesson-runner-core.js cursor theme must set marginLeft for centering"
+        );
+
+        // Clause 6: the theme targets .cm-content with caretColor. The
         // native contenteditable caret renders as faint gray in dark mode;
         // setting caretColor makes it match the drawn cursor.
         assert!(
@@ -2089,7 +1921,7 @@ exercise:
              without it)"
         );
 
-        // Clause 6: the theme extension is added to the editorExtensions
+        // Clause 7: the theme extension is added to the editorExtensions
         // array. A theme defined but not wired into the extensions array
         // would have no effect (sneaky-pass: defined but not composed).
         assert!(


### PR DESCRIPTION
## Summary
Previous CSS-only fixes (#93, #94) didn't work in live browser despite correct CSS on deployed site. Root cause: CM6's injected base-theme styles were winning the CSS cascade over `styles.css` rules, even with `!important`.

This fix sets cursor color directly via CM6 `EditorView.theme()` API in `lesson-runner-core.js`. Theme extensions inject styles via CM6's own style-module system at a higher precedence than the base theme, bypassing the external CSS cascade entirely.

Uses `var(--bt-color-cursor)` so cursor adapts to light/dark mode:
- light: `#1a1a1a` (dark cursor on light background)
- dark: `#ffffff` (white cursor on dark background)

No `&dark` selector: editor does NOT use `EditorView.darkTheme` — dark mode is driven by `prefers-color-scheme`, so `&dark` would never match. The CSS variable resolves correctly via the `@media` block in `styles.css`.

Also sets `caret-color` on `.cm-content` for the native contenteditable caret, which renders faint gray in dark mode by default.

## Issue
Follow-up to #93, #94 — cursor still faint gray in dark mode on live GitHub Pages site.

## Test plan
- [x] All tests pass (`cargo test --workspace` — 140 tests, 0 failures)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --tests` clean
- [x] New test `plan_site_runner_core_sets_cursor_color_via_cm6_theme` verifies JS contains cursor theme extension
- [ ] User visually verifies cursor visibility post-merge