### PR TITLE
feat: CSP + SRI + Referrer Policy on all built sites

### DIFF
--- a/crates/core/assets/pyodide/index.html
+++ b/crates/core/assets/pyodide/index.html
@@ -4,6 +4,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>blendtutor — interactive Python lessons</title>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net https://webr.r-wasm.org; style-src 'self' 'unsafe-inline'; connect-src 'self' https://cdn.jsdelivr.net https://webr.r-wasm.org https://repo.r-wasm.org https://api.fireworks.ai https://api.anthropic.com; img-src 'self' data: blob:; worker-src 'self' blob:; frame-src 'none'; object-src 'none'; base-uri 'self';" />
+    <meta name="referrer" content="no-referrer" />
     <!--
       COOP/COEP shim, loaded first. It registers a service worker that re-serves
       this site cross-origin isolated, so SharedArrayBuffer works on
@@ -16,7 +18,9 @@
       the runner calls to boot Python in the browser. Pinned to a versioned CDN
       build so the site is reproducible.
     -->
-    <script src="https://cdn.jsdelivr.net/pyodide/v0.27.2/full/pyodide.js"></script>
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.27.2/full/pyodide.js"
+            integrity="sha384-Dz8WbRJS+zEg3mTsQKFzS7uiJxTV6CVDI6lD5b49KMnhy6hlO1vl+ru6YCYNiaXz"
+            crossorigin="anonymous"></script>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>

--- a/crates/core/assets/webr/index.html
+++ b/crates/core/assets/webr/index.html
@@ -4,6 +4,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>blendtutor — interactive R lessons</title>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net https://webr.r-wasm.org; style-src 'self' 'unsafe-inline'; connect-src 'self' https://cdn.jsdelivr.net https://webr.r-wasm.org https://repo.r-wasm.org https://api.fireworks.ai https://api.anthropic.com; img-src 'self' data: blob:; worker-src 'self' blob:; frame-src 'none'; object-src 'none'; base-uri 'self';" />
+    <meta name="referrer" content="no-referrer" />
     <!--
       COOP/COEP shim, loaded first. It registers a service worker that re-serves
       this site cross-origin isolated, so SharedArrayBuffer works on

--- a/crates/core/src/site/mod.rs
+++ b/crates/core/src/site/mod.rs
@@ -392,6 +392,35 @@ pub fn eval_summary_from_report_json(json: &str) -> Result<EvalSummary, EvalRepo
     })
 }
 
+/// The Content-Security-Policy for every built site — the single source of
+/// truth (§1.3.1, §3.2). Both target shells hardcode this same string in their
+/// `<meta http-equiv="Content-Security-Policy">` tag, and [`eval_results_html`]
+/// references this const directly. The test
+/// `plan_site_emits_csp_sri_and_referrer_policy` is the boundary guard that
+/// pins the shells to the const — a drift is a test failure, not a runtime
+/// error.
+///
+/// - `script-src` allows `'unsafe-eval'` + `'wasm-unsafe-eval'` (webR/Pyodide
+///   need `eval` and WASM), both CDN origins, but NO wildcards (`https:`, `*`,
+///   `'unsafe-inline'`).
+/// - `style-src` allows `'unsafe-inline'` because CM6's `StyleModule` injects
+///   `<style>` tags at runtime.
+/// - `connect-src` includes both LLM providers (Fireworks + Anthropic) for
+///   BYOK feedback, and `repo.r-wasm.org` for webR package installs.
+/// - `worker-src` allows `blob:` for webR's channel workers.
+const CSP_POLICY: &str = "\
+default-src 'self'; \
+script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' \
+https://cdn.jsdelivr.net https://webr.r-wasm.org; \
+style-src 'self' 'unsafe-inline'; \
+connect-src 'self' https://cdn.jsdelivr.net https://webr.r-wasm.org \
+https://repo.r-wasm.org https://api.fireworks.ai https://api.anthropic.com; \
+img-src 'self' data: blob:; \
+worker-src 'self' blob:; \
+frame-src 'none'; \
+object-src 'none'; \
+base-uri 'self';";
+
 /// Render the standalone eval-results page for a site's [`EvalSummary`].
 ///
 /// §5.1: the single function mapping the validation state to its page. Each state
@@ -421,13 +450,16 @@ fn eval_results_html(summary: &EvalSummary) -> String {
          <head>\n\
          <meta charset=\"utf-8\">\n\
          <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n\
+         <meta http-equiv=\"Content-Security-Policy\" content=\"{csp_policy}\">\n\
+         <meta name=\"referrer\" content=\"no-referrer\">\n\
          <title>Eval results</title>\n\
          </head>\n\
          <body {status}>\n\
          <h1>Eval results</h1>\n\
          <p>{body}</p>\n\
          </body>\n\
-         </html>\n"
+         </html>\n",
+        csp_policy = CSP_POLICY,
     )
 }
 
@@ -2165,6 +2197,264 @@ exercise:
             gotchas_body.contains("var(--bt-"),
             "#lesson-gotchas must use var(--bt-*) tokens, got: {gotchas_body}"
         );
+    }
+
+    #[test]
+    fn plan_site_emits_csp_sri_and_referrer_policy() {
+        // AC-1 (issue #96): CSP + SRI + Referrer Policy on all built sites.
+        // Free hardening: a Content-Security-Policy meta tag restricts what
+        // origins may serve scripts/styles/connections, SRI pins CDN scripts to
+        // a known hash, and a referrer policy prevents leaking the site URL to
+        // cross-origin LLM providers.
+        //
+        // 11 clauses pin the security envelope (§1.5 — predicates, not
+        // coincident shape):
+        //   1. Exactly one CSP meta tag in head, before first script tag
+        //   2. CSP content = single CSP_POLICY const (no wildcard schemes in
+        //      script-src: no https:, http:, *, 'unsafe-inline')
+        //   3. script-src includes both CDN origins (cdn.jsdelivr.net +
+        //      webr.r-wasm.org) in BOTH targets
+        //   4. connect-src includes self, cdn.jsdelivr.net, webr.r-wasm.org,
+        //      repo.r-wasm.org, api.fireworks.ai, api.anthropic.com
+        //   5. style-src includes 'unsafe-inline' (CM6 StyleModule injects
+        //      style tags)
+        //   6. worker-src includes 'self' blob: (WebR channel workers)
+        //   7. Exactly one referrer meta tag, content="no-referrer"
+        //   8. Pyodide CDN script has non-empty integrity (sha256/384/512
+        //      prefix) + crossorigin="anonymous"
+        //   9. WebR target: NO integrity attributes on any HTML tag (ES module
+        //      import can't have SRI — gap accepted, documented)
+        //   10. eval-results.html has same CSP + referrer meta
+        //   11. CSP_POLICY defined as single const in site/mod.rs
+
+        // Clause 11: CSP_POLICY is a single const — referencing it here proves
+        // it exists at compile time. A CSP string duplicated per target would
+        // not have a single named source the test can pin.
+        let csp = CSP_POLICY;
+        assert!(
+            !csp.is_empty(),
+            "CSP_POLICY must be a non-empty const, not a placeholder"
+        );
+
+        for (target, course) in [
+            (BuildTarget::Webr, r_course()),
+            (BuildTarget::Pyodide, python_course()),
+        ] {
+            let site = plan_site(&course, target, &EvalSummary::NotValidated).expect("plans");
+            let html = &file(&site, "index.html").contents;
+
+            // --- Clause 1: exactly one CSP meta tag in head, before first script
+            let csp_meta = r#"<meta http-equiv="Content-Security-Policy""#;
+            let csp_count = html.matches(csp_meta).count();
+            assert_eq!(
+                csp_count, 1,
+                "{target}: expected exactly one CSP meta tag, got {csp_count}"
+            );
+            let csp_pos = html.find(csp_meta).expect("CSP meta exists");
+            let head_close = html.find("</head>").expect("head closes");
+            assert!(
+                csp_pos < head_close,
+                "{target}: CSP meta must be inside <head>"
+            );
+            let first_script_pos = html.find("<script").expect("at least one script tag");
+            assert!(
+                csp_pos < first_script_pos,
+                "{target}: CSP meta must appear before first <script> tag"
+            );
+
+            // --- Clause 2: CSP content matches CSP_POLICY const, no wildcards
+            let csp_content = extract_meta_content(html, "Content-Security-Policy")
+                .expect("CSP content attribute is present");
+            assert_eq!(
+                csp_content, csp,
+                "{target}: CSP content must match CSP_POLICY const exactly"
+            );
+            let script_src = extract_csp_directive(&csp_content, "script-src");
+            assert!(
+                !script_src.is_empty(),
+                "{target}: CSP must have a script-src directive"
+            );
+            let script_sources: Vec<&str> = script_src.split_whitespace().collect();
+            for wildcard in ["https:", "http:", "*", "'unsafe-inline'"] {
+                assert!(
+                    !script_sources.contains(&wildcard),
+                    "{target}: script-src must not contain wildcard `{wildcard}`, \
+                     sources: {script_src}"
+                );
+            }
+
+            // --- Clause 3: script-src includes both CDN origins in BOTH targets
+            assert!(
+                script_src.contains("https://cdn.jsdelivr.net"),
+                "{target}: script-src must include cdn.jsdelivr.net"
+            );
+            assert!(
+                script_src.contains("https://webr.r-wasm.org"),
+                "{target}: script-src must include webr.r-wasm.org"
+            );
+
+            // --- Clause 4: connect-src includes all required origins
+            let connect_src = extract_csp_directive(&csp_content, "connect-src");
+            for origin in [
+                "https://cdn.jsdelivr.net",
+                "https://webr.r-wasm.org",
+                "https://repo.r-wasm.org",
+                "https://api.fireworks.ai",
+                "https://api.anthropic.com",
+            ] {
+                assert!(
+                    connect_src.contains(origin),
+                    "{target}: connect-src must include {origin}, got: {connect_src}"
+                );
+            }
+
+            // --- Clause 5: style-src includes 'unsafe-inline'
+            let style_src = extract_csp_directive(&csp_content, "style-src");
+            assert!(
+                style_src.contains("'unsafe-inline'"),
+                "{target}: style-src must include 'unsafe-inline' \
+                 (CM6 StyleModule injects style tags), got: {style_src}"
+            );
+
+            // --- Clause 6: worker-src includes 'self' blob:
+            let worker_src = extract_csp_directive(&csp_content, "worker-src");
+            assert!(
+                worker_src.contains("'self'") && worker_src.contains("blob:"),
+                "{target}: worker-src must include 'self' blob: \
+                 (WebR channel workers), got: {worker_src}"
+            );
+
+            // --- Clause 7: exactly one referrer meta, content="no-referrer"
+            let referrer_meta = r#"<meta name="referrer""#;
+            let referrer_count = html.matches(referrer_meta).count();
+            assert_eq!(
+                referrer_count, 1,
+                "{target}: expected exactly one referrer meta tag, got {referrer_count}"
+            );
+            let referrer_content =
+                extract_meta_content(html, "referrer").expect("referrer content");
+            assert_eq!(
+                referrer_content, "no-referrer",
+                "{target}: referrer meta must have content=\"no-referrer\""
+            );
+            let referrer_pos = html.find(referrer_meta).expect("referrer meta exists");
+            assert!(
+                referrer_pos < first_script_pos,
+                "{target}: referrer meta must appear before first <script> tag"
+            );
+
+            // --- Clauses 8/9: SRI per target
+            match target {
+                BuildTarget::Pyodide => {
+                    // Clause 8: Pyodide CDN script has non-empty integrity +
+                    // crossorigin="anonymous"
+                    let cdn_pos = html
+                        .find(r#"src="https://cdn.jsdelivr.net/pyodide"#)
+                        .expect("pyodide CDN script exists");
+                    // Find the closing > of this script tag
+                    let tag_end = html[cdn_pos..]
+                        .find('>')
+                        .map(|p| cdn_pos + p)
+                        .expect("pyodide CDN script tag closes");
+                    let script_tag = &html[cdn_pos..=tag_end];
+
+                    // integrity attribute with sha256/384/512 prefix
+                    let integrity = extract_attr_value(script_tag, "integrity")
+                        .expect("pyodide CDN script must have integrity attribute");
+                    assert!(
+                        integrity.starts_with("sha256-")
+                            || integrity.starts_with("sha384-")
+                            || integrity.starts_with("sha512-"),
+                        "pyodide CDN integrity must start with sha256/384/512 prefix, \
+                         got: {integrity}"
+                    );
+                    assert!(
+                        integrity.len() > 10,
+                        "pyodide CDN integrity must be non-empty (not just the prefix), \
+                         got: {integrity}"
+                    );
+
+                    // crossorigin="anonymous"
+                    let crossorigin = extract_attr_value(script_tag, "crossorigin")
+                        .expect("pyodide CDN script must have crossorigin attribute");
+                    assert_eq!(
+                        crossorigin, "anonymous",
+                        "pyodide CDN script must have crossorigin=\"anonymous\""
+                    );
+                }
+                BuildTarget::Webr => {
+                    // Clause 9: WebR target has NO integrity attributes on any
+                    // HTML tag. webR is loaded as an ES module import, which
+                    // cannot carry an HTML integrity attribute — the SRI gap is
+                    // accepted and documented in code comments.
+                    assert!(
+                        !html.contains("integrity="),
+                        "webr index.html must NOT contain any integrity attributes \
+                         (ES module import SRI gap — accepted, documented)"
+                    );
+                }
+            }
+
+            // --- Clause 10: eval-results.html has same CSP + referrer meta
+            let eval_html = &file(&site, "eval-results.html").contents;
+            let eval_csp = extract_meta_content(eval_html, "Content-Security-Policy")
+                .expect("eval-results.html must have CSP meta");
+            assert_eq!(
+                eval_csp, csp,
+                "{target}: eval-results.html CSP must match CSP_POLICY const"
+            );
+            let eval_referrer =
+                extract_meta_content(eval_html, "referrer").expect("eval-results referrer");
+            assert_eq!(
+                eval_referrer, "no-referrer",
+                "{target}: eval-results.html must have referrer content=\"no-referrer\""
+            );
+        }
+    }
+
+    /// Extract the `content` attribute value from a `<meta>` tag identified by
+    /// its `http-equiv` or `name` attribute. Returns `None` if the tag or its
+    /// content attribute is not found.
+    fn extract_meta_content(html: &str, key: &str) -> Option<String> {
+        for prefix in [format!(r#"http-equiv="{key}""#), format!(r#"name="{key}""#)] {
+            if let Some(pos) = html.find(&prefix) {
+                let after = &html[pos + prefix.len()..];
+                if let Some(content_pos) = after.find(r#"content=""#) {
+                    let start = content_pos + r#"content=""#.len();
+                    let rest = &after[start..];
+                    if let Some(end) = rest.find('"') {
+                        return Some(rest[..end].to_string());
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Extract a CSP directive's value (the sources after the directive name,
+    /// up to the next `;` or end of string).
+    fn extract_csp_directive<'a>(csp: &'a str, directive: &str) -> &'a str {
+        let needle = format!("{directive} ");
+        if let Some(pos) = csp.find(&needle) {
+            let start = pos + needle.len();
+            let rest = &csp[start..];
+            let end = rest.find(';').unwrap_or(rest.len());
+            &rest[..end]
+        } else {
+            ""
+        }
+    }
+
+    /// Extract an attribute value from an HTML tag fragment. The `tag` slice
+    /// should start at or before the attribute and end at or after the closing
+    /// `>`. Returns `None` if the attribute is not found.
+    fn extract_attr_value(tag: &str, attr: &str) -> Option<String> {
+        let needle = format!(r#"{attr}=""#);
+        let pos = tag.find(&needle)?;
+        let start = pos + needle.len();
+        let rest = &tag[start..];
+        let end = rest.find('"')?;
+        Some(rest[..end].to_string())
     }
 
     /// Detect whether a `.cm-gutters` rule sets display:none or visibility:hidden.

--- a/crates/core/src/site/webr.rs
+++ b/crates/core/src/site/webr.rs
@@ -14,6 +14,17 @@ use crate::lesson::Lesson;
 use super::{SiteFiles, TargetAssets};
 
 /// The page shell — boots the shim, the webR runtime, and the runner.
+///
+/// # SRI gap (accepted)
+///
+/// Unlike the Pyodide target (which loads its runtime via a classic `<script>`
+/// tag and so can carry a Subresource Integrity hash), webR is loaded as an ES
+/// module import inside `lesson-runner.js`. The HTML `integrity` attribute is
+/// not valid on `<script type="module">` imports — the browser ignores it — so
+/// no `<script>` tag in this shell carries an `integrity` attribute. The CSP
+/// `script-src` allow-list (cdn.jsdelivr.net + webr.r-wasm.org) is the
+/// mitigation: only those two origins may serve scripts. A future restructuring
+/// to `<link rel="modulepreload">` with a versioned URL would enable SRI.
 const INDEX_HTML: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/assets/webr/index.html"

--- a/docs/evidence/96/build-output.log
+++ b/docs/evidence/96/build-output.log
@@ -1,0 +1,71 @@
+=== WebR target ===
+--- index.html (head) ---
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>blendtutor — interactive R lessons</title>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net https://webr.r-wasm.org; style-src 'self' 'unsafe-inline'; connect-src 'self' https://cdn.jsdelivr.net https://webr.r-wasm.org https://repo.r-wasm.org https://api.fireworks.ai https://api.anthropic.com; img-src 'self' data: blob:; worker-src 'self' blob:; frame-src 'none'; object-src 'none'; base-uri 'self';" />
+    <meta name="referrer" content="no-referrer" />
+    <!--
+      COOP/COEP shim, loaded first. It registers a service worker that re-serves
+      this site cross-origin isolated, so SharedArrayBuffer works on
+      GitHub Pages (which cannot set the headers itself). Must run before
+      anything that depends on isolation.
+    -->
+    <script src="coi-serviceworker.js"></script>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <h1>blendtutor</h1>
+--- eval-results.html (head) ---
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net https://webr.r-wasm.org; style-src 'self' 'unsafe-inline'; connect-src 'self' https://cdn.jsdelivr.net https://webr.r-wasm.org https://repo.r-wasm.org https://api.fireworks.ai https://api.anthropic.com; img-src 'self' data: blob:; worker-src 'self' blob:; frame-src 'none'; object-src 'none'; base-uri 'self';">
+<meta name="referrer" content="no-referrer">
+<title>Eval results</title>
+</head>
+<body data-eval-status="not-validated">
+<h1>Eval results</h1>
+<p>These lessons have <strong>not been validated</strong> — no eval report accompanied this course.</p>
+--- integrity attr count (expect 0) ---
+0
+
+=== Pyodide target ===
+--- index.html (head) ---
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>blendtutor — interactive Python lessons</title>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net https://webr.r-wasm.org; style-src 'self' 'unsafe-inline'; connect-src 'self' https://cdn.jsdelivr.net https://webr.r-wasm.org https://repo.r-wasm.org https://api.fireworks.ai https://api.anthropic.com; img-src 'self' data: blob:; worker-src 'self' blob:; frame-src 'none'; object-src 'none'; base-uri 'self';" />
+    <meta name="referrer" content="no-referrer" />
+    <!--
+      COOP/COEP shim, loaded first. It registers a service worker that re-serves
+      this site cross-origin isolated, so SharedArrayBuffer works on
+      GitHub Pages (which cannot set the headers itself). Must run before
+      anything that depends on isolation.
+    -->
+    <script src="coi-serviceworker.js"></script>
+    <!--
+      The Pyodide runtime: a classic script that exposes the global `loadPyodide`
+      the runner calls to boot Python in the browser. Pinned to a versioned CDN
+      build so the site is reproducible.
+    -->
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.27.2/full/pyodide.js"
+            integrity="sha384-Dz8WbRJS+zEg3mTsQKFzS7uiJxTV6CVDI6lD5b49KMnhy6hlO1vl+ru6YCYNiaXz"
+            crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+--- CDN script SRI ---
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.27.2/full/pyodide.js"
+            integrity="sha384-Dz8WbRJS+zEg3mTsQKFzS7uiJxTV6CVDI6lD5b49KMnhy6hlO1vl+ru6YCYNiaXz"
+            crossorigin="anonymous"></script>
+--- eval-results.html CSP ---
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net https://webr.r-wasm.org; style-src 'self' 'unsafe-inline'; connect-src 'self' https://cdn.jsdelivr.net https://webr.r-wasm.org https://repo.r-wasm.org https://api.fireworks.ai https://api.anthropic.com; img-src 'self' data: blob:; worker-src 'self' blob:; frame-src 'none'; object-src 'none'; base-uri 'self';">

--- a/docs/evidence/96/csp-sri-referrer-test.log
+++ b/docs/evidence/96/csp-sri-referrer-test.log
@@ -1,0 +1,32 @@
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.35s
+     Running unittests src/lib.rs (target/debug/deps/blendtutor_core-e6b2900eafa92e80)
+
+running 1 test
+test site::tests::plan_site_emits_csp_sri_and_referrer_policy ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 139 filtered out; finished in 0.01s
+
+     Running tests/eval.rs (target/debug/deps/eval-e9648ff30096cad5)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s
+
+     Running tests/grade.rs (target/debug/deps/grade-416df2804283aa22)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s
+
+     Running tests/llm.rs (target/debug/deps/llm-a39751c294fe72cb)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 9 filtered out; finished in 0.00s
+
+     Running tests/runner.rs (target/debug/deps/runner-32e835ce7f66b862)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s
+

--- a/docs/evidence/96/test-suite.log
+++ b/docs/evidence/96/test-suite.log
@@ -1,0 +1,196 @@
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/blendtutor_core-e6b2900eafa92e80)
+
+running 140 tests
+test course::tests::open_missing_manifest_is_a_read_error_not_a_parse_error ... ok
+test eval::tests::aggregate_is_matched_over_total_and_zero_for_an_empty_suite ... ok
+test eval::tests::case_result_derives_matched_from_score_case ... ok
+test course::tests::manifest_parse_reads_each_entrys_id_and_path ... ok
+test course::tests::manifest_parse_rejects_unknown_key_so_author_typos_surface ... ok
+test eval::tests::eval_run_error_names_the_one_based_case_and_chains_its_source ... ok
+test eval::tests::expected_verdict_serializes_to_its_canonical_token ... ok
+test eval::tests::from_token_maps_the_two_polarity_words_and_rejects_others ... ok
+test eval::tests::score_case_matches_same_polarity_and_rejects_the_opposite ... ok
+test eval::tests::scores_two_of_three_and_aggregates ... ok
+test eval::tests::structural_error_surfaces_the_underlying_parser_message ... ok
+test eval::tests::unknown_verdict_error_names_the_case_index_and_quotes_the_token ... ok
+test eval::tests::verdict_polarity_drops_the_feedback_message ... ok
+test eval::tests::parse_eval_suite_surfaces_unknown_verdict_with_its_case_index_and_token ... ok
+test course::tests::manifest_error_display_and_source_distinguish_each_variant ... ok
+test course::tests::manifest_parse_rejects_a_path_escaping_the_course_directory ... ok
+test eval::tests::parse_rejects_unknown_key_so_author_typos_surface ... ok
+test course::tests::load_lessons_returns_every_lesson_in_full_and_in_author_order ... ok
+test grade::tests::checks_are_classified_element_wise_in_order ... ok
+test course::tests::discover_summarizes_each_lesson_with_its_slug_language_and_title ... ok
+test grade::tests::a_submission_that_exits_nonzero_makes_every_check_notrun ... ok
+test grade::tests::a_submission_whose_interpreter_cannot_launch_makes_checks_notrun ... ok
+test grade::tests::a_check_whose_interpreter_cannot_launch_is_a_fail ... ok
+test grade::tests::select_runner_dispatches_a_python_lesson_to_the_python_runner ... ok
+test grade::tests::no_checks_runs_nothing_and_returns_empty ... ok
+test grade::tests::select_runner_dispatches_an_r_lesson_to_the_r_runner ... ok
+test grade::tests::select_runner_threads_packages_to_python_runner ... ok
+test lesson::tests::load_error_display_and_source_surface_the_cause ... ok
+test course::tests::discover_reports_a_malformed_lesson_as_an_error_row_keeping_the_good_ones ... ok
+test course::tests::discovery_error_display_and_source_surface_the_underlying_load_failure ... ok
+test course::tests::load_lessons_fails_on_the_first_broken_lesson_rather_than_dropping_it ... ok
+test lesson::tests::lesson_id_displays_its_value ... ok
+test lesson::tests::parse_accepts_empty_hints ... ok
+test lesson::tests::parse_accepts_hints_with_star_bullets ... ok
+test lesson::tests::parse_accepts_empty_gotchas ... ok
+test lesson::tests::parse_accepts_none_gotchas ... ok
+test lesson::tests::parse_accepts_gotchas_with_star_bullets ... ok
+test lesson::tests::parse_defaults_checks_to_empty_when_absent ... ok
+test lesson::tests::parse_accepts_valid_lesson ... ok
+test lesson::tests::parse_reads_an_optional_hints_field ... ok
+test lesson::tests::parse_reads_an_optional_reference_solution ... ok
+test lesson::tests::parse_reads_an_optional_gotchas_field ... ok
+test lesson::tests::parse_reads_packages_as_ordered_strings ... ok
+test lesson::tests::parse_defaults_gotchas_to_none_when_absent ... ok
+test lesson::tests::parse_defaults_solution_to_none_when_absent ... ok
+test lesson::tests::parse_defaults_hints_to_none_when_absent ... ok
+test lesson::tests::parse_defaults_packages_to_empty_when_absent ... ok
+test lesson::tests::lesson_json_roundtrip_preserves_value ... ok
+test lesson::tests::parse_reads_checks_as_ordered_code_strings ... ok
+test lesson::tests::parse_rejects_gotchas_with_non_bullet_lines ... ok
+test lesson::tests::parse_rejects_hints_with_non_bullet_lines ... ok
+test lesson::tests::parse_rejects_missing_required_field_naming_it ... ok
+test lesson::tests::read_lesson_file_missing_path_is_a_read_error_not_a_validation_error ... ok
+test llm::feedback::tests::completion_errors_map_to_the_completion_kind ... ok
+test llm::feedback::tests::extraction_failures_map_to_the_extraction_kind ... ok
+test lesson::tests::parse_rejects_unknown_language ... ok
+test llm::prompt::tests::neutralize_marker_introduces_no_structural_token ... ok
+test lesson::tests::parse_rejects_prompt_missing_student_code_placeholder ... ok
+test llm::feedback::tests::feedback_maps_to_the_matching_verdict_variant ... ok
+test lesson::tests::parse_validates_hints_as_bullets_via_fixture ... ok
+test llm::prompt::tests::render_check_neutralizes_a_token_in_the_outcome_detail ... ok
+test llm::prompt::tests::neutralize_rewrites_every_structural_token ... ok
+test llm::prompt::tests::render_check_distinguishes_the_three_outcomes ... ok
+test lesson::tests::parse_rejects_unknown_field_so_author_typos_surface ... ok
+test lesson::tests::parse_rejects_unknown_exercise_type ... ok
+test llm::prompt::tests::render_checks_labels_each_outcome_with_its_check_in_order ... ok
+test llm::prompt::tests::render_checks_never_drops_a_verdict_when_outcomes_exceed_checks ... ok
+test llm::provider::tests::each_provider_has_a_recognizable_default_model ... ok
+test llm::prompt::tests::render_checks_renders_no_line_for_a_check_without_an_outcome ... ok
+test llm::provider::tests::fireworks_is_the_default_provider ... ok
+test llm::provider::tests::each_provider_names_its_own_key_var ... ok
+test llm::provider::tests::each_provider_targets_its_own_api_host ... ok
+test lesson::tests::read_lesson_file_loads_and_parses_the_ported_fixture ... ok
+test run::tests::json_tags_an_incorrect_verdict_distinctly ... ok
+test run::tests::json_splits_the_verdict_into_a_string_tag_and_feedback ... ok
+test run::tests::run_error_labels_each_stage_and_exposes_its_source ... ok
+test runner::python::tests::interpreter_includes_with_flags_for_packages ... ok
+test run::tests::run_report_json_roundtrip_preserves_value ... ok
+test runner::tests::from_capture_keeps_streams_distinct_and_passes_exit_through ... ok
+test lesson::tests::read_lesson_file_invalid_contents_is_a_validation_error ... ok
+test runner::python::tests::interpreter_omits_with_flags_when_packages_empty ... ok
+test scaffold::tests::add_lesson_error_display_and_source_distinguish_each_variant ... ok
+test runner::tests::runner_error_displays_its_stage_and_exposes_the_io_source ... ok
+test scaffold::tests::is_valid_slug_accepts_word_chars_hyphens_and_underscores_but_nothing_else ... ok
+test scaffold::tests::plan_lists_the_starter_files_as_pure_data ... ok
+test scaffold::tests::lesson_template_produces_a_valid_r_lesson ... ok
+test scaffold::tests::lesson_template_produces_a_valid_python_lesson ... ok
+test scaffold::tests::scaffold_course_refuses_a_broken_symlink_target_instead_of_a_cryptic_write_error ... ok
+test scaffold::tests::add_lesson_refuses_a_non_course_directory_without_leaving_an_orphan ... ok
+test scaffold::tests::is_empty_target_surfaces_a_non_notfound_error_rather_than_reading_it_as_empty ... ok
+test scaffold::tests::scaffold_error_display_and_source_distinguish_each_variant ... ok
+test site::tests::build_target_display_names_each_runtime ... ok
+test site::tests::build_target_language_maps_each_runtime_to_its_language ... ok
+test site::tests::eval_report_error_displays_each_variant_and_chains_its_source ... ok
+test site::tests::eval_results_html_not_validated_renders_an_explicit_marker ... ok
+test site::tests::eval_results_html_validated_renders_the_accuracy_and_validated_marker ... ok
+test site::tests::eval_summary_from_report_json_rejects_a_malformed_report ... ok
+test site::tests::eval_summary_from_report_json_rejects_an_out_of_range_accuracy ... ok
+test site::tests::eval_summary_from_report_json_takes_the_accuracy_as_is ... ok
+test scaffold::tests::scaffold_course_refuses_a_nonempty_target_before_writing_anything ... ok
+test scaffold::tests::the_scaffolded_lesson_eval_and_manifest_parse_with_production_parsers ... ok
+test site::tests::plan_error_language_mismatch_displays_the_clash_with_no_nested_source ... ok
+test scaffold::tests::scaffold_course_writes_every_planned_file_verbatim ... ok
+test scaffold::tests::scaffold_course_accepts_an_existing_empty_directory ... ok
+test site::tests::plan_site_cm6_editor_ux_extensions_configured ... ok
+test scaffold::tests::scaffold_course_creates_the_target_directory_when_absent ... ok
+test scaffold::tests::add_lesson_refuses_a_duplicate_without_clobbering_or_double_registering ... ok
+test site::tests::plan_site_assembles_the_shared_byok_feedback_backend ... ok
+test scaffold::tests::add_lesson_refuses_an_unsafe_id_before_writing_anything ... ok
+test site::tests::plan_site_pyodide_assembles_the_shell_runner_core_shim_and_one_json_per_lesson ... ok
+test site::tests::plan_site_carries_the_same_shared_core_and_shim_across_both_targets ... ok
+test site::tests::plan_site_refuses_an_r_course_built_for_the_pyodide_target ... ok
+test site::tests::plan_site_serializes_a_missing_gotchas_as_json_null_not_dropped ... ok
+test site::tests::plan_site_runner_core_splits_hints_and_gotchas ... ok
+test site::tests::plan_site_serializes_a_missing_solution_as_json_null_not_dropped ... ok
+test site::tests::plan_site_serializes_a_missing_hints_as_json_null_not_dropped ... ok
+test site::tests::plan_site_runner_core_renders_hints_as_expandable_details ... ok
+test site::tests::plan_site_emits_csp_sri_and_referrer_policy ... ok
+test site::tests::plan_site_runner_core_sets_cursor_color_via_cm6_theme ... ok
+test site::tests::plan_site_serializes_each_lesson_to_the_browser_contract ... ok
+test site::tests::plan_site_serializes_hints_when_present ... ok
+test site::tests::plan_site_serializes_gotchas_when_present ... ok
+test site::tests::plan_site_folds_the_eval_results_page_for_each_state ... ok
+test site::tests::plan_site_shells_differ_only_by_three_known_diffs ... ok
+test site::tests::plan_site_shells_contain_semantic_regions ... ok
+test scaffold::tests::add_lesson_writes_the_file_and_registers_it_so_the_course_lists_it ... ok
+test site::tests::plan_site_shells_have_link_and_no_inline_style ... ok
+test site::tests::plan_site_serializes_packages_as_array_even_when_empty ... ok
+test site::tests::plan_site_styles_css_declares_tokens_and_uses_them ... ok
+test site::tests::plan_site_shells_have_correct_head_load_order ... ok
+test tests::display_names_the_command_and_the_unimplemented_state ... ok
+test site::tests::plan_site_shells_load_codemirror_as_import ... ok
+test site::tests::plan_site_webr_assembles_the_shell_runner_shim_and_one_json_per_lesson ... ok
+test site::tests::site_lesson_from_lesson_projects_each_contract_field ... ok
+test site::tests::plan_site_styles_css_has_gotchas_panel_rules ... ok
+test site::tests::plan_site_styles_css_is_present_for_both_targets ... ok
+test site::tests::plan_site_styles_css_has_hints_panel_rules ... ok
+test site::tests::write_site_writes_every_planned_file_to_disk ... ok
+test site::tests::plan_site_emits_vendored_codemirror_bundle ... ok
+test site::tests::plan_site_workspace_styles_use_tokens_and_status_renders_as_pill ... ok
+
+test result: ok. 140 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+
+     Running tests/eval.rs (target/debug/deps/eval-e9648ff30096cad5)
+
+running 2 tests
+test rejects_unknown_verdict_naming_the_offending_case ... ok
+test parses_ten_fireworks_vitals_cases_into_typed_suite ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running tests/grade.rs (target/debug/deps/grade-416df2804283aa22)
+
+running 3 tests
+test python_lesson_selects_python_runner ... ok
+test submission_error_is_notrun_not_fail ... ok
+test r_runner_reports_per_check_pass_fail ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.90s
+
+     Running tests/llm.rs (target/debug/deps/llm-a39751c294fe72cb)
+
+running 9 tests
+test build_prompt_neutralizes_injected_delimiter ... ok
+test build_prompt_is_deterministic_offline ... ok
+test build_prompt_renders_delimited_code_and_labeled_sections ... ok
+test request_feedback_incorrect_verdict_and_missing_field_errors ... ok
+test request_feedback_correct_verdict ... ok
+test fireworks_missing_key_errs_before_request ... ok
+test anthropic_missing_key_errs_before_request ... ok
+test fireworks_empty_key_errs_before_request ... ok
+test fireworks_present_key_reaches_server ... ok
+
+test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
+
+     Running tests/runner.rs (target/debug/deps/runner-32e835ce7f66b862)
+
+running 5 tests
+test python_captures_streams_distinctly ... ok
+test captures_stdout_stderr_exit_separately ... ok
+test runs_in_isolated_temp_dir_cleaned_up ... ok
+test python_infinite_loop_times_out ... ok
+test timeout_kills_process_tree_under_natural_runtime ... ok
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.02s
+
+   Doc-tests blendtutor_core
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+


### PR DESCRIPTION
Closes #96. Adds CSP_POLICY const, CSP+referrer meta tags, SRI on Pyodide CDN script. WebR SRI gap documented (ES module import). See .opencode/plans/site-security-hardening/AC-1.md for full spec.