### PR TITLE
[docs] Correct README Quarto install path to _extensions/mcmullarkey/blendtutor/ (AC-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,11 @@ quarto add mcmullarkey/blendtutor
 
 This installs the extension from the
 [`mcmullarkey/blendtutor`](https://github.com/mcmullarkey/blendtutor) GitHub
-repository into your project's `_extensions/blendtutor/` directory.
+repository into your project's `_extensions/mcmullarkey/blendtutor/` directory.
+
+Asset resolution is install-path-independent — the extension locates its
+assets relative to the filter script, so it works regardless of where `quarto
+add` installs it.
 
 ### Authoring syntax
 

--- a/docs/adr/0017-quarto-extension-distribution.md
+++ b/docs/adr/0017-quarto-extension-distribution.md
@@ -54,6 +54,10 @@ Option 3 — same-repo distribution via `quarto add` with CI verification.
   asserts `_extensions/blendtutor/_extension.yml` and `blendtutor.lua` exist.
   No `continue-on-error` — a failed install fails the job.
 
+  > **Note (2026-08-02):** The path in the bullet above is stale — CI actually
+  > asserts the org/repo install path `_extensions/mcmullarkey/blendtutor/`
+  > (Quarto's `quarto add <org>/<repo>` convention), not `_extensions/blendtutor/`.
+
 - **Demo book**: `demo-book/` in the same repo, with `_quarto.yml`
   (`project: type: book`), R and Python exercise chapters, COI config, and no
   `llm_evaluation_prompt` (per ADR-0006 — prompt structure is fixed, authors

--- a/docs/evidence/131/probe.log
+++ b/docs/evidence/131/probe.log
@@ -1,0 +1,83 @@
+# Issue #131 Evidence — README install-path correction (AC-3)
+
+Verification: `code` (grep-based content assertion on README.md + ADR file). No rodney, no screenshots — not UI-touching.
+
+Commit: `5f5e218` (docs) + `b90280c` (test red). Test suite: `bash scripts/tests/test_quarto_distribution.sh` → **28 passed, 0 failed**.
+
+## Spec probe result
+
+```bash
+$ grep -qF 'quarto add mcmullarkey/blendtutor' README.md \
+  && grep -qF '_extensions/mcmullarkey/blendtutor/' README.md \
+  && ! grep -qF "your project's \`_extensions/blendtutor/\`" README.md \
+  && grep -qiE 'install-path-independent|independent of.{0,40}install|regardless install|relative to.*filter|PANDOC_SCRIPT_FILE' README.md \
+  && grep -qF 'mcmullarkey/blendtutor' docs/adr/0017-quarto-extension-distribution.md \
+  && echo PROBE-PASS
+PROBE-PASS
+```
+
+## Clause-by-clause evidence (after fix)
+
+### 1. Install command survives
+```bash
+$ grep -nF 'quarto add mcmullarkey/blendtutor' README.md
+167:quarto add mcmullarkey/blendtutor
+```
+PASS — command at :167 unchanged.
+
+### 2. Correct path stated (org/repo path)
+```bash
+$ grep -nF '_extensions/mcmullarkey/blendtutor/' README.md
+172:repository into your project's `_extensions/mcmullarkey/blendtutor/` directory.
+```
+PASS — before: `_extensions/blendtutor/` (wrong); after: `_extensions/mcmullarkey/blendtutor/`.
+
+### 3. Old wrong claim gone
+```bash
+$ grep -nF "your project's \`_extensions/blendtutor/\`" README.md
+(no match — exit 1)
+```
+PASS — narrow unique phrase absent.
+
+### 4. Install-path independence stated
+```bash
+$ grep -niE 'install-path-independent|independent of.{0,40}install|regardless install|relative to.*filter|PANDOC_SCRIPT_FILE' README.md
+174:Asset resolution is install-path-independent — the extension locates its
+175:assets relative to the filter script, so it works regardless of where `quarto
+176:add` installs it.
+```
+PASS — matches `install-path-independent` and `relative to.*filter`.
+
+### 5. ADR-0017 annotated with org/repo path
+```bash
+$ grep -nF 'mcmullarkey/blendtutor' docs/adr/0017-quarto-extension-distribution.md
+35:   run `quarto add mcmullarkey/blendtutor-quarto`. Clean separation (§3), but
+41:   `quarto add mcmullarkey/blendtutor`. CI verifies the install in a temp
+48:- **Install command**: `quarto add mcmullarkey/blendtutor` — Quarto's native
+53:  via `mktemp -d`, runs `quarto add mcmullarkey/blendtutor --no-prompt`, and
+58:  > asserts the org/repo install path `_extensions/mcmullarkey/blendtutor/`
+```
+PASS — annotation at ~:54 (line 56-59) notes CI actually asserts `_extensions/mcmullarkey/blendtutor/`.
+
+## Negative control (before fix)
+
+Current README before fix contained the wrong phrase and no independence mention; probe exited non-zero.
+
+```bash
+# Pre-fix README.md:170-172 (git show HEAD^)
+This installs the extension from the
+[`mcmullarkey/blendtutor`](https://github.com/mcmullarkey/blendtutor) GitHub
+repository into your project's `_extensions/blendtutor/` directory.
+```
+
+RED run confirmed: `FAIL: install path stated — '_extensions/mcmullarkey/blendtutor/' not found`, `FAIL: old wrong install path claim removed`, `FAIL: install-path independence stated`.
+
+## Test suite (full)
+
+```bash
+$ bash scripts/tests/test_quarto_distribution.sh 2>&1 | tail -6
+=========================================
+  Results: 28 passed, 0 failed
+=========================================
+All tests passed.
+```

--- a/docs/evidence/131/probe.log
+++ b/docs/evidence/131/probe.log
@@ -2,7 +2,33 @@
 
 Verification: `code` (grep-based content assertion on README.md + ADR file). No rodney, no screenshots — not UI-touching.
 
-Commit: `5f5e218` (docs) + `b90280c` (test red). Test suite: `bash scripts/tests/test_quarto_distribution.sh` → **28 passed, 0 failed**.
+Commit: `5f5e218` (docs) + `b90280c` (test red) + review-fix (test green tightened). Test suite: `bash scripts/tests/test_quarto_distribution.sh` → **28 passed, 0 failed**.
+
+## Review-fix (cycle 1): tighten clause 6e ADR grep (discrimination)
+
+Finding: clause 6e `grep -qF 'mcmullarkey/blendtutor' "$ADR"` was non-discriminatory — 4 pre-existing occurrences in ADR body (lines 35/41/48/53) matched even with the annotation block deleted, violating AC-3 spec clause 5's negative contract ("skipping ADR annotation" sneaky-pass not caught).
+
+Fix: require BOTH annotation-unique strings — `CI actually` (ADR :57) AND `_extensions/mcmullarkey/blendtutor/` (ADR :58). Note: `CI actually asserts` was initially tried but spans a line break (":57 ends 'CI actually', :58 starts 'asserts'"), so single-line grep failed on the real annotation.
+
+Discrimination proof (run whole suite, grep clause-6e lines):
+
+```bash
+# 1. Annotation present → PASS
+$ bash scripts/tests/test_quarto_distribution.sh 2>&1 | grep -E 'ADR-0017 annotated'
+  PASS: ADR-0017 annotated with org/repo install path (CI actually + _extensions/mcmullarkey/blendtutor/)
+
+# 2. Annotation block deleted (sed '57,59d') → FAIL (negative contract holds)
+$ sed -i '' '57,59d' docs/adr/0017-quarto-extension-distribution.md && \
+  bash scripts/tests/test_quarto_distribution.sh 2>&1 | grep -E 'ADR-0017 annotated'
+  FAIL: ADR-0017 annotated with org/repo install path — annotation missing ('CI actually' + '_extensions/mcmullarkey/blendtutor/' not both found)
+
+# 3. Restored → PASS again
+$ cp /tmp/adr-backup.md docs/adr/0017-quarto-extension-distribution.md && \
+  bash scripts/tests/test_quarto_distribution.sh 2>&1 | grep -E 'ADR-0017 annotated'
+  PASS: ADR-0017 annotated with org/repo install path (CI actually + _extensions/mcmullarkey/blendtutor/)
+```
+
+Both unique strings verified present exactly once each, both inside the annotation (ADR :57-58); ADR body's 4 `mcmullarkey/blendtutor` occurrences lack both.
 
 ## Spec probe result
 
@@ -11,7 +37,8 @@ $ grep -qF 'quarto add mcmullarkey/blendtutor' README.md \
   && grep -qF '_extensions/mcmullarkey/blendtutor/' README.md \
   && ! grep -qF "your project's \`_extensions/blendtutor/\`" README.md \
   && grep -qiE 'install-path-independent|independent of.{0,40}install|regardless install|relative to.*filter|PANDOC_SCRIPT_FILE' README.md \
-  && grep -qF 'mcmullarkey/blendtutor' docs/adr/0017-quarto-extension-distribution.md \
+  && grep -qF 'CI actually' docs/adr/0017-quarto-extension-distribution.md \
+  && grep -qF '_extensions/mcmullarkey/blendtutor/' docs/adr/0017-quarto-extension-distribution.md \
   && echo PROBE-PASS
 PROBE-PASS
 ```
@@ -50,14 +77,11 @@ PASS — matches `install-path-independent` and `relative to.*filter`.
 
 ### 5. ADR-0017 annotated with org/repo path
 ```bash
-$ grep -nF 'mcmullarkey/blendtutor' docs/adr/0017-quarto-extension-distribution.md
-35:   run `quarto add mcmullarkey/blendtutor-quarto`. Clean separation (§3), but
-41:   `quarto add mcmullarkey/blendtutor`. CI verifies the install in a temp
-48:- **Install command**: `quarto add mcmullarkey/blendtutor` — Quarto's native
-53:  via `mktemp -d`, runs `quarto add mcmullarkey/blendtutor --no-prompt`, and
+$ grep -nF 'CI actually' docs/adr/0017-quarto-extension-distribution.md && grep -nF '_extensions/mcmullarkey/blendtutor/' docs/adr/0017-quarto-extension-distribution.md
+57:  > **Note (2026-08-02):** The path in the bullet above is stale — CI actually
 58:  > asserts the org/repo install path `_extensions/mcmullarkey/blendtutor/`
 ```
-PASS — annotation at ~:54 (line 56-59) notes CI actually asserts `_extensions/mcmullarkey/blendtutor/`.
+PASS — annotation at :57-58. Both strings unique to the annotation (4 pre-existing `mcmullarkey/blendtutor` body occurrences at :35/41/48/53 match neither).
 
 ## Negative control (before fix)
 

--- a/docs/evidence/131/test-suite.log
+++ b/docs/evidence/131/test-suite.log
@@ -1,0 +1,59 @@
+== Group 1: README ==
+== Clause 1: install command ==
+  PASS: install command present (quarto add mcmullarkey/blendtutor)
+== Clause 2: syntax both languages ==
+  PASS: R exercise syntax shown in README
+  PASS: Python exercise syntax shown in README
+== Clause 3: BYOK ==
+  PASS: BYOK mentioned in README
+== Clause 4: minimum Quarto version ==
+  PASS: minimum Quarto version stated in README
+== Clause 5: demo book link ==
+  PASS: demo book link present in README
+== Clause 6: install path contract ==
+  PASS: install command present (quarto add mcmullarkey/blendtutor)
+  PASS: install path stated (_extensions/mcmullarkey/blendtutor/)
+  PASS: old wrong install path claim removed
+  PASS: install-path independence stated in README
+  PASS: ADR-0017 annotated with org/repo install path (mcmullarkey/blendtutor)
+
+== Group 2: Demo book ==
+== Clause 6: render exits 0 ==
+  PASS: quarto render demo-book exits 0
+== Clause 7: ≥2 exercises per language ==
+  PASS: ≥2 R exercises (2 found)
+  PASS: ≥2 Python exercises (2 found)
+== Clause 8: non-empty content ==
+  PASS: non-empty content (no empty exercise divs)
+  PASS: non-empty content (code blocks present: 4)
+== Clause 9: mixed-language ==
+  PASS: mixed-language (R: 2, Python: 2)
+== Clause 10: no llm_evaluation_prompt ==
+  PASS: no llm_evaluation_prompt (0 occurrences)
+== Clause 11: COI config ==
+  PASS: COI config present (coi="true" or coi: true)
+
+== Group 3: CI ==
+== Clause 12: quarto add in temp dir ==
+  PASS: quarto add mcmullarkey/blendtutor present in CI
+  PASS: temp dir creation in CI
+  PASS: test -f paths use _extensions/mcmullarkey/blendtutor/ (actual install path)
+== Clause 13: setup@v2 ==
+  PASS: quarto-dev/quarto-actions/setup@v2 present in CI
+== Clause 14: no continue-on-error ==
+  PASS: no continue-on-error in quarto-distribution job
+
+== Negative cases ==
+== Negative 1: correct org/repo ==
+  PASS: correct org/repo (mcmullarkey/blendtutor)
+== Negative 2: no empty JSON (exercises have content) ==
+  PASS: no empty JSON (all exercises have content)
+== Negative 3: CI does not use _extensions: copy ==
+  PASS: CI does not use _extensions: copy (uses quarto add instead)
+== Negative 4: README mentions BYOK ==
+  PASS: README mentions BYOK
+
+=========================================
+  Results: 28 passed, 0 failed
+=========================================
+All tests passed.

--- a/scripts/tests/test_quarto_distribution.sh
+++ b/scripts/tests/test_quarto_distribution.sh
@@ -160,10 +160,12 @@ ADR="docs/adr/0017-quarto-extension-distribution.md"
 if [ ! -f "$ADR" ]; then
   ko "ADR-0017 annotation — ADR file not found: $ADR"
 else
-  if grep -qF 'mcmullarkey/blendtutor' "$ADR"; then
-    ok "ADR-0017 annotated with org/repo install path (mcmullarkey/blendtutor)"
+  # Require both annotation-unique strings — 'mcmullarkey/blendtutor' alone is
+  # non-discriminatory (4 pre-existing occurrences in ADR body, lines 35/41/48/53).
+  if grep -qF 'CI actually' "$ADR" && grep -qF '_extensions/mcmullarkey/blendtutor/' "$ADR"; then
+    ok "ADR-0017 annotated with org/repo install path (CI actually + _extensions/mcmullarkey/blendtutor/)"
   else
-    ko "ADR-0017 annotated with org/repo install path — 'mcmullarkey/blendtutor' not found"
+    ko "ADR-0017 annotated with org/repo install path — annotation missing ('CI actually' + '_extensions/mcmullarkey/blendtutor/' not both found)"
   fi
 fi
 

--- a/scripts/tests/test_quarto_distribution.sh
+++ b/scripts/tests/test_quarto_distribution.sh
@@ -45,7 +45,7 @@ DEMO_BOOK_DIR="demo-book"
 CI_FILE=".github/workflows/ci.yml"
 
 # ---------------------------------------------------------------------------
-# Group 1 — README (5 clauses)
+# Group 1 — README (6 clauses)
 # ---------------------------------------------------------------------------
 
 echo "== Group 1: README =="
@@ -118,6 +118,52 @@ else
     ok "demo book link present in README"
   else
     ko "demo book link present in README — no demo-book reference found"
+  fi
+fi
+
+# Clause 6: Install path contract (AC-3)
+echo "== Clause 6: install path contract =="
+if [ ! -f "$README" ]; then
+  ko "install path — README not found"
+else
+  # 6a: Install command survives
+  if grep -qF 'quarto add mcmullarkey/blendtutor' "$README"; then
+    ok "install command present (quarto add mcmullarkey/blendtutor)"
+  else
+    ko "install command present — 'quarto add mcmullarkey/blendtutor' not found"
+  fi
+
+  # 6b: Correct install path stated (org/repo path, not bare repo name)
+  if grep -qF '_extensions/mcmullarkey/blendtutor/' "$README"; then
+    ok "install path stated (_extensions/mcmullarkey/blendtutor/)"
+  else
+    ko "install path stated — '_extensions/mcmullarkey/blendtutor/' not found"
+  fi
+
+  # 6c: Old wrong claim gone (bare 'your project's _extensions/blendtutor/' phrase)
+  if ! grep -qF "your project's \`_extensions/blendtutor/\`" "$README"; then
+    ok "old wrong install path claim removed"
+  else
+    ko "old wrong install path claim removed — found 'your project's \`_extensions/blendtutor/\`'"
+  fi
+
+  # 6d: Install-path independence stated
+  if grep -qiE 'install-path-independent|independent of.{0,40}install|regardless install|relative to.*filter|PANDOC_SCRIPT_FILE' "$README"; then
+    ok "install-path independence stated in README"
+  else
+    ko "install-path independence stated in README — no independence mention found"
+  fi
+fi
+
+# 6e: ADR-0017 annotated with actual CI-asserted org/repo path
+ADR="docs/adr/0017-quarto-extension-distribution.md"
+if [ ! -f "$ADR" ]; then
+  ko "ADR-0017 annotation — ADR file not found: $ADR"
+else
+  if grep -qF 'mcmullarkey/blendtutor' "$ADR"; then
+    ok "ADR-0017 annotated with org/repo install path (mcmullarkey/blendtutor)"
+  else
+    ko "ADR-0017 annotated with org/repo install path — 'mcmullarkey/blendtutor' not found"
   fi
 fi
 


### PR DESCRIPTION
## Summary
Corrects the README install-path claim and annotates a stale ADR-0017 bullet.

`quarto add mcmullarkey/blendtutor` installs into `_extensions/mcmullarkey/blendtutor/` (Quarto org/repo convention) — README.md:172 previously claimed `_extensions/blendtutor/`. Also documents that asset resolution is install-path-independent (true once AC-1's Lua fix lands), and annotates ADR-0017:~54 where CI's asserted path was stale.

## Issue
Closes #131

## Changes
- README.md:170-176 — correct install path + install-path-independence sentence; `quarto add mcmullarkey/blendtutor` command at :167 unchanged
- docs/adr/0017-quarto-extension-distribution.md:~54 — one-line annotation: CI actually asserts `_extensions/mcmullarkey/blendtutor/` (org/repo path). ADR history untouched.
- scripts/tests/test_quarto_distribution.sh Group 1 — new Clause 6 (install path contract, 5 sub-checks) following existing ok/ko pattern
- docs/evidence/131/ — probe log + full test-suite log

In-repo `_extensions/blendtutor/` source-path references (dev tree) intentionally untouched.

## ACs implemented
- [x] README states correct install path `_extensions/mcmullarkey/blendtutor/`, old wrong sentence gone
- [x] README states asset resolution is install-path-independent
- [x] Install command `quarto add mcmullarkey/blendtutor` survives unchanged
- [x] ADR-0017:54 annotated with actual CI-asserted org/repo path
- [x] New grep clause in test_quarto_distribution.sh Group 1 covering the above

## Test plan
- [x] Spec probe: PROBE-PASS (5/5 clauses)
- [x] `bash scripts/tests/test_quarto_distribution.sh` → 28 passed, 0 failed
- [x] RED confirmed: new clause failed against pre-fix README (6b/6c/6d)

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested
- [x] Verification medium satisfied (code)
- [x] Design intent respected
- [x] No scope creep

NOTE: merge after #129 (AC-1) — independence sentence only true after Lua fix lands.