### PR TITLE
test: kill 5 surviving mutants from mutation testing

### DIFF
--- a/crates/core/src/crypto.rs
+++ b/crates/core/src/crypto.rs
@@ -278,4 +278,53 @@ mod tests {
             "file B must decrypt with its own salt + correct password"
         );
     }
+
+    #[test]
+    fn from_base64_accepts_payload_with_exactly_salt_plus_nonce_length() {
+        // A payload with exactly SALT_LEN + NONCE_LEN bytes (28) has a valid
+        // salt and nonce but zero-length ciphertext. from_base64 must accept it
+        // (the length check is `<`, not `<=` or `==`) — the empty ciphertext is
+        // structurally valid; decryption would fail, but parsing succeeds.
+        //
+        // Kills the mutant that replaces `<` with `==`: the mutant rejects
+        // 28-byte payloads (== SALT_LEN + NONCE_LEN), while the original accepts
+        // them (>= SALT_LEN + NONCE_LEN).
+        let mut bytes = vec![0u8; SALT_LEN + NONCE_LEN];
+        bytes.iter_mut().enumerate().for_each(|(i, b)| *b = i as u8);
+        let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+        let payload = EncryptedPayload::from_base64(&encoded)
+            .expect("a payload with exactly SALT_LEN + NONCE_LEN bytes is accepted");
+        assert_eq!(payload.salt.len(), SALT_LEN);
+        assert_eq!(payload.nonce.len(), NONCE_LEN);
+        assert!(
+            payload.ciphertext.is_empty(),
+            "ciphertext is empty (zero-length payload)"
+        );
+    }
+
+    #[test]
+    fn crypto_error_display_contains_expected_text() {
+        // Each CryptoError variant's Display output must contain its expected
+        // message text. Kills the mutant that replaces the fmt body with
+        // Ok(Default::default()) (empty string).
+        let decryption_failed = CryptoError::DecryptionFailed.to_string();
+        assert!(
+            decryption_failed.contains("decryption failed"),
+            "DecryptionFailed Display must mention 'decryption failed', got: {decryption_failed}"
+        );
+        assert!(
+            !decryption_failed.is_empty(),
+            "DecryptionFailed Display must not be empty"
+        );
+
+        let invalid_payload = CryptoError::InvalidPayload.to_string();
+        assert!(
+            invalid_payload.contains("invalid encrypted payload"),
+            "InvalidPayload Display must mention 'invalid encrypted payload', got: {invalid_payload}"
+        );
+        assert!(
+            !invalid_payload.is_empty(),
+            "InvalidPayload Display must not be empty"
+        );
+    }
 }

--- a/crates/core/src/site/mod.rs
+++ b/crates/core/src/site/mod.rs
@@ -3273,4 +3273,110 @@ exercise:
         let end = rest.find('"')?;
         Some(rest[..end].to_string())
     }
+
+    /// Extract an EncryptedPayload from a decrypt shell's data-* attributes.
+    /// Reconstructs the salt, nonce, and ciphertext from the separate base64
+    /// attributes the decrypt shell emits.
+    fn extract_encrypted_payload(html: &str) -> crypto::EncryptedPayload {
+        let ciphertext = base64::engine::general_purpose::STANDARD
+            .decode(
+                extract_data_attr(html, "data-encrypted-payload")
+                    .expect("decrypt shell must have data-encrypted-payload"),
+            )
+            .expect("ciphertext is valid base64");
+        let salt_bytes = base64::engine::general_purpose::STANDARD
+            .decode(
+                extract_data_attr(html, "data-salt").expect("decrypt shell must have data-salt"),
+            )
+            .expect("salt is valid base64");
+        let nonce_bytes = base64::engine::general_purpose::STANDARD
+            .decode(extract_data_attr(html, "data-iv").expect("decrypt shell must have data-iv"))
+            .expect("iv is valid base64");
+        let mut salt = [0u8; 16];
+        salt.copy_from_slice(&salt_bytes);
+        let mut nonce = [0u8; 12];
+        nonce.copy_from_slice(&nonce_bytes);
+        crypto::EncryptedPayload {
+            ciphertext,
+            salt,
+            nonce,
+        }
+    }
+
+    #[test]
+    fn is_content_file_classifies_index_and_eval_results_as_content() {
+        // index.html and eval-results.html are content files that get encrypted.
+        // Kills the mutant that replaces || with && in the first two conditions:
+        // `path == "index.html" && path == "eval-results.html"` is always false
+        // (a path can't equal both), so both would be misclassified as non-content.
+        assert!(
+            is_content_file("index.html"),
+            "index.html must be classified as a content file"
+        );
+        assert!(
+            is_content_file("eval-results.html"),
+            "eval-results.html must be classified as a content file"
+        );
+    }
+
+    #[test]
+    fn is_content_file_rejects_non_content_files_matching_one_condition() {
+        // A file that starts with "lessons/" but doesn't end in ".json" is NOT
+        // a content file. Kills the mutant that replaces && with || in the
+        // last condition: `starts_with("lessons/") || ends_with(".json")`
+        // would classify "lessons/readme.txt" as content (matching starts_with
+        // alone) and "config.json" as content (matching ends_with alone).
+        assert!(
+            !is_content_file("lessons/readme.txt"),
+            "lessons/readme.txt must NOT be a content file (not a .json)"
+        );
+        assert!(
+            !is_content_file("config.json"),
+            "config.json must NOT be a content file (not under lessons/)"
+        );
+    }
+
+    #[test]
+    fn encrypt_site_files_embeds_key_only_in_index_html() {
+        // When an embed_key is provided, index.html's plaintext is JSON-wrapped
+        // ({"html":"...","embeddedKey":{...}}) so the decrypt shell can extract
+        // the key. eval-results.html does NOT receive the JSON wrapping — it
+        // stays as plain encrypted HTML.
+        //
+        // Kills the mutant that replaces == with != in
+        // `if path_str == "index.html"`: the mutant swaps the behavior,
+        // JSON-wrapping eval-results.html instead of index.html.
+        let planned = plan(&r_course(), BuildTarget::Webr).expect("plans");
+        let mut rng = rand_core::OsRng;
+        let embed_key = EmbeddedKey {
+            provider: "fireworks".to_string(),
+            key: "fw_testkey123".to_string(),
+        };
+        let encrypted = encrypt_site_files(&planned, TEST_PASSWORD, Some(&embed_key), &mut rng);
+
+        // index.html: decrypt and verify the plaintext contains embeddedKey JSON.
+        let index_html = &file(&encrypted, "index.html").contents;
+        let index_payload = extract_encrypted_payload(index_html);
+        let index_plaintext = crypto::decrypt(&index_payload, TEST_PASSWORD)
+            .expect("index.html decrypts with the correct password");
+        assert!(
+            index_plaintext.contains("embeddedKey"),
+            "index.html plaintext must contain embeddedKey JSON wrapping, got: {index_plaintext}"
+        );
+        assert!(
+            index_plaintext.contains("fw_testkey123"),
+            "index.html plaintext must contain the embedded API key, got: {index_plaintext}"
+        );
+
+        // eval-results.html: decrypt and verify the plaintext does NOT contain
+        // embeddedKey JSON — it stays as plain HTML.
+        let eval_html = &file(&encrypted, "eval-results.html").contents;
+        let eval_payload = extract_encrypted_payload(eval_html);
+        let eval_plaintext = crypto::decrypt(&eval_payload, TEST_PASSWORD)
+            .expect("eval-results.html decrypts with the correct password");
+        assert!(
+            !eval_plaintext.contains("embeddedKey"),
+            "eval-results.html plaintext must NOT contain embeddedKey JSON wrapping, got: {eval_plaintext}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Add 5 targeted tests to close test gaps found by cargo-mutants. No production code changes — all mutants are test gaps, not bugs.

## Mutants killed

| # | Location | Mutant | Test added |
|---|----------|--------|------------|
| 1 | `crypto.rs:75` | `<` → `==` in `from_base64` length check | Assert 28-byte payload (SALT_LEN + NONCE_LEN, zero ciphertext) is accepted |
| 2 | `crypto.rs:157` | `CryptoError::fmt` → `Ok(Default::default())` | Assert each variant's `to_string()` contains expected text |
| 3 | `site/mod.rs:589` | `\|\|` → `&&` in `is_content_file` | Assert `index.html` and `eval-results.html` classify as content |
| 4 | `site/mod.rs:591` | `&&` → `\|\|` in `is_content_file` | Assert `lessons/readme.txt` and `config.json` are NOT content |
| 5 | `site/mod.rs:664` | `==` → `!=` in `encrypt_site_files` | Decrypt index.html + eval-results.html, verify embeddedKey JSON only in index.html |

## Test plan

- [x] All 196 tests pass (`cargo nextest run -p blendtutor-core`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo mutants --in-place -j 4` confirms 0 surviving mutants (long-running, run separately)