### PR TITLE
feat: Client-side rate limiting for feedback requests

### DIFF
--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::process::ExitCode;
 
 use anyhow::Context;
-use blendtutor_core::course::Course;
+use blendtutor_core::course::{Course, SiteConfig};
 use blendtutor_core::site::{self, BuildTarget, EvalSummary};
 
 /// The conventional name of the Slice-13 eval report a course bundles to have its
@@ -40,7 +40,12 @@ pub fn run(dir: &Path, target: BuildTarget, out: &Path) -> anyhow::Result<ExitCo
     let course = Course::open(dir)?;
     let lessons = course.load_lessons()?;
     let eval = load_eval_summary(dir)?;
-    let site = site::plan_site(&lessons, target, &eval)?;
+    // The site config from the manifest's [site] section, or the default
+    // (max_feedback_per_session = 20) when absent — the caller decides the
+    // default, not plan_site (§2.1: plan_site is pure, takes explicit input).
+    let default_site = SiteConfig::default();
+    let site_config = course.site_config().unwrap_or(&default_site);
+    let site = site::plan_site(&lessons, target, &eval, site_config)?;
     site::write_site(out, &site)?;
     println!(
         "built {} lesson(s) for {target} into {}",

--- a/crates/core/assets/pyodide/index.html
+++ b/crates/core/assets/pyodide/index.html
@@ -47,6 +47,7 @@
     </main>
     <footer class="site-footer"></footer>
     <script type="module" src="lesson-runner.js"></script>
+    <script src="config.js"></script>
     <script type="module" src="feedback.js"></script>
   </body>
 </html>

--- a/crates/core/assets/shared/feedback.js
+++ b/crates/core/assets/shared/feedback.js
@@ -499,6 +499,54 @@ function renderError(container, error) {
   container.replaceChildren(note);
 }
 
+// --- rate limiting (sessionStorage counter) -----------------------------------
+
+// The sessionStorage key for the per-session feedback request counter. A
+// distinct key (not a provider key slot) so the counter is provider-agnostic:
+// feedback requests count against the limit regardless of which provider the
+// learner chose.
+const FEEDBACK_COUNT_KEY = "bt_feedback_count";
+
+// Read the current feedback request count, defaulting to 0 when the key is
+// absent or holds a non-integer value. The parseInt + || 0 guard ensures a
+// corrupt or missing value never yields NaN (which would make every >=
+// comparison false, silently disabling limiting — the negative case from the
+// spec: "no parseInt guard (NaN disables limiting)").
+function feedbackCount() {
+  return parseInt(sessionStorage.getItem(FEEDBACK_COUNT_KEY)) || 0;
+}
+
+// Whether the learner has reached the per-session feedback request limit.
+// Reads window.__btConfig.maxFeedbackPerSession (emitted by config.js); a max
+// of 0 disables feedback entirely (the limit is reached before any request).
+// The comparison is pure: count >= max. JS is single-threaded so the
+// check+increment is atomic — no race condition between concurrent submits.
+function rateLimitReached() {
+  const max =
+    (window.__btConfig && window.__btConfig.maxFeedbackPerSession) || 0;
+  return feedbackCount() >= max;
+}
+
+// Increment the per-session feedback request counter. Called AFTER the
+// try/catch in handleSubmit — both successful and failed requests count, so
+// a provider outage still bounds cost (the user decision: failed requests
+// count). Model discovery (listModels) does NOT call this — discovery is not
+// feedback.
+function incrementFeedbackCount() {
+  sessionStorage.setItem(FEEDBACK_COUNT_KEY, String(feedbackCount() + 1));
+}
+
+// Render the limit-reached message. textContent only — the message is a fixed
+// string (not model output), but textContent is the consistent XSS defense
+// (mirrors renderVerdict precedent: untrusted text is never parsed as HTML).
+function renderLimitReached(container) {
+  const note = document.createElement("p");
+  note.dataset.byok = "limit-reached";
+  note.textContent =
+    "Feedback request limit reached for this session. Reload the page to reset.";
+  container.replaceChildren(note);
+}
+
 // Render the model picker into the feedback container: a labeled `<select>`
 // populated from the learner's live model roster, defaulting to the named fallback
 // when present. The select carries a distinct `data-byok="model"` marker and lives
@@ -585,7 +633,19 @@ async function handleSubmit() {
     // construction — there is no reachable error to surface, so the loading note is
     // always replaced. If a future provider adds throwing logic *outside* listModels,
     // add the renderError guard here then.
+    //
+    // Rate limiting does NOT apply here: model discovery (listModels) is not a
+    // feedback request, so it does not count against the per-session limit. The
+    // counter is incremented only after the actual feedback try/catch below.
     await renderModelPicker(container, { baseUrl, apiKey, provider: providerId });
+    return;
+  }
+  // The rate-limit guard sits at the top of the feedback phase — after model
+  // discovery (which doesn't count) and before the actual feedback request.
+  // A max of 0 (from config.js) disables feedback entirely: the limit is
+  // reached before any request is sent.
+  if (rateLimitReached()) {
+    renderLimitReached(container);
     return;
   }
   const model = selectedModel(container, providerId);
@@ -598,6 +658,11 @@ async function handleSubmit() {
   } catch (error) {
     renderError(container, error);
   }
+  // Increment AFTER the try/catch — both successful and failed requests count
+  // (the user decision: a provider outage still bounds cost). Placing this
+  // inside the try would skip it on error; placing it inside the catch would
+  // only count failures. Here, both paths reach it.
+  incrementFeedbackCount();
 }
 
 const submitButton = document.querySelector("[data-action=submit]");

--- a/crates/core/assets/webr/index.html
+++ b/crates/core/assets/webr/index.html
@@ -41,6 +41,7 @@
     </main>
     <footer class="site-footer"></footer>
     <script type="module" src="lesson-runner.js"></script>
+    <script src="config.js"></script>
     <script type="module" src="feedback.js"></script>
   </body>
 </html>

--- a/crates/core/src/course.rs
+++ b/crates/core/src/course.rs
@@ -50,6 +50,40 @@ pub struct ManifestEntry {
     pub path: PathBuf,
 }
 
+/// The default maximum feedback requests per browser session when the `[site]`
+/// section is absent or omits `max_feedback_per_session`. Lifted to a named
+/// function so both the serde default and [`SiteConfig::default`] share one
+/// source (§5.1) — a future tuning change touches one place.
+const fn default_max_feedback() -> u32 {
+    20
+}
+
+/// Site-level configuration from the optional `[site]` section of
+/// `blendtutor.toml`.
+///
+/// Unknown keys are rejected (§1.3.1) so an author's typo in `[site]` fails
+/// loudly rather than dropping silently, matching the lesson and manifest
+/// models. The `max_feedback_per_session` field defaults to 20 when the `[site]`
+/// section is present but omits it (via `#[serde(default = "default_max_feedback")]`);
+/// when the entire `[site]` section is absent, [`Manifest::site`] is `None` and
+/// the caller applies [`SiteConfig::default`] (which also yields 20).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SiteConfig {
+    /// The maximum number of feedback requests a learner may make per browser
+    /// session. Defaults to 20. A value of 0 disables feedback entirely.
+    #[serde(default = "default_max_feedback")]
+    pub max_feedback_per_session: u32,
+}
+
+impl Default for SiteConfig {
+    fn default() -> Self {
+        SiteConfig {
+            max_feedback_per_session: default_max_feedback(),
+        }
+    }
+}
+
 /// A course manifest: the ordered list of lessons a course contains, parsed from
 /// `blendtutor.toml`.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -57,6 +91,10 @@ pub struct ManifestEntry {
 pub struct Manifest {
     /// The lessons this course lists, in author order.
     pub lessons: Vec<ManifestEntry>,
+    /// Site-level configuration from the optional `[site]` section. `None` when
+    /// the section is absent; the caller applies [`SiteConfig::default`] (max=20).
+    #[serde(default)]
+    pub site: Option<SiteConfig>,
 }
 
 impl Manifest {
@@ -219,6 +257,13 @@ impl Course {
                     })
             })
             .collect()
+    }
+
+    /// The site-level configuration from the manifest's `[site]` section, if
+    /// present. Returns `None` when the course has no `[site]` section; the
+    /// caller applies [`SiteConfig::default`] (max=20) in that case.
+    pub fn site_config(&self) -> Option<&SiteConfig> {
+        self.manifest.site.as_ref()
     }
 }
 
@@ -512,6 +557,75 @@ pathh = "add_two.yaml"
             err.id().to_string(),
             "broken",
             "the failure names the manifest slug of the lesson that broke"
+        );
+    }
+
+    // --- AC-4: client-side rate limiting — SiteConfig parse (predicates 1-3) ----
+
+    #[test]
+    fn feedback_rate_limit_manifest_parses_max_from_site_section() {
+        // Predicate 1: Manifest::parse on [site] max_feedback_per_session = 5
+        // yields manifest.site.max_feedback_per_session == 5.
+        let manifest = Manifest::parse(
+            r#"
+[[lessons]]
+id = "add-two"
+path = "add_two.yaml"
+
+[site]
+max_feedback_per_session = 5
+"#,
+        )
+        .expect("a manifest with [site] max=5 should parse");
+        assert_eq!(
+            manifest
+                .site
+                .as_ref()
+                .expect("site config present when [site] is given")
+                .max_feedback_per_session,
+            5,
+        );
+    }
+
+    #[test]
+    fn feedback_rate_limit_manifest_defaults_to_20_without_site_section() {
+        // Predicate 2: Manifest::parse without [site] yields default 20.
+        // The absent [site] section makes manifest.site None; the caller applies
+        // SiteConfig::default() which carries max=20 (#[serde(default)]).
+        let manifest = Manifest::parse(
+            r#"
+[[lessons]]
+id = "add-two"
+path = "add_two.yaml"
+"#,
+        )
+        .expect("a manifest without [site] should parse");
+        assert!(
+            manifest.site.is_none(),
+            "absent [site] yields None; the caller applies SiteConfig::default()"
+        );
+        // The default the caller applies carries max=20.
+        assert_eq!(SiteConfig::default().max_feedback_per_session, 20);
+    }
+
+    #[test]
+    fn feedback_rate_limit_manifest_rejects_negative_max() {
+        // Predicate 3: Manifest::parse on max_feedback_per_session = -1 is Err
+        // (u32 rejects negatives at the parse boundary — §1.3.1).
+        let err = Manifest::parse(
+            r#"
+[[lessons]]
+id = "add-two"
+path = "add_two.yaml"
+
+[site]
+max_feedback_per_session = -1
+"#,
+        )
+        .expect_err("a negative max must be rejected (u32 rejects negatives)");
+        assert!(
+            matches!(err, ManifestError::Parse(_)),
+            "a negative max is a parse error, got: {err:?}"
         );
     }
 }

--- a/crates/core/src/course.rs
+++ b/crates/core/src/course.rs
@@ -628,4 +628,55 @@ max_feedback_per_session = -1
             "a negative max is a parse error, got: {err:?}"
         );
     }
+
+    // --- Course::site_config accessor — kills mutants on the method itself -----
+
+    #[test]
+    fn site_config_returns_the_manifests_site_section_when_present() {
+        // The accessor must return the actual [site] config, not None and not a
+        // default — a non-default max (5) pins both: None fails is_some, default
+        // (max=20) fails the value check.
+        let manifest = Manifest::parse(
+            r#"
+[[lessons]]
+id = "add-two"
+path = "add_two.yaml"
+
+[site]
+max_feedback_per_session = 5
+"#,
+        )
+        .expect("a manifest with [site] max=5 should parse");
+        let course = Course {
+            root: PathBuf::from("."),
+            manifest,
+        };
+        let config = course
+            .site_config()
+            .expect("site_config must return Some when [site] is present");
+        assert_eq!(config.max_feedback_per_session, 5);
+    }
+
+    #[test]
+    fn site_config_returns_none_when_no_site_section() {
+        // Without [site], the accessor returns None — the caller applies
+        // SiteConfig::default() (max=20). Returning a leaked default here would
+        // break the None contract the build relies on.
+        let manifest = Manifest::parse(
+            r#"
+[[lessons]]
+id = "add-two"
+path = "add_two.yaml"
+"#,
+        )
+        .expect("a manifest without [site] should parse");
+        let course = Course {
+            root: PathBuf::from("."),
+            manifest,
+        };
+        assert!(
+            course.site_config().is_none(),
+            "site_config must return None when [site] is absent"
+        );
+    }
 }

--- a/crates/core/src/site/mod.rs
+++ b/crates/core/src/site/mod.rs
@@ -2352,19 +2352,32 @@ exercise:
 
         // Clause 5: textContent for the limit message (NOT innerHTML). The
         // existing !innerHTML invariant (plan_site_shells_load_codemirror_as_import
-        // clause 6) already guarantees no innerHTML anywhere in lesson-runner-core.js;
-        // here we pin that feedback.js uses textContent for the limit message.
+        // clause 6) already guarantees no innerHTML in lesson-runner-core.js;
+        // here we pin that feedback.js also never uses .innerHTML (property
+        // access) — the comment at line ~473 mentions `innerHTML` in backticks
+        // (no dot), so checking `.innerHTML` catches only real property access.
+        // This covers the limit message AND all other rendering (verdict,
+        // error, pending) — feedback.js handles untrusted model output, so
+        // innerHTML is never safe.
         assert!(
             feedback.contains("textContent"),
             "feedback.js must use textContent for the limit message; feedback={feedback}"
         );
+        assert!(
+            !feedback.contains(".innerHTML"),
+            "feedback.js must NOT use .innerHTML (XSS defense — untrusted model output \
+             and limit messages use textContent); feedback={feedback}"
+        );
 
         // Clause 6: parseInt guard on the stored counter. Without parseInt, a
         // corrupt or missing sessionStorage value yields a string comparison
-        // (or NaN), silently disabling limiting.
+        // (or NaN), silently disabling limiting. We check for `parseInt(`
+        // (the call, with opening paren) rather than bare `parseInt` — the
+        // word appears in explanatory comments but only the call enforces the
+        // guard at runtime.
         assert!(
-            feedback.contains("parseInt"),
-            "feedback.js must use parseInt to guard the stored counter; feedback={feedback}"
+            feedback.contains("parseInt("),
+            "feedback.js must call parseInt() to guard the stored counter; feedback={feedback}"
         );
 
         // Clause 4: counter increment AFTER try/catch (failed requests count).

--- a/crates/core/src/site/mod.rs
+++ b/crates/core/src/site/mod.rs
@@ -21,7 +21,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::course::LessonSlug;
+use crate::course::{LessonSlug, SiteConfig};
 use crate::lesson::{Language, Lesson};
 
 /// Which browser runtime a built site targets, and so which language it serves.
@@ -309,20 +309,39 @@ pub(super) struct TargetAssets<'a> {
     pub lesson_runner_js: &'a str,
 }
 
+/// Render the `config.js` contract file: the `window.__btConfig` global the
+/// feedback.js rate limiter reads. Pure (§2.2): a direct projection of the
+/// [`SiteConfig`] into the JS contract shape — the Rust→JS boundary for
+/// site-level configuration (§3.2), alongside the per-lesson JSON contract.
+fn config_js(site_config: &SiteConfig) -> String {
+    format!(
+        "window.__btConfig = {{ maxFeedbackPerSession: {} }};",
+        site_config.max_feedback_per_session
+    )
+}
+
 /// Assemble a site from one target's [`TargetAssets`] and the loaded lessons.
 ///
 /// The shared scaffolding both targets reuse (§4.2): a target supplies only its
-/// own shell and runner; the runner core, the COOP/COEP shim, and the per-lesson
-/// JSON contract — keyed by position, never by slug, so an author's slug can never
-/// reach the filesystem as a path — are identical across targets and laid out here
-/// in deterministic order. The slug rides inside the JSON as `id`; `lessons.json`
-/// is the ordered slug index the runner enumerates.
-fn assemble(assets: TargetAssets<'_>, lessons: &[(LessonSlug, Lesson)]) -> SiteFiles {
+/// own shell and runner; the runner core, the COOP/COEP shim, the `config.js`
+/// contract, and the per-lesson JSON contract — keyed by position, never by
+/// slug, so an author's slug can never reach the filesystem as a path — are
+/// identical across targets and laid out here in deterministic order. The slug
+/// rides inside the JSON as `id`; `lessons.json` is the ordered slug index the
+/// runner enumerates. `config.js` sits immediately before `feedback.js` so the
+/// `window.__btConfig` global is available when the rate limiter reads it.
+fn assemble(
+    assets: TargetAssets<'_>,
+    lessons: &[(LessonSlug, Lesson)],
+    site_config: &SiteConfig,
+) -> SiteFiles {
+    let config_contents = config_js(site_config);
     let mut files = vec![
         asset("index.html", assets.index_html),
         asset("lesson-runner.js", assets.lesson_runner_js),
         asset("lesson-runner-core.js", LESSON_RUNNER_CORE_JS),
         asset("coi-serviceworker.js", COI_SERVICEWORKER_JS),
+        asset("config.js", &config_contents),
         asset("feedback.js", FEEDBACK_JS),
         asset("styles.css", STYLES_CSS),
         asset("codemirror.js", CODEMIRROR_JS),
@@ -456,6 +475,7 @@ pub fn plan_site(
     lessons: &[(LessonSlug, Lesson)],
     target: BuildTarget,
     eval: &EvalSummary,
+    site_config: &SiteConfig,
 ) -> Result<SiteFiles, PlanError> {
     for (slug, lesson) in lessons {
         if lesson.language != target.language() {
@@ -467,8 +487,8 @@ pub fn plan_site(
         }
     }
     let mut site = match target {
-        BuildTarget::Webr => webr::plan(lessons),
-        BuildTarget::Pyodide => pyodide::plan(lessons),
+        BuildTarget::Webr => webr::plan(lessons, site_config),
+        BuildTarget::Pyodide => pyodide::plan(lessons, site_config),
     };
     site.files.push(SiteFile {
         path: "eval-results.html".into(),
@@ -536,9 +556,16 @@ mod tests {
 
     /// Plan a site with no eval validation — the default for the tests about
     /// lesson assembly, not the eval-results page. Eval folding is exercised by the
-    /// dedicated tests below with an explicit [`EvalSummary`].
+    /// dedicated tests below with an explicit [`EvalSummary`]. Uses the default
+    /// [`SiteConfig`] (max_feedback_per_session = 20) — site-config behavior is
+    /// exercised by the dedicated `feedback_rate_limit_*` tests below.
     fn plan(lessons: &[(LessonSlug, Lesson)], target: BuildTarget) -> Result<SiteFiles, PlanError> {
-        plan_site(lessons, target, &EvalSummary::NotValidated)
+        plan_site(
+            lessons,
+            target,
+            &EvalSummary::NotValidated,
+            &SiteConfig::default(),
+        )
     }
 
     #[test]
@@ -1440,6 +1467,7 @@ exercise:
             &EvalSummary::Validated {
                 accuracy: 0.6666666666666666,
             },
+            &SiteConfig::default(),
         )
         .expect("plans");
         let validated_page = file(&validated, "eval-results.html").contents.clone();
@@ -1447,8 +1475,13 @@ exercise:
         assert!(validated_page.contains(EvalSummary::VALIDATED_MARKER));
         assert!(!validated_page.contains(EvalSummary::NOT_VALIDATED_MARKER));
 
-        let unvalidated =
-            plan_site(&r_course(), BuildTarget::Webr, &EvalSummary::NotValidated).expect("plans");
+        let unvalidated = plan_site(
+            &r_course(),
+            BuildTarget::Webr,
+            &EvalSummary::NotValidated,
+            &SiteConfig::default(),
+        )
+        .expect("plans");
         assert!(
             file(&unvalidated, "eval-results.html")
                 .contents
@@ -1463,6 +1496,7 @@ exercise:
             &EvalSummary::Validated {
                 accuracy: 0.6666666666666666,
             },
+            &SiteConfig::default(),
         )
         .expect("plans");
         assert_eq!(
@@ -2189,5 +2223,92 @@ exercise:
             rest = &rest[body_start + close..];
         }
         false
+    }
+
+    // --- AC-4: client-side rate limiting — config.js emission (predicates 4-5) --
+
+    #[test]
+    fn feedback_rate_limit_plan_site_emits_config_js() {
+        // Predicate 4: plan_site emits config.js with "maxFeedbackPerSession": 5.
+        // The config.js file is the Rust→JS contract for site-level configuration
+        // (§3.2): it carries window.__btConfig = { maxFeedbackPerSession: N },
+        // which feedback.js reads to enforce the per-session rate limit.
+        let site_config = SiteConfig {
+            max_feedback_per_session: 5,
+        };
+        let site = plan_site(
+            &r_course(),
+            BuildTarget::Webr,
+            &EvalSummary::NotValidated,
+            &site_config,
+        )
+        .expect("plans");
+        let config = file(&site, "config.js");
+        assert!(
+            config.contents.contains("window.__btConfig"),
+            "config.js must set window.__btConfig; got: {}",
+            config.contents
+        );
+        assert!(
+            config.contents.contains("maxFeedbackPerSession"),
+            "config.js must contain maxFeedbackPerSession; got: {}",
+            config.contents
+        );
+        assert!(
+            config.contents.contains("maxFeedbackPerSession: 5"),
+            "config.js must carry the configured max (5); got: {}",
+            config.contents
+        );
+
+        // The default SiteConfig (max=20) emits 20 — the default the feedback
+        // rate limiter reads when no [site] section is present.
+        let default_site = plan(&r_course(), BuildTarget::Webr).expect("plans");
+        let default_config = file(&default_site, "config.js");
+        assert!(
+            default_config
+                .contents
+                .contains("maxFeedbackPerSession: 20"),
+            "config.js must carry the default max (20); got: {}",
+            default_config.contents
+        );
+
+        // config.js is byte-identical across targets (shared contract, §4.2).
+        let pyodide = plan_site(
+            &python_course(),
+            BuildTarget::Pyodide,
+            &EvalSummary::NotValidated,
+            &site_config,
+        )
+        .expect("plans");
+        assert_eq!(
+            file(&site, "config.js").contents,
+            file(&pyodide, "config.js").contents,
+            "config.js must be byte-identical across targets for the same SiteConfig"
+        );
+    }
+
+    #[test]
+    fn feedback_rate_limit_shells_load_config_before_feedback() {
+        // Predicate 5: both targets' index.html load config.js BEFORE feedback.js.
+        // config.js sets window.__btConfig synchronously (classic script, not a
+        // deferred module) so the global is available when feedback.js (a deferred
+        // module) reads it. A shell that loads feedback.js first would leave
+        // __btConfig undefined at rate-limit check time.
+        let webr = plan(&r_course(), BuildTarget::Webr).expect("plans");
+        let pyodide = plan(&python_course(), BuildTarget::Pyodide).expect("plans");
+        for (target, site) in [(BuildTarget::Webr, &webr), (BuildTarget::Pyodide, &pyodide)] {
+            let html = &file(&site, "index.html").contents;
+            let config_pos = html
+                .find(r#"src="config.js""#)
+                .unwrap_or_else(|| panic!("{target}: index.html must reference config.js"));
+            let feedback_pos = html
+                .find(r#"src="feedback.js""#)
+                .unwrap_or_else(|| panic!("{target}: index.html must reference feedback.js"));
+            assert!(
+                config_pos < feedback_pos,
+                "{target}: config.js must load before feedback.js (so __btConfig is set \
+                 before the rate limiter reads it)"
+            );
+        }
     }
 }

--- a/crates/core/src/site/mod.rs
+++ b/crates/core/src/site/mod.rs
@@ -2311,4 +2311,145 @@ exercise:
             );
         }
     }
+
+    // --- AC-4: client-side rate limiting — feedback.js source scan (6,7) -------
+
+    #[test]
+    fn feedback_rate_limit_feedback_js_has_rate_limiting() {
+        // Predicate 6: feedback.js contains the rate-limiting patterns. No JS
+        // harness exists, so this is a static source scan of the emitted feedback.js
+        // (verification: code). 6 sub-clauses pin the invariant (§1.5):
+        //   1. "bt_feedback_count" sessionStorage key
+        //   2. window.__btConfig.maxFeedbackPerSession read
+        //   3. limit-reached message string
+        //   4. counter increment AFTER try/catch (failed requests count)
+        //   5. textContent for limit message (NOT innerHTML — XSS defense)
+        //   6. parseInt guard on stored counter
+        let webr = plan(&r_course(), BuildTarget::Webr).expect("plans");
+        let feedback = &file(&webr, "feedback.js").contents;
+
+        // Clause 1: the bt_feedback_count sessionStorage key.
+        assert!(
+            feedback.contains("bt_feedback_count"),
+            "feedback.js must use the bt_feedback_count sessionStorage key; feedback={feedback}"
+        );
+
+        // Clause 2: window.__btConfig.maxFeedbackPerSession read.
+        assert!(
+            feedback.contains("__btConfig"),
+            "feedback.js must read window.__btConfig; feedback={feedback}"
+        );
+        assert!(
+            feedback.contains("maxFeedbackPerSession"),
+            "feedback.js must read maxFeedbackPerSession from __btConfig; feedback={feedback}"
+        );
+
+        // Clause 3: a limit-reached message string (the user-facing copy).
+        assert!(
+            feedback.to_lowercase().contains("limit"),
+            "feedback.js must contain a limit-reached message; feedback={feedback}"
+        );
+
+        // Clause 5: textContent for the limit message (NOT innerHTML). The
+        // existing !innerHTML invariant (plan_site_shells_load_codemirror_as_import
+        // clause 6) already guarantees no innerHTML anywhere in lesson-runner-core.js;
+        // here we pin that feedback.js uses textContent for the limit message.
+        assert!(
+            feedback.contains("textContent"),
+            "feedback.js must use textContent for the limit message; feedback={feedback}"
+        );
+
+        // Clause 6: parseInt guard on the stored counter. Without parseInt, a
+        // corrupt or missing sessionStorage value yields a string comparison
+        // (or NaN), silently disabling limiting.
+        assert!(
+            feedback.contains("parseInt"),
+            "feedback.js must use parseInt to guard the stored counter; feedback={feedback}"
+        );
+
+        // Clause 4: counter increment AFTER try/catch (failed requests count).
+        // The increment call must NOT be inside the try block (which would skip
+        // it on error) and must appear after the catch block's renderError call
+        // (the last statement in the catch). We scope the search to handleSubmit
+        // to avoid matching the try/catch in listModels.
+        let handle_submit_pos = feedback
+            .find("async function handleSubmit")
+            .expect("feedback.js must define handleSubmit");
+        let handle_submit_body = &feedback[handle_submit_pos..];
+
+        let try_pos = handle_submit_body
+            .find("try {")
+            .expect("handleSubmit must have a try block");
+        let catch_pos = handle_submit_body
+            .find("} catch (error) {")
+            .expect("handleSubmit must have a catch block");
+        let increment_pos = handle_submit_body
+            .find("incrementFeedbackCount()")
+            .expect("feedback.js must call incrementFeedbackCount in handleSubmit");
+        let render_error_pos = handle_submit_body
+            .find("renderError(container, error)")
+            .expect("handleSubmit must call renderError in the catch block");
+
+        // The increment must NOT be inside the try block (between try { and } catch).
+        assert!(
+            !(increment_pos > try_pos && increment_pos < catch_pos),
+            "incrementFeedbackCount must NOT be inside the try block \
+             (failed requests count — the negative case: increment only inside try \
+             skips failures); feedback={feedback}"
+        );
+        // The increment must be after renderError (the last statement in the catch),
+        // so it is reached on both success and failure paths.
+        assert!(
+            increment_pos > render_error_pos,
+            "incrementFeedbackCount must be called AFTER the try/catch block \
+             (after renderError in the catch — both paths reach it); feedback={feedback}"
+        );
+    }
+
+    #[test]
+    fn feedback_rate_limit_feedback_js_does_not_increment_around_list_models() {
+        // Predicate 7: feedback.js does NOT increment the counter around
+        // listModels (model discovery is not feedback — it doesn't count).
+        // We verify the increment call does not appear in the listModels or
+        // renderModelPicker function bodies.
+        let webr = plan(&r_course(), BuildTarget::Webr).expect("plans");
+        let feedback = &file(&webr, "feedback.js").contents;
+
+        // Check listModels: find its body (from the function definition to the
+        // next function definition) and assert no increment call within.
+        let listmodels_start = feedback
+            .find("async function listModels")
+            .expect("feedback.js must define listModels");
+        let after_listmodels = &feedback[listmodels_start..];
+        let listmodels_end = after_listmodels[1..]
+            .find("\nfunction ")
+            .or_else(|| after_listmodels[1..].find("\nasync function "))
+            .map(|p| p + 1)
+            .unwrap_or(after_listmodels.len());
+        let listmodels_body = &after_listmodels[..listmodels_end];
+        assert!(
+            !listmodels_body.contains("incrementFeedbackCount()"),
+            "listModels must NOT call incrementFeedbackCount \
+             (model discovery doesn't count); feedback={feedback}"
+        );
+
+        // Check renderModelPicker: the function that calls listModels. The
+        // increment must not appear here either — the guard and increment live
+        // in handleSubmit, after the model picker phase.
+        let picker_start = feedback
+            .find("async function renderModelPicker")
+            .expect("feedback.js must define renderModelPicker");
+        let after_picker = &feedback[picker_start..];
+        let picker_end = after_picker[1..]
+            .find("\nfunction ")
+            .or_else(|| after_picker[1..].find("\nasync function "))
+            .map(|p| p + 1)
+            .unwrap_or(after_picker.len());
+        let picker_body = &after_picker[..picker_end];
+        assert!(
+            !picker_body.contains("incrementFeedbackCount()"),
+            "renderModelPicker must NOT call incrementFeedbackCount \
+             (model discovery doesn't count); feedback={feedback}"
+        );
+    }
 }

--- a/crates/core/src/site/mod.rs
+++ b/crates/core/src/site/mod.rs
@@ -2297,7 +2297,7 @@ exercise:
         let webr = plan(&r_course(), BuildTarget::Webr).expect("plans");
         let pyodide = plan(&python_course(), BuildTarget::Pyodide).expect("plans");
         for (target, site) in [(BuildTarget::Webr, &webr), (BuildTarget::Pyodide, &pyodide)] {
-            let html = &file(&site, "index.html").contents;
+            let html = &file(site, "index.html").contents;
             let config_pos = html
                 .find(r#"src="config.js""#)
                 .unwrap_or_else(|| panic!("{target}: index.html must reference config.js"));

--- a/crates/core/src/site/pyodide.rs
+++ b/crates/core/src/site/pyodide.rs
@@ -9,7 +9,7 @@
 //! [`super::BuildTarget`] seam: a second target adds an impl + assets, reusing the
 //! shared layout and the lesson-JSON contract (§3.2, §3.4, §4.2).
 
-use crate::course::LessonSlug;
+use crate::course::{LessonSlug, SiteConfig};
 use crate::lesson::Lesson;
 
 use super::{SiteFiles, TargetAssets};
@@ -29,12 +29,13 @@ const LESSON_RUNNER_JS: &str = include_str!(concat!(
 /// Assemble the Pyodide site for `lessons`. Pure: the caller has already verified
 /// every lesson is Python (§1.3.1), so this only contributes the Pyodide shell +
 /// runner to the shared [`super::assemble`] scaffolding.
-pub(super) fn plan(lessons: &[(LessonSlug, Lesson)]) -> SiteFiles {
+pub(super) fn plan(lessons: &[(LessonSlug, Lesson)], site_config: &SiteConfig) -> SiteFiles {
     super::assemble(
         TargetAssets {
             index_html: INDEX_HTML,
             lesson_runner_js: LESSON_RUNNER_JS,
         },
         lessons,
+        site_config,
     )
 }

--- a/crates/core/src/site/webr.rs
+++ b/crates/core/src/site/webr.rs
@@ -8,7 +8,7 @@
 //! [`super::assemble`], so a second target adds an impl + assets without
 //! re-deriving the shared layout (§4.2).
 
-use crate::course::LessonSlug;
+use crate::course::{LessonSlug, SiteConfig};
 use crate::lesson::Lesson;
 
 use super::{SiteFiles, TargetAssets};
@@ -28,12 +28,13 @@ const LESSON_RUNNER_JS: &str = include_str!(concat!(
 /// Assemble the webR site for `lessons`. Pure: the caller has already verified
 /// every lesson is R (§1.3.1), so this only contributes the webR shell + runner
 /// to the shared [`super::assemble`] scaffolding.
-pub(super) fn plan(lessons: &[(LessonSlug, Lesson)]) -> SiteFiles {
+pub(super) fn plan(lessons: &[(LessonSlug, Lesson)], site_config: &SiteConfig) -> SiteFiles {
     super::assemble(
         TargetAssets {
             index_html: INDEX_HTML,
             lesson_runner_js: LESSON_RUNNER_JS,
         },
         lessons,
+        site_config,
     )
 }

--- a/docs/evidence/98/spec-probe.log
+++ b/docs/evidence/98/spec-probe.log
@@ -1,0 +1,39 @@
+   Compiling blendtutor-core v0.1.0 (/Users/carbonite/Documents/coding/portfolio/worktree-issue-98/crates/core)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 2.90s
+     Running unittests src/lib.rs (target/debug/deps/blendtutor_core-e6b2900eafa92e80)
+
+running 7 tests
+test course::tests::feedback_rate_limit_manifest_parses_max_from_site_section ... ok
+test course::tests::feedback_rate_limit_manifest_defaults_to_20_without_site_section ... ok
+test course::tests::feedback_rate_limit_manifest_rejects_negative_max ... ok
+test site::tests::feedback_rate_limit_feedback_js_does_not_increment_around_list_models ... ok
+test site::tests::feedback_rate_limit_feedback_js_has_rate_limiting ... ok
+test site::tests::feedback_rate_limit_shells_load_config_before_feedback ... ok
+test site::tests::feedback_rate_limit_plan_site_emits_config_js ... ok
+
+test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 139 filtered out; finished in 0.01s
+
+     Running tests/eval.rs (target/debug/deps/eval-e9648ff30096cad5)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s
+
+     Running tests/grade.rs (target/debug/deps/grade-416df2804283aa22)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s
+
+     Running tests/llm.rs (target/debug/deps/llm-a39751c294fe72cb)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 9 filtered out; finished in 0.00s
+
+     Running tests/runner.rs (target/debug/deps/runner-32e835ce7f66b862)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s
+

--- a/docs/evidence/98/test-suite.log
+++ b/docs/evidence/98/test-suite.log
@@ -1,0 +1,367 @@
+   Compiling blendtutor-core v0.1.0 (/Users/carbonite/Documents/coding/portfolio/worktree-issue-98/crates/core)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.93s
+     Running unittests src/main.rs (target/debug/deps/blendtutor-78897dbdb2b5c55f)
+
+running 9 tests
+test commands::eval::tests::sibling_suite_keeps_a_bare_file_name_in_the_current_directory ... ok
+test commands::eval::tests::sibling_suite_of_a_path_without_a_file_name_is_the_prefix_alone ... ok
+test output::tests::list_renders_an_empty_course_in_both_formats ... ok
+test commands::eval::tests::sibling_suite_prefixes_the_lesson_file_name_with_eval ... ok
+test output::tests::list_json_separates_found_rows_from_failed_rows ... ok
+test output::tests::validate_human_invalid_matches_snapshot ... ok
+test output::tests::list_human_matches_snapshot ... ok
+test output::tests::eval_human_matches_snapshot ... ok
+test output::tests::validate_human_matches_snapshot ... ok
+
+test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+
+     Running tests/build.rs (target/debug/deps/build-b1e5f10ad570ac6c)
+
+running 14 tests
+test build_refuses_a_language_target_mismatch_before_writing_anything ... ok
+test build_emits_empty_packages_array_when_lesson_has_no_packages ... ok
+test build_emits_lesson_json_with_packages_array ... ok
+test build_webr_ships_the_multi_provider_feedback_seam ... ok
+test build_webr_ships_the_byok_anthropic_feedback_seam ... ok
+test build_webr_ships_the_byok_fireworks_feedback_seam ... ok
+test build_pyodide_emits_a_deployable_python_lesson_site ... ok
+test corrupt_eval_report_fails_the_build_loudly ... ok
+test build_webr_emits_a_deployable_r_lesson_site ... ok
+test build_pyodide_ships_the_same_shared_feedback_seam ... ok
+test missing_report_builds_with_not_validated_page ... ok
+test eval_report_page_reflects_actual_accuracy ... ok
+test build_dark_mode_token_overrides ... ok
+test build_webr_styles_byok_feedback_panel ... ok
+
+test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.36s
+
+     Running tests/cli.rs (target/debug/deps/cli-e5fdfcb641f75fdc)
+
+running 2 tests
+test version_prints_crate_version ... ok
+test help_lists_subcommands ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+
+     Running tests/cutover.rs (target/debug/deps/cutover-cf5a1576aef45451)
+
+running 2 tests
+test r_package_artifacts_are_absent_from_root ... ok
+test no_r_package_sources_are_tracked ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+
+     Running tests/eval.rs (target/debug/deps/eval-6d3a09b074180302)
+
+running 2 tests
+test eval_json_emits_per_case_verdicts_and_aggregate ... ok
+test eval_reports_aggregate_accuracy_and_per_case_results ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.09s
+
+     Running tests/hints_content.rs (target/debug/deps/hints_content-ec73f3b67ce288cb)
+
+running 8 tests
+test r_lesson_2_prompt_retains_stress_6 ... ok
+test python_lesson_2_prompt_retains_stress_6 ... ok
+test r_hints_and_gotchas_satisfy_all_invariants ... ok
+test python_hints_and_gotchas_satisfy_all_invariants ... ok
+test build_python_course_emits_non_null_hints_and_gotchas ... ok
+test build_r_course_emits_non_null_hints_and_gotchas ... ok
+test r_validate_each_lesson_exits_zero ... ok
+test python_validate_each_lesson_exits_zero ... ok
+
+test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+
+     Running tests/init.rs (target/debug/deps/init-c5e64538711fd323)
+
+running 2 tests
+test init_refuses_a_nonempty_target_leaving_it_untouched ... ok
+test init_scaffolds_a_ready_course_that_list_accepts ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+
+     Running tests/list.rs (target/debug/deps/list-082a03a2ff1c7a67)
+
+running 3 tests
+test list_on_a_directory_without_a_manifest_exits_nonzero ... ok
+test list_reports_each_lessons_id_language_and_title ... ok
+test list_reports_a_malformed_lesson_as_an_error_row_without_losing_the_good_ones ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+
+     Running tests/new.rs (target/debug/deps/new-cd8cae3d7a5a8b81)
+
+running 3 tests
+test new_lesson_refuses_a_duplicate_id_without_clobbering ... ok
+test new_lesson_r_creates_a_lesson_that_validates_and_lists ... ok
+test new_lesson_python_creates_a_lesson_that_validates_and_lists ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+
+     Running tests/readme.rs (target/debug/deps/readme-01876217fcf2db51)
+
+running 1 test
+test readme_documents_the_cli_install_and_workflow ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running tests/run.rs (target/debug/deps/run-0820e0e778dd75c5)
+
+running 7 tests
+test run_missing_code_exits_one ... ok
+test run_provider_error_exits_one ... ok
+test run_format_json_stays_clean_under_logging ... ok
+test run_human_format_is_not_json ... ok
+test run_incorrect_submission_exits_two_with_feedback ... ok
+test run_correct_code_reports_correct_and_exit_zero ... ok
+test run_format_json_emits_one_typed_report ... ok
+
+test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.15s
+
+     Running tests/validate.rs (target/debug/deps/validate-9afd1ae7c7a72246)
+
+running 4 tests
+test validate_invalid_lesson_exits_nonzero_naming_problem ... ok
+test validate_lesson_without_student_code_placeholder_exits_nonzero_naming_the_rule ... ok
+test validate_valid_lesson_reports_ok_and_exit_zero ... ok
+test validate_json_emits_documented_object_with_exit_code_parity ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+
+     Running tests/write_less_code_python.rs (target/debug/deps/write_less_code_python-a6f079db8864f351)
+
+running 10 tests
+test lesson_4_solution_uses_explicit_for_loop_not_list_comprehension ... ok
+test lesson_2_prompt_contains_literal_stress_6 ... ok
+test eval_suites_have_correct_case_distribution ... ok
+test each_lesson_is_valid_python_with_student_code_and_textbook ... ok
+test packages_bidirectional_pandas_iff_used ... ok
+test checks_non_empty_and_specific ... ok
+test list_returns_five_python_lessons ... ok
+test validate_each_lesson_exits_zero ... ok
+test eval_suites_have_near_miss_that_runs_cleanly ... ok
+test run_solution_exits_zero_with_correct ... ok
+
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.34s
+
+     Running tests/write_less_code_r.rs (target/debug/deps/write_less_code_r-170a2c73000824aa)
+
+running 13 tests
+test layer8_each_lesson_has_textbook_reference ... ok
+test layer5_eval_suites_have_minimum_cases ... ok
+test layer7_solutions_are_self_contained ... ok
+test negative_lesson2_check_references_stress_6_rev ... ok
+test layer2_list_returns_five_r_lessons ... ok
+test layer1_validate_exits_zero_for_all_lessons ... ok
+test negative_lesson4_solution_uses_purrr_dplyr ... ok
+test layer9_run_exits_zero_with_correct_verdict ... ok
+test negative_checks_fail_against_wrong_submissions ... ok
+test layer6_each_lesson_has_genuine_near_miss ... ok
+test layer3_solutions_execute_cleanly ... ok
+test near_miss_submissions_fail_at_least_one_check ... ok
+test layer4_checks_pass_against_reference_solution ... ok
+
+test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.68s
+
+     Running unittests src/lib.rs (target/debug/deps/blendtutor_core-afe9e8a79b46e2b0)
+
+running 146 tests
+test course::tests::manifest_error_display_and_source_distinguish_each_variant ... ok
+test course::tests::feedback_rate_limit_manifest_parses_max_from_site_section ... ok
+test course::tests::manifest_parse_reads_each_entrys_id_and_path ... ok
+test course::tests::feedback_rate_limit_manifest_defaults_to_20_without_site_section ... ok
+test course::tests::feedback_rate_limit_manifest_rejects_negative_max ... ok
+test course::tests::manifest_parse_rejects_unknown_key_so_author_typos_surface ... ok
+test course::tests::manifest_parse_rejects_a_path_escaping_the_course_directory ... ok
+test course::tests::open_missing_manifest_is_a_read_error_not_a_parse_error ... ok
+test eval::tests::aggregate_is_matched_over_total_and_zero_for_an_empty_suite ... ok
+test eval::tests::case_result_derives_matched_from_score_case ... ok
+test eval::tests::eval_run_error_names_the_one_based_case_and_chains_its_source ... ok
+test eval::tests::from_token_maps_the_two_polarity_words_and_rejects_others ... ok
+test eval::tests::expected_verdict_serializes_to_its_canonical_token ... ok
+test eval::tests::score_case_matches_same_polarity_and_rejects_the_opposite ... ok
+test eval::tests::scores_two_of_three_and_aggregates ... ok
+test eval::tests::structural_error_surfaces_the_underlying_parser_message ... ok
+test eval::tests::unknown_verdict_error_names_the_case_index_and_quotes_the_token ... ok
+test eval::tests::parse_eval_suite_surfaces_unknown_verdict_with_its_case_index_and_token ... ok
+test eval::tests::verdict_polarity_drops_the_feedback_message ... ok
+test course::tests::discover_summarizes_each_lesson_with_its_slug_language_and_title ... ok
+test course::tests::load_lessons_returns_every_lesson_in_full_and_in_author_order ... ok
+test eval::tests::parse_rejects_unknown_key_so_author_typos_surface ... ok
+test grade::tests::select_runner_dispatches_a_python_lesson_to_the_python_runner ... ok
+test grade::tests::a_submission_that_exits_nonzero_makes_every_check_notrun ... ok
+test grade::tests::select_runner_dispatches_an_r_lesson_to_the_r_runner ... ok
+test grade::tests::checks_are_classified_element_wise_in_order ... ok
+test grade::tests::no_checks_runs_nothing_and_returns_empty ... ok
+test grade::tests::a_submission_whose_interpreter_cannot_launch_makes_checks_notrun ... ok
+test course::tests::discover_reports_a_malformed_lesson_as_an_error_row_keeping_the_good_ones ... ok
+test grade::tests::a_check_whose_interpreter_cannot_launch_is_a_fail ... ok
+test grade::tests::select_runner_threads_packages_to_python_runner ... ok
+test course::tests::discovery_error_display_and_source_surface_the_underlying_load_failure ... ok
+test lesson::tests::load_error_display_and_source_surface_the_cause ... ok
+test lesson::tests::parse_accepts_empty_gotchas ... ok
+test course::tests::load_lessons_fails_on_the_first_broken_lesson_rather_than_dropping_it ... ok
+test lesson::tests::lesson_id_displays_its_value ... ok
+test lesson::tests::parse_accepts_hints_with_star_bullets ... ok
+test lesson::tests::parse_accepts_gotchas_with_star_bullets ... ok
+test lesson::tests::parse_accepts_empty_hints ... ok
+test lesson::tests::parse_defaults_checks_to_empty_when_absent ... ok
+test lesson::tests::lesson_json_roundtrip_preserves_value ... ok
+test lesson::tests::parse_defaults_gotchas_to_none_when_absent ... ok
+test lesson::tests::parse_defaults_packages_to_empty_when_absent ... ok
+test lesson::tests::parse_defaults_hints_to_none_when_absent ... ok
+test lesson::tests::parse_accepts_valid_lesson ... ok
+test lesson::tests::parse_defaults_solution_to_none_when_absent ... ok
+test lesson::tests::parse_reads_an_optional_gotchas_field ... ok
+test lesson::tests::parse_reads_an_optional_hints_field ... ok
+test lesson::tests::parse_accepts_none_gotchas ... ok
+test lesson::tests::parse_reads_an_optional_reference_solution ... ok
+test lesson::tests::parse_reads_checks_as_ordered_code_strings ... ok
+test lesson::tests::parse_reads_packages_as_ordered_strings ... ok
+test lesson::tests::parse_rejects_gotchas_with_non_bullet_lines ... ok
+test lesson::tests::parse_rejects_missing_required_field_naming_it ... ok
+test lesson::tests::parse_rejects_unknown_exercise_type ... ok
+test lesson::tests::parse_rejects_hints_with_non_bullet_lines ... ok
+test lesson::tests::parse_rejects_unknown_field_so_author_typos_surface ... ok
+test lesson::tests::parse_rejects_prompt_missing_student_code_placeholder ... ok
+test lesson::tests::parse_rejects_unknown_language ... ok
+test llm::feedback::tests::feedback_maps_to_the_matching_verdict_variant ... ok
+test llm::prompt::tests::neutralize_rewrites_every_structural_token ... ok
+test lesson::tests::read_lesson_file_missing_path_is_a_read_error_not_a_validation_error ... ok
+test lesson::tests::parse_validates_hints_as_bullets_via_fixture ... ok
+test lesson::tests::read_lesson_file_loads_and_parses_the_ported_fixture ... ok
+test llm::prompt::tests::render_check_neutralizes_a_token_in_the_outcome_detail ... ok
+test llm::feedback::tests::completion_errors_map_to_the_completion_kind ... ok
+test llm::feedback::tests::extraction_failures_map_to_the_extraction_kind ... ok
+test llm::prompt::tests::neutralize_marker_introduces_no_structural_token ... ok
+test llm::prompt::tests::render_check_distinguishes_the_three_outcomes ... ok
+test llm::provider::tests::each_provider_has_a_recognizable_default_model ... ok
+test llm::provider::tests::each_provider_names_its_own_key_var ... ok
+test llm::provider::tests::each_provider_targets_its_own_api_host ... ok
+test llm::prompt::tests::render_checks_labels_each_outcome_with_its_check_in_order ... ok
+test llm::prompt::tests::render_checks_never_drops_a_verdict_when_outcomes_exceed_checks ... ok
+test llm::provider::tests::fireworks_is_the_default_provider ... ok
+test llm::prompt::tests::render_checks_renders_no_line_for_a_check_without_an_outcome ... ok
+test lesson::tests::read_lesson_file_invalid_contents_is_a_validation_error ... ok
+test run::tests::json_splits_the_verdict_into_a_string_tag_and_feedback ... ok
+test run::tests::json_tags_an_incorrect_verdict_distinctly ... ok
+test run::tests::run_error_labels_each_stage_and_exposes_its_source ... ok
+test run::tests::run_report_json_roundtrip_preserves_value ... ok
+test runner::python::tests::interpreter_omits_with_flags_when_packages_empty ... ok
+test runner::tests::runner_error_displays_its_stage_and_exposes_the_io_source ... ok
+test scaffold::tests::add_lesson_error_display_and_source_distinguish_each_variant ... ok
+test scaffold::tests::is_valid_slug_accepts_word_chars_hyphens_and_underscores_but_nothing_else ... ok
+test scaffold::tests::plan_lists_the_starter_files_as_pure_data ... ok
+test scaffold::tests::is_empty_target_surfaces_a_non_notfound_error_rather_than_reading_it_as_empty ... ok
+test runner::python::tests::interpreter_includes_with_flags_for_packages ... ok
+test runner::tests::from_capture_keeps_streams_distinct_and_passes_exit_through ... ok
+test scaffold::tests::add_lesson_refuses_a_non_course_directory_without_leaving_an_orphan ... ok
+test scaffold::tests::lesson_template_produces_a_valid_python_lesson ... ok
+test scaffold::tests::lesson_template_produces_a_valid_r_lesson ... ok
+test scaffold::tests::scaffold_error_display_and_source_distinguish_each_variant ... ok
+test site::tests::build_target_display_names_each_runtime ... ok
+test site::tests::build_target_language_maps_each_runtime_to_its_language ... ok
+test site::tests::eval_report_error_displays_each_variant_and_chains_its_source ... ok
+test site::tests::eval_results_html_not_validated_renders_an_explicit_marker ... ok
+test scaffold::tests::scaffold_course_refuses_a_broken_symlink_target_instead_of_a_cryptic_write_error ... ok
+test scaffold::tests::the_scaffolded_lesson_eval_and_manifest_parse_with_production_parsers ... ok
+test site::tests::eval_results_html_validated_renders_the_accuracy_and_validated_marker ... ok
+test scaffold::tests::scaffold_course_refuses_a_nonempty_target_before_writing_anything ... ok
+test site::tests::eval_summary_from_report_json_rejects_a_malformed_report ... ok
+test site::tests::eval_summary_from_report_json_rejects_an_out_of_range_accuracy ... ok
+test site::tests::eval_summary_from_report_json_takes_the_accuracy_as_is ... ok
+test scaffold::tests::add_lesson_refuses_a_duplicate_without_clobbering_or_double_registering ... ok
+test scaffold::tests::add_lesson_refuses_an_unsafe_id_before_writing_anything ... ok
+test scaffold::tests::scaffold_course_accepts_an_existing_empty_directory ... ok
+test scaffold::tests::scaffold_course_writes_every_planned_file_verbatim ... ok
+test scaffold::tests::scaffold_course_creates_the_target_directory_when_absent ... ok
+test site::tests::feedback_rate_limit_feedback_js_does_not_increment_around_list_models ... ok
+test scaffold::tests::add_lesson_writes_the_file_and_registers_it_so_the_course_lists_it ... ok
+test site::tests::plan_error_language_mismatch_displays_the_clash_with_no_nested_source ... ok
+test site::tests::feedback_rate_limit_feedback_js_has_rate_limiting ... ok
+test site::tests::feedback_rate_limit_shells_load_config_before_feedback ... ok
+test site::tests::plan_site_cm6_editor_ux_extensions_configured ... ok
+test site::tests::plan_site_assembles_the_shared_byok_feedback_backend ... ok
+test site::tests::feedback_rate_limit_plan_site_emits_config_js ... ok
+test site::tests::plan_site_pyodide_assembles_the_shell_runner_core_shim_and_one_json_per_lesson ... ok
+test site::tests::plan_site_carries_the_same_shared_core_and_shim_across_both_targets ... ok
+test site::tests::plan_site_refuses_an_r_course_built_for_the_pyodide_target ... ok
+test site::tests::plan_site_runner_core_renders_hints_as_expandable_details ... ok
+test site::tests::plan_site_runner_core_sets_cursor_color_via_cm6_theme ... ok
+test site::tests::plan_site_serializes_a_missing_hints_as_json_null_not_dropped ... ok
+test site::tests::plan_site_serializes_a_missing_solution_as_json_null_not_dropped ... ok
+test site::tests::plan_site_folds_the_eval_results_page_for_each_state ... ok
+test site::tests::plan_site_serializes_each_lesson_to_the_browser_contract ... ok
+test site::tests::plan_site_serializes_a_missing_gotchas_as_json_null_not_dropped ... ok
+test site::tests::plan_site_runner_core_splits_hints_and_gotchas ... ok
+test site::tests::plan_site_serializes_hints_when_present ... ok
+test site::tests::plan_site_serializes_packages_as_array_even_when_empty ... ok
+test site::tests::plan_site_serializes_gotchas_when_present ... ok
+test site::tests::plan_site_styles_css_has_gotchas_panel_rules ... ok
+test site::tests::plan_site_shells_have_link_and_no_inline_style ... ok
+test site::tests::plan_site_shells_have_correct_head_load_order ... ok
+test site::tests::plan_site_shells_contain_semantic_regions ... ok
+test site::tests::plan_site_styles_css_declares_tokens_and_uses_them ... ok
+test tests::display_names_the_command_and_the_unimplemented_state ... ok
+test site::tests::plan_site_shells_differ_only_by_three_known_diffs ... ok
+test site::tests::plan_site_styles_css_has_hints_panel_rules ... ok
+test site::tests::plan_site_styles_css_is_present_for_both_targets ... ok
+test site::tests::plan_site_webr_assembles_the_shell_runner_shim_and_one_json_per_lesson ... ok
+test site::tests::plan_site_shells_load_codemirror_as_import ... ok
+test site::tests::site_lesson_from_lesson_projects_each_contract_field ... ok
+test site::tests::write_site_writes_every_planned_file_to_disk ... ok
+test site::tests::plan_site_emits_vendored_codemirror_bundle ... ok
+test site::tests::plan_site_workspace_styles_use_tokens_and_status_renders_as_pill ... ok
+
+test result: ok. 146 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
+
+     Running tests/eval.rs (target/debug/deps/eval-ec86ef06241a5f95)
+
+running 2 tests
+test rejects_unknown_verdict_naming_the_offending_case ... ok
+test parses_ten_fireworks_vitals_cases_into_typed_suite ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running tests/grade.rs (target/debug/deps/grade-53a9b289dbbe82fb)
+
+running 3 tests
+test python_lesson_selects_python_runner ... ok
+test submission_error_is_notrun_not_fail ... ok
+test r_runner_reports_per_check_pass_fail ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.26s
+
+     Running tests/llm.rs (target/debug/deps/llm-919eedfbc5f220b8)
+
+running 9 tests
+test build_prompt_is_deterministic_offline ... ok
+test build_prompt_neutralizes_injected_delimiter ... ok
+test build_prompt_renders_delimited_code_and_labeled_sections ... ok
+test fireworks_present_key_reaches_server ... ok
+test fireworks_empty_key_errs_before_request ... ok
+test fireworks_missing_key_errs_before_request ... ok
+test anthropic_missing_key_errs_before_request ... ok
+test request_feedback_incorrect_verdict_and_missing_field_errors ... ok
+test request_feedback_correct_verdict ... ok
+
+test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s
+
+     Running tests/runner.rs (target/debug/deps/runner-2f4059e7e610a19d)
+
+running 5 tests
+test python_captures_streams_distinctly ... ok
+test runs_in_isolated_temp_dir_cleaned_up ... ok
+test captures_stdout_stderr_exit_separately ... ok
+test python_infinite_loop_times_out ... ok
+test timeout_kills_process_tree_under_natural_runtime ... ok
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.01s
+
+   Doc-tests blendtutor_core
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+


### PR DESCRIPTION
Closes #98. Adds SiteConfig with max_feedback_per_session (default 20), config.js emission, rate limiting in feedback.js (sessionStorage counter, textContent limit message, parseInt guard, failed requests count). See .opencode/plans/site-security-hardening/AC-4.md for full spec.