### PR TITLE
feat: scaffold Quarto extension skeleton with no-op filter and CI harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,14 @@ jobs:
       # Uses grep (not rg) so ubuntu-latest needs no extra install.
       - name: Model alignment
         run: ./scripts/check-model-alignment.sh
+
+  quarto-render:
+    name: quarto render
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Quarto extension render test
+        run: bash scripts/tests/test_quarto_render.sh

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ screenshots/
 # mdBook build output (rendered narrative site; rebuilt by scripts/check-docs.sh
 # and the docs workflow, with rustdoc merged under book/api at deploy time)
 /docs/book/book/
+
+# Quarto render output (quarto-fixture/minimal.html and _site/)
+/quarto-fixture/*.html
+/quarto-fixture/_site/
+/quarto-fixture/*_files/

--- a/.opencode/plans/quarto-extension/AC-1.md
+++ b/.opencode/plans/quarto-extension/AC-1.md
@@ -1,0 +1,55 @@
+---
+ac: 1
+depends_on: none
+risk: low
+status: complete
+---
+
+## AC-1: Scaffold Quarto extension skeleton with no-op filter, fixture .qmd, and CI render harness
+
+### Executable Spec
+- **predicate:** Extension skeleton passes ALL of: (1) `_extensions/blendtutor/_extension.yml` contains `contributes.filters: [blendtutor.lua]`; (2) `blendtutor.lua` is valid Pandoc filter returning doc unmodified; (3) `quarto render quarto-fixture/minimal.qmd` exits 0 and produces HTML containing BOTH standard markdown content ("Hello from Quarto") AND blendtutor fenced-div content ("add(a, b)" AND "stopifnot(add(1, 2) == 3)"); (4) CI uses `quarto-dev/quarto-actions/setup@v2` with NO `continue-on-error`.
+- **probe:** `bash scripts/tests/test_quarto_render.sh` (7 assertions: contributes.filters present, render exits 0, standard content survived, blendtutor content survived, CI setup@v2, no continue-on-error)
+- **negative:** `_extension.yml` present but omits `contributes.filters` → structurally dead extension, CI green but filter never loads. Also: declares filter but file missing → Quarto errors.
+- **verification:** code
+- **fixture status:** _extension.yml (NEW), blendtutor.lua (NEW), quarto-fixture/minimal.qmd (NEW), scripts/tests/test_quarto_render.sh (NEW), .github/workflows/ci.yml (append)
+- **rubric anchor:** §1.5 (refuse cheapest fake), §1.5.1 (absence assertions need positive companions), §3.2 (extension↔CLI boundary), §4.1 (module header)
+
+### Design Intent
+- §1: _extension.yml schema IS the type — missing contributes.filters is illegal state Quarto can't detect
+- §2: No-op filter pure by construction; CI shell is effectful layer
+- §3: Extension at _extensions/blendtutor/, loaded by Quarto CLI not Rust CLI
+- §4: blendtutor.lua header names WHAT (no-op filter scaffold), WHERE (_extensions/blendtutor/), NOT (no AST transform, no HTML deps, no runtime JS)
+- §5: Single no-op function, one job
+
+### Technical Context
+- Files: _extension.yml, blendtutor.lua, quarto-fixture/minimal.qmd, scripts/tests/test_quarto_render.sh, .github/workflows/ci.yml
+- Quarto auto-discovers extensions in _extensions/. .qmd must NOT declare filters: [blendtutor] in frontmatter — relies on auto-discovery
+- 7 error sinks: Quarto not installed, missing contributes.filters, invalid Lua, fixture syntax, content mangled, div swallowed, CI continue-on-error
+
+### Dependencies
+- Depends on: none
+- Blocks: AC-2 through AC-11
+- Conflict set: _extensions/blendtutor/**, quarto-fixture/**, scripts/tests/test_quarto_render.sh, .github/workflows/ci.yml
+
+### Progress
+- [x] Red: wrote test_quarto_render.sh (7 assertions), confirmed all fail (files absent)
+- [x] Implement: created _extension.yml, blendtutor.lua, minimal.qmd
+- [x] CI: appended quarto-render job to ci.yml
+- [x] Green: all 10 assertions pass (quarto 1.6.42 local install)
+- [x] Negative control: removed contributes.filters → assertion 1 fails
+- [x] Committed: test(red) 45534f3, feat 984921e
+
+### Decision Log
+- 2026-07-22 — Filter wiring: take B's contributes.filters (extension-idiomatic) over A's .qmd frontmatter filters (bypasses extension mechanism)
+- 2026-07-22 — Fixture name: take A's quarto-fixture/minimal.qmd over B's exercise.qmd (dedicated fixture dir more organized)
+
+### Surprises & Discoveries
+- Pandoc syntax highlighting wraps code tokens in `<span>` tags, breaking literal `grep -qF 'stopifnot(add(1, 2) == 3)'` on raw HTML. Fix: strip HTML tags via `sed 's/<[^>]*>//g'` before content-matching assertions. Without this, the stopifnot assertion false-fails even though content is present.
+- YAML `_extension.yml` uses nested form (`contributes:\n  filters:\n    - blendtutor.lua`), not inline `contributes.filters: [blendtutor.lua]`. Test must check for `contributes` + `filters` keys separately, not literal `contributes.filters:` string.
+- Quarto render produces `quarto-fixture/minimal_files/` directory (libs) alongside the HTML. Added `*_files/` to .gitignore.
+- Quarto not installed on macOS without sudo (brew cask needs installer pkg). Downloaded pre-built binary tarball to temp dir for local testing.
+
+### Idempotence & Recovery
+- Safe retry: re-run scripts/tests/test_quarto_render.sh
+- Rollback: delete _extensions/blendtutor/ directory

--- a/_extensions/blendtutor/_extension.yml
+++ b/_extensions/blendtutor/_extension.yml
@@ -1,0 +1,6 @@
+title: blendtutor
+author: blendtutor
+version: 0.1.0
+contributes:
+  filters:
+    - blendtutor.lua

--- a/_extensions/blendtutor/blendtutor.lua
+++ b/_extensions/blendtutor/blendtutor.lua
@@ -1,0 +1,17 @@
+--- blendtutor.lua ---
+-- WHAT:  No-op Pandoc filter scaffold for the blendtutor Quarto extension.
+-- WHERE: _extensions/blendtutor/blendtutor.lua (loaded via _extension.yml contributes.filters)
+-- NOT:   No AST transformation, no HTML dependencies, no runtime JS injection.
+--         This is the skeleton — subsequent ACs add fenced-div processing.
+--
+-- Quarto auto-discovers this filter via the _extensions/ directory. The .qmd
+-- frontmatter must NOT declare `filters: [blendtutor]` — that bypasses the
+-- extension mechanism. The extension manifest (_extension.yml) is the single
+-- source of truth for filter registration.
+
+--- No-op filter: returns the document unmodified.
+-- @param doc Pandoc document object
+-- @return doc unmodified
+function Pandoc(doc)
+  return doc
+end

--- a/docs/evidence/106/test-suite.log
+++ b/docs/evidence/106/test-suite.log
@@ -1,0 +1,19 @@
+== Assertion 1: contributes.filters present in _extension.yml ==
+  PASS: contributes.filters key present
+  PASS: blendtutor.lua listed in contributes.filters
+== Assertion 2: blendtutor.lua is valid Pandoc filter ==
+  PASS: blendtutor.lua defines Pandoc function
+  PASS: blendtutor.lua returns doc unmodified
+== Assertions 3-6: quarto render + content survival ==
+  PASS: quarto render exits 0
+  PASS: standard content survived (Hello from Quarto)
+  PASS: blendtutor content survived (add(a, b))
+  PASS: blendtutor content survived (stopifnot(add(1, 2) == 3))
+== Assertion 7: CI setup@v2 + no continue-on-error ==
+  PASS: CI uses quarto-dev/quarto-actions/setup@v2
+  PASS: no continue-on-error in quarto-render job
+
+=========================================
+  Results: 10 passed, 0 failed
+=========================================
+All tests passed.

--- a/quarto-fixture/minimal.qmd
+++ b/quarto-fixture/minimal.qmd
@@ -1,0 +1,20 @@
+---
+title: Minimal blendtutor fixture
+---
+
+## Hello from Quarto
+
+This is a standard markdown paragraph to verify the extension skeleton
+does not mangle non-blendtutor content.
+
+::: {.blendtutor language="r"}
+Write a function `add(a, b)` that returns the sum.
+
+```r
+add <- function(a, b) { ___ }
+```
+
+```{.r .checks}
+stopifnot(add(1, 2) == 3)
+```
+:::

--- a/scripts/tests/test_quarto_render.sh
+++ b/scripts/tests/test_quarto_render.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Executable spec for issue #106 — Quarto extension skeleton.
+#
+# Verifies the 7-point compound predicate from AC-1:
+#   1. _extension.yml contains contributes.filters: [blendtutor.lua]
+#   2. blendtutor.lua is a valid Pandoc filter (function Pandoc(doc) return doc end)
+#   3. quarto render quarto-fixture/minimal.qmd exits 0
+#   4. HTML output contains standard markdown content ("Hello from Quarto")
+#   5. HTML output contains blendtutor fenced-div content ("add(a, b)")
+#   6. HTML output contains blendtutor fenced-div content ("stopifnot(add(1, 2) == 3)")
+#   7. CI uses quarto-dev/quarto-actions/setup@v2 with NO continue-on-error
+#
+# Negative case: _extension.yml present but omits contributes.filters →
+# structurally dead extension, CI green but filter never loads.
+# Caught by assertion 1 which grep-checks the exact key.
+#
+# Usage: bash scripts/tests/test_quarto_render.sh
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+PASS=0
+FAIL=0
+
+ok() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+ko() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# Assertion 1 — _extension.yml contains contributes.filters: [blendtutor.lua]
+# ---------------------------------------------------------------------------
+
+echo "== Assertion 1: contributes.filters present in _extension.yml =="
+
+EXT_YML="_extensions/blendtutor/_extension.yml"
+
+if [ ! -f "$EXT_YML" ]; then
+  ko "_extension.yml exists — file not found: $EXT_YML"
+else
+  if grep -qF 'contributes.filters:' "$EXT_YML"; then
+    ok "contributes.filters key present"
+  else
+    ko "contributes.filters key present — key missing in $EXT_YML"
+  fi
+
+  if grep -qF 'blendtutor.lua' "$EXT_YML"; then
+    ok "blendtutor.lua listed in contributes.filters"
+  else
+    ko "blendtutor.lua listed in contributes.filters — filter file not referenced"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 2 — blendtutor.lua is a valid Pandoc filter
+# ---------------------------------------------------------------------------
+
+echo "== Assertion 2: blendtutor.lua is valid Pandoc filter =="
+
+LUA_FILTER="_extensions/blendtutor/blendtutor.lua"
+
+if [ ! -f "$LUA_FILTER" ]; then
+  ko "blendtutor.lua exists — file not found: $LUA_FILTER"
+else
+  # A valid no-op Pandoc filter must define function Pandoc(doc) return doc end
+  if grep -qF 'function Pandoc(doc)' "$LUA_FILTER" || grep -qE 'function\s+Pandoc\s*\(' "$LUA_FILTER"; then
+    ok "blendtutor.lua defines Pandoc function"
+  else
+    ko "blendtutor.lua defines Pandoc function — function Pandoc(doc) not found"
+  fi
+
+  if grep -qE 'return\s+doc' "$LUA_FILTER"; then
+    ok "blendtutor.lua returns doc unmodified"
+  else
+    ko "blendtutor.lua returns doc unmodified — 'return doc' not found"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Assertions 3-6 — quarto render exits 0 and content survives
+# ---------------------------------------------------------------------------
+
+echo "== Assertions 3-6: quarto render + content survival =="
+
+FIXTURE="quarto-fixture/minimal.qmd"
+
+if [ ! -f "$FIXTURE" ]; then
+  ko "fixture .qmd exists — file not found: $FIXTURE"
+  ko "quarto render exits 0 — fixture missing"
+  ko "standard content survived — fixture missing"
+  ko "blendtutor content (add(a, b)) survived — fixture missing"
+  ko "blendtutor content (stopifnot) survived — fixture missing"
+else
+  if ! command -v quarto &>/dev/null; then
+    echo "  SKIP: quarto not installed locally — render assertions skipped"
+    echo "  (CI installs quarto via quarto-dev/quarto-actions/setup@v2)"
+    ko "quarto render exits 0 — quarto not installed"
+    ko "standard content survived — quarto not installed"
+    ko "blendtutor content (add(a, b)) survived — quarto not installed"
+    ko "blendtutor content (stopifnot) survived — quarto not installed"
+  else
+    # Clean any previous render output.
+    rm -f quarto-fixture/minimal.html
+
+    RENDER_OUTPUT=$(quarto render "$FIXTURE" --to html 2>&1) && RENDER_RC=0 || RENDER_RC=$?
+
+    if [ "$RENDER_RC" -eq 0 ]; then
+      ok "quarto render exits 0"
+    else
+      ko "quarto render exits 0 — exit code $RENDER_RC"
+      echo "  render output: $RENDER_OUTPUT" >&2
+    fi
+
+    HTML_FILE="quarto-fixture/minimal.html"
+
+    if [ ! -f "$HTML_FILE" ]; then
+      ko "standard content survived — HTML output not found: $HTML_FILE"
+      ko "blendtutor content (add(a, b)) survived — HTML output not found"
+      ko "blendtutor content (stopifnot) survived — HTML output not found"
+    else
+      HTML_CONTENT=$(cat "$HTML_FILE")
+
+      if echo "$HTML_CONTENT" | grep -qF 'Hello from Quarto'; then
+        ok "standard content survived (Hello from Quarto)"
+      else
+        ko "standard content survived (Hello from Quarto) — not found in HTML"
+      fi
+
+      if echo "$HTML_CONTENT" | grep -qF 'add(a, b)'; then
+        ok "blendtutor content survived (add(a, b))"
+      else
+        ko "blendtutor content survived (add(a, b)) — not found in HTML"
+      fi
+
+      if echo "$HTML_CONTENT" | grep -qF 'stopifnot(add(1, 2) == 3)'; then
+        ok "blendtutor content survived (stopifnot(add(1, 2) == 3))"
+      else
+        ko "blendtutor content survived (stopifnot(add(1, 2) == 3)) — not found in HTML"
+      fi
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 7 — CI uses quarto-dev/quarto-actions/setup@v2, no continue-on-error
+# ---------------------------------------------------------------------------
+
+echo "== Assertion 7: CI setup@v2 + no continue-on-error =="
+
+CI_FILE=".github/workflows/ci.yml"
+
+if [ ! -f "$CI_FILE" ]; then
+  ko "CI file exists — not found: $CI_FILE"
+else
+  if grep -qF 'quarto-dev/quarto-actions/setup@v2' "$CI_FILE"; then
+    ok "CI uses quarto-dev/quarto-actions/setup@v2"
+  else
+    ko "CI uses quarto-dev/quarto-actions/setup@v2 — action not found in CI"
+  fi
+
+  # Check that the quarto-render job has no continue-on-error.
+  # We look for continue-on-error in the quarto-render job section.
+  # A simple heuristic: if continue-on-error appears anywhere after the
+  # quarto-render job definition, flag it.
+  if grep -q 'continue-on-error' "$CI_FILE"; then
+    # Check if it's in the quarto-render job (not the concurrency block at top).
+    QUARTO_JOB_LINE=$(grep -n 'quarto-render' "$CI_FILE" | head -1 | cut -d: -f1)
+    if [ -n "$QUARTO_JOB_LINE" ]; then
+      CONTINUE_LINE=$(grep -n 'continue-on-error' "$CI_FILE" | head -1 | cut -d: -f1)
+      if [ -n "$CONTINUE_LINE" ] && [ "$CONTINUE_LINE" -gt "$QUARTO_JOB_LINE" ]; then
+        ko "no continue-on-error in quarto-render job — found at line $CONTINUE_LINE"
+      else
+        ok "no continue-on-error in quarto-render job"
+      fi
+    else
+      ok "no continue-on-error in quarto-render job (job not found yet)"
+    fi
+  else
+    ok "no continue-on-error in quarto-render job"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "========================================="
+echo "  Results: $PASS passed, $FAIL failed"
+echo "========================================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+
+echo "All tests passed."

--- a/scripts/tests/test_quarto_render.sh
+++ b/scripts/tests/test_quarto_render.sh
@@ -36,10 +36,13 @@ EXT_YML="_extensions/blendtutor/_extension.yml"
 if [ ! -f "$EXT_YML" ]; then
   ko "_extension.yml exists — file not found: $EXT_YML"
 else
-  if grep -qF 'contributes.filters:' "$EXT_YML"; then
+  # YAML allows both inline (contributes.filters: [blendtutor.lua]) and
+  # nested (contributes:\n  filters:\n    - blendtutor.lua) forms.
+  # Check for the contributes section with a filters key referencing blendtutor.lua.
+  if grep -qE 'contributes' "$EXT_YML" && grep -qE 'filters' "$EXT_YML"; then
     ok "contributes.filters key present"
   else
-    ko "contributes.filters key present — key missing in $EXT_YML"
+    ko "contributes.filters key present — contributes/filters keys missing in $EXT_YML"
   fi
 
   if grep -qF 'blendtutor.lua' "$EXT_YML"; then
@@ -118,19 +121,23 @@ else
     else
       HTML_CONTENT=$(cat "$HTML_FILE")
 
+      # Strip HTML tags for content-matching assertions — Pandoc syntax
+      # highlighting wraps tokens in <span> tags, breaking literal grep.
+      HTML_TEXT=$(echo "$HTML_CONTENT" | sed 's/<[^>]*>//g')
+
       if echo "$HTML_CONTENT" | grep -qF 'Hello from Quarto'; then
         ok "standard content survived (Hello from Quarto)"
       else
         ko "standard content survived (Hello from Quarto) — not found in HTML"
       fi
 
-      if echo "$HTML_CONTENT" | grep -qF 'add(a, b)'; then
+      if echo "$HTML_TEXT" | grep -qF 'add(a, b)'; then
         ok "blendtutor content survived (add(a, b))"
       else
         ko "blendtutor content survived (add(a, b)) — not found in HTML"
       fi
 
-      if echo "$HTML_CONTENT" | grep -qF 'stopifnot(add(1, 2) == 3)'; then
+      if echo "$HTML_TEXT" | grep -qF 'stopifnot(add(1, 2) == 3)'; then
         ok "blendtutor content survived (stopifnot(add(1, 2) == 3))"
       else
         ko "blendtutor content survived (stopifnot(add(1, 2) == 3)) — not found in HTML"


### PR DESCRIPTION
## Summary
Scaffolds the blendtutor Quarto extension skeleton: `_extension.yml` manifest, no-op `blendtutor.lua` Pandoc filter, fixture `.qmd`, and CI render test harness. This is the foundation for subsequent ACs (fenced-div processing, runtime JS, etc.).

## Issue
Closes #106

## ACs implemented
- [x] Scaffold extension skeleton (_extension.yml, no-op blendtutor.lua), fixture .qmd, and quarto render test harness wired into CI

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec (contributes.filters, valid Lua filter, render exits 0, content survival, CI setup@v2, no continue-on-error)
- [x] Negative case tested (removed contributes.filters → assertion 1 fails)
- [x] Verification medium satisfied (code — shell script + CI)
- [x] Design intent respected (extension-idiomatic contributes.filters, no .qmd frontmatter filters, no-op filter with header docstring)
- [x] No scope creep

## Test plan
- [x] `bash scripts/tests/test_quarto_render.sh` — 10/10 assertions pass
- [x] `cargo fmt --all --check` — pass
- [x] `cargo clippy --all-targets --locked -- -D warnings` — pass
- [x] `./scripts/check-model-alignment.sh` — pass
- [x] Negative control: removing contributes.filters causes test failure
- [ ] CI green (quarto-render job on ubuntu-latest)