### PR TITLE
[fix] Resolve asset paths script-relative via PANDOC_SCRIPT_FILE (AC-1)

### DIFF
--- a/_extensions/blendtutor/blendtutor.lua
+++ b/_extensions/blendtutor/blendtutor.lua
@@ -49,13 +49,58 @@ local PYODIDE_CDN = "https://cdn.jsdelivr.net/pyodide/v0.27.2/full/pyodide.js"
 local has_coi = false
 local hasCoiDone = false
 
--- Path to vendored coi-serviceworker.js (synced via sync-quarto-assets.sh, mode=copy).
--- The service worker re-serves pages with COOP/COEP headers for SharedArrayBuffer.
-local COI_SCRIPT_PATH = "_extensions/blendtutor/assets/coi-serviceworker.js"
+-- Asset paths are derived from the filter's own location (ADR-0018), never
+-- hardcoded. `quarto add mcmullarkey/blendtutor` installs to
+-- _extensions/mcmullarkey/blendtutor/ (org/repo path), so a hardcoded
+-- _extensions/blendtutor/ prefix 404s in installed projects.
+
+--- Resolve an asset path relative to the filter script's own location.
+-- PANDOC_SCRIPT_FILE arrives in one of two forms (verified quarto 1.10.18):
+--   * explicit YAML filter path — as written, relative to the qmd directory
+--     (e.g. "../_extensions/blendtutor/blendtutor.lua" from quarto-fixture/);
+--   * by-name _extension.yml install — an ABSOLUTE path into the project
+--     (e.g. "/abs/proj/_extensions/mcmullarkey/blendtutor/blendtutor.lua").
+-- Quarto does not rewrite in-header hrefs, so an absolute script path MUST be
+-- converted back to a project-relative URL or the browser 404s (the emitted
+-- href would be a filesystem path, not a URL).
+-- @param script_file PANDOC_SCRIPT_FILE value (absolute or relative)
+-- @param filename    asset basename, e.g. "styles.css"
+-- @return project-relative URL (forward slashes) to the asset
+local function resolve_asset_path(script_file, filename)
+  local script = script_file or "blendtutor.lua"
+  -- Directory extraction handles both / and \ separators (Windows, §5).
+  -- pandoc.path is POSIX-only and mis-parses backslash paths, so do it here.
+  local dir = script:match("^(.*)[/\\]") or "."
+  local asset = dir .. "/assets/" .. filename
+
+  -- Absolute path (by-name install): convert to project-relative. Prefer
+  -- slicing from "_extensions/" — always present for a filter install and
+  -- robust when the script path uses a different root than PWD (macOS
+  -- /private/tmp vs /tmp symlinks). Strip the PWD prefix as a last resort.
+  if asset:match("^/") or asset:match("^[A-Za-z]:[/\\]") then
+    local ext = asset:find("_extensions[/\\]")
+    if ext then
+      asset = asset:sub(ext)
+    else
+      local cwd = os.getenv("PWD") or ""
+      if cwd ~= "" and asset:find(cwd, 1, true) == 1 then
+        asset = asset:sub(#cwd + 1):gsub("^[/\\]", "")
+      end
+    end
+  end
+
+  -- Normalize Windows backslashes to forward slashes (href-safe).
+  return asset:gsub("\\", "/")
+end
+
+-- Path to vendored coi-serviceworker.js (synced via sync-quarto-assets.sh,
+-- mode=copy). The service worker re-serves pages with COOP/COEP headers for
+-- SharedArrayBuffer. Derived from the filter's own location (ADR-0018).
+local COI_SCRIPT_PATH = resolve_asset_path(PANDOC_SCRIPT_FILE, "coi-serviceworker.js")
 
 -- Path to vendored styles.css (synced via sync-quarto-assets.sh, mode=scope).
 -- Provides .bt-exercise styling: button states, cursor not-allowed, data-status.
-local STYLES_CSS_PATH = "_extensions/blendtutor/assets/styles.css"
+local STYLES_CSS_PATH = resolve_asset_path(PANDOC_SCRIPT_FILE, "styles.css")
 
 -- ---------------------------------------------------------------------------
 -- JSON encoding helpers (Lua has no built-in JSON encoder)

--- a/docs/adr/0015-opt-in-coi-cross-origin.md
+++ b/docs/adr/0015-opt-in-coi-cross-origin.md
@@ -53,8 +53,11 @@ Option 3 — opt-in via both div attribute and YAML metadata.
 - **Per-page isolation** (§3): `has_coi` and `hasCoiDone` are reset in `Pandoc()`
   so each document in a multi-page render (Quarto book) gets a fresh check.
 
-- **Script tag path**: `_extensions/blendtutor/assets/coi-serviceworker.js` —
-  vendored via `sync-quarto-assets.sh` (mode=copy, byte-identical to source).
+- **Script tag path**: derived from the filter's own location via
+  `PANDOC_SCRIPT_FILE` (ADR-0018) — `_extensions/blendtutor/assets/
+  coi-serviceworker.js` in-repo, `_extensions/mcmullarkey/blendtutor/assets/
+  coi-serviceworker.js` when installed via `quarto add` — vendored via
+  `sync-quarto-assets.sh` (mode=copy, byte-identical to source).
 
 ## Consequences
 

--- a/docs/adr/0018-script-relative-asset-paths.md
+++ b/docs/adr/0018-script-relative-asset-paths.md
@@ -1,0 +1,95 @@
+# ADR-0018: Script-relative asset path resolution via `PANDOC_SCRIPT_FILE`
+
+- Status: Accepted
+- Date: 2026-08-02
+
+## Context
+
+`blendtutor.lua` hardcodes asset paths as `_extensions/blendtutor/assets/...`
+(`COI_SCRIPT_PATH` / `STYLES_CSS_PATH`). This works for the in-repo layout,
+but `quarto add mcmullarkey/blendtutor` installs the extension to
+`_extensions/mcmullarkey/blendtutor/` (org/repo path, verified empirically —
+see ADR-0017). With a hardcoded prefix the emitted `<link href=...>` /
+`<script src=...>` points at `_extensions/blendtutor/assets/styles.css`, which
+does not exist in the installed project — the browser 404s (lstat NotFound).
+
+The filter must derive asset URLs from its own install location so the same
+code works under in-repo, installed org/repo, and `../`-referenced layouts.
+
+`PANDOC_SCRIPT_FILE` (the path to the executing filter) arrives in two forms,
+verified with Quarto 1.10.18:
+
+- **Explicit YAML filter path** — as written, relative to the project root
+  (e.g. `../_extensions/blendtutor/blendtutor.lua` from `quarto-fixture/ux.qmd`,
+  or `_extensions/mcmullarkey/blendtutor/blendtutor.lua` from a project root).
+- **By-name install** (`filters: [blendtutor]` via `_extension.yml`
+  `contributes.filters`) — an **absolute** path into the project
+  (e.g. `/abs/proj/_extensions/mcmullarkey/blendtutor/blendtutor.lua`).
+  On macOS the absolute path may use a different root than `$PWD`
+  (`/private/var/...` vs `/var/...` — `/tmp` is a symlink).
+
+Quarto does not rewrite `in-header` hrefs, so an absolute script path must be
+converted back to a project-relative URL or the browser 404s.
+
+## Options
+
+1. **Keep hardcoded `_extensions/blendtutor/` constants.** Zero code change,
+   but broken for every `quarto add` install (the bug being fixed). Rejected.
+
+2. **Naive dir-extraction of `PANDOC_SCRIPT_FILE`**
+   (`script_file:match("^(.*)[/\\]") .. "/assets/"`). Correct for relative
+   explicit paths, but emits `/abs/proj/.../assets/styles.css` for by-name
+   installs — the file exists on disk (lstat passes) but the browser 404s
+   because the href is a filesystem path, not a URL. Rejected (clause 4).
+
+3. **`quarto.utils.relative_to` under Quarto, CWD-strip fallback.**
+   Proposed during design, but `quarto.utils.relative_to` does **not** exist
+   in Quarto 1.10.18 (verified: `quarto.utils` exposes `resolve_path`,
+   `resolve_path_relative_to_document`, etc., but no `relative_to`). A pure
+   `$PWD`-prefix strip also fails on macOS `/private/var` vs `/var`. Rejected.
+
+4. **`pandoc.path.directory` + `pandoc.path.is_absolute`.**
+   Portable on POSIX, but `pandoc.path` is POSIX-only — a Windows
+   `C:\proj\_extensions\...` path returns `directory = "."` and
+   `is_absolute = false` (backslash is not a separator for `pandoc.path`).
+   Rejected for Windows (code-review requirement).
+
+5. **Own `[/\\]` dir-extraction + `_extensions/` slice for absolute paths.**
+   Extract the directory with a Windows-safe `[/\\]` pattern, append
+   `/assets/<filename>`, and for absolute results (leading `/` or drive
+   letter) slice from the first `_extensions[/\\]` occurrence — which is
+   always present for a filter install — falling back to stripping the `$PWD`
+   prefix. Normalize backslashes to forward slashes in the emitted href.
+
+## Decision
+
+Option 5 — a pure `resolve_asset_path(script_file, filename)` function in
+`blendtutor.lua` (§5 single-responsibility; §2 pure core, effectful emission
+stays in `Pandoc()`):
+
+- Directory extraction handles both `/` and `\` separators.
+- Absolute paths (by-name install) are converted project-relative by slicing
+  from `_extensions/` — robust against macOS `/private/tmp` vs `/tmp`
+  root-mismatch — with a `$PWD`-prefix strip as last-resort fallback.
+- Emitted hrefs are normalized to `/` (no backslashes).
+
+Behavior contract (§3.2): in-repo → `_extensions/blendtutor/assets/...` when
+referenced from a root qmd, `../_extensions/blendtutor/assets/...` from
+`quarto-fixture/`-style subdirectories; installed → `_extensions/mcmullarkey/
+blendtutor/assets/...`; demo-book/fixture → `../_extensions/blendtutor/
+assets/...`. All browser-usable.
+
+## Consequences
+
+- `blendtutor.lua` contains no literal `_extensions/blendtutor/` string — the
+  source-grep-zero invariant (spec clause 6) is a regression guard.
+- The filter assumes nothing about its install location — it derives from its
+  own `PANDOC_SCRIPT_FILE` (§1.5 encode invariant in types).
+- `quarto-fixture/` renders (ux.qmd, coi-true.qmd) now emit `../_extensions/`
+  hrefs that resolve to the repo-root extension without a symlink.
+- **Future work (out of scope, pre-existing):** `coi-serviceworker.js` scope
+  defaults to the script's URL directory at runtime; deeply nested install
+  paths can leave the page outside the service-worker scope so COI headers are
+  never applied. Orthogonal to this ADR — deferred to a future COI AC.
+- `docs/adr/0015` line 56's literal path note is superseded by this ADR's
+  derived-path contract.

--- a/docs/agent-notes/quarto-extension-lua.md
+++ b/docs/agent-notes/quarto-extension-lua.md
@@ -1,0 +1,27 @@
+---
+topic: quarto-extension-lua
+created: 2026-08-02
+slices: [129]
+---
+
+# Quarto extension Lua filter notes
+
+- 2026-08-02 (#129): **`quarto.utils.relative_to` does not exist** in Quarto
+  1.10.18. The `quarto.utils` table exposes `resolve_path`,
+  `resolve_path_relative_to_document`, `render`, etc. — but no `relative_to`.
+  Do not propose it in specs/ADRs without verifying the Quarto version.
+- 2026-08-02 (#129): **`pandoc.path` is POSIX-only.** `pandoc.path.directory`
+  on a Windows backslash path (`C:\proj\_extensions\x\blendtutor.lua`) returns
+  `"."` and `pandoc.path.is_absolute` returns `false`. For Windows-safe path
+  handling in filters, do your own `[/\\]` regex dir-extraction
+  (`script:match("^(.*)[/\\]")`) and normalize `\` → `/` in emitted hrefs.
+- 2026-08-02 (#129): **`PANDOC_SCRIPT_FILE` has two forms.** Explicit YAML
+  filter paths arrive as written (relative to the qmd/project root); by-name
+  `_extension.yml` installs arrive ABSOLUTE. On macOS the absolute path root
+  can differ from `$PWD` (`/private/var/...` vs `/var/...` — `/tmp` is a
+  symlink), so a CWD-prefix strip can silently fail; slicing from the
+  `_extensions[/\\]` marker is the robust absolute→project-relative
+  conversion for filter asset URLs. Quarto does not rewrite `in-header` hrefs.
+- 2026-08-02 (#129): **`quarto render` can mutate sibling files.** Rendering
+  `demo-book` added `**/*.quarto_ipynb` to `demo-book/.gitignore` — an
+  unrelated side effect that must be reverted, not committed.

--- a/docs/evidence/129/coi-true-render.log
+++ b/docs/evidence/129/coi-true-render.log
@@ -1,0 +1,20 @@
+[1mpandoc [22m
+  to: html
+  output-file: coi-true.html
+  standalone: true
+  section-divs: true
+  html-math-method: mathjax
+  wrap: none
+  default-image-extension: png
+  
+[1mmetadata[22m
+  document-css: false
+  link-citations: true
+  date-format: long
+  lang: en
+  extensions:
+    - blendtutor
+  title: COI true fixture
+  
+Output created: coi-true.html
+

--- a/docs/evidence/129/emitted-urls.log
+++ b/docs/evidence/129/emitted-urls.log
@@ -1,0 +1,7 @@
+=== Clause 1: ux.html href ===
+href="../_extensions/blendtutor/assets/styles.css"
+=== Clause 2: coi-true.html src ===
+src="../_extensions/blendtutor/assets/coi-serviceworker.js"
+=== Clause 4+5: all emitted asset URLs ===
+quarto-fixture/ux.html:href="../_extensions/blendtutor/assets/styles.css"
+quarto-fixture/coi-true.html:src="../_extensions/blendtutor/assets/coi-serviceworker.js"

--- a/docs/evidence/129/installed-layout-probe.log
+++ b/docs/evidence/129/installed-layout-probe.log
@@ -1,0 +1,3 @@
+=== Clause 3: temp-dir installed-layout probe ===
+href="_extensions/mcmullarkey/blendtutor/assets/styles.css"
+INSTALLED-LAYOUT: PASS

--- a/docs/evidence/129/source-grep-zero.log
+++ b/docs/evidence/129/source-grep-zero.log
@@ -1,0 +1,2 @@
+=== Clause 6: source grep zero (empty = pass) ===
+GREP-ZERO: PASS — no literal '_extensions/blendtutor/' in blendtutor.lua

--- a/docs/evidence/129/test-suite.log
+++ b/docs/evidence/129/test-suite.log
@@ -1,0 +1,87 @@
+=== AC-8 Exercise UX polish — test_quarto_ux.py ===
+
+  PASS: exercise-runtime.js exists
+  PASS: ux.qmd exists
+-- ux.qmd structure --
+  PASS: ux.qmd has 3 exercises (>=3 for UX polish test)
+  PASS: ux.qmd has a .solution code block (solution reveal test)
+  PASS: ux.qmd has a hints div (hints toggle test)
+  PASS: ux.qmd has .checks code block (check button test)
+  PASS: ux.qmd imports exercise-runtime.js
+
+-- Clause 1: hints visible/absent --
+  PASS: hints <details> toggle present in exercise-runtime.js
+  PASS: hints rendering is conditional on payload.hints
+
+-- Clause 2: solution button click inserts text --
+  PASS: solution rendering references payload.solution
+  PASS: solution button creation present in exercise-runtime.js
+  PASS: solution button calls setEditorContent
+
+-- Clause 3: check button absent when no checks --
+  PASS: check button creation is conditional on checks length
+  PASS: check button referenced in exercise-runtime.js
+
+-- Clause 4: Run disables ex-0 only (per-exercise) --
+  PASS: per-exercise Run button reference found
+  PASS: button disable/enable mechanism present
+  PASS: no singleton getElementById('run') — per-exercise Run button
+
+-- Clause 5: cursor=not-allowed --
+  PASS: cursor: not-allowed present in styles.css
+  PASS: disabled button selector present in styles.css
+
+-- Clause 6: data-status closed set --
+  PASS: data-status closed set referenced (4/4 values found)
+  PASS: data-status attribute mechanism present
+  PASS: data-status="idle" selector present in styles.css
+  PASS: data-status="running" selector present in styles.css
+  PASS: data-status="pass" selector present in styles.css
+  PASS: data-status="fail" selector present in styles.css
+
+-- Clause 7: buttons re-enabled on pass --
+  PASS: button re-enable mechanism present (disabled = false or finally)
+
+-- Regression: Check/Solution disabled during run --
+  PASS: entry.checkBtn ref stored for runSubmission access
+  PASS: entry.solutionBtn ref stored for runSubmission access
+  PASS: Check button disabled during runSubmission
+  PASS: Solution button disabled during runSubmission
+  PASS: Check button re-enabled after runSubmission
+  PASS: Solution button re-enabled after runSubmission
+
+-- CSS: hints + solution styling --
+  PASS: hints styling present in styles.css
+  PASS: solution button styling present in styles.css
+
+-- Rendered HTML: styles.css <link> injection --
+  PASS: styles.css <link> present in rendered HTML (project-relative href)
+
+-- Rendered HTML: coi script src project-relative (issue #129) --
+  PASS: coi script src present in rendered HTML (project-relative src)
+
+-- Asset URLs project-relative + resolvable (issue #129 clauses 4-5) --
+  PASS: asset URL project-relative: ../_extensions/blendtutor/assets/coi-serviceworker.js
+  PASS: asset URL resolves to file on disk: ../_extensions/blendtutor/assets/coi-serviceworker.js
+  PASS: asset URL project-relative: ../_extensions/blendtutor/assets/styles.css
+  PASS: asset URL resolves to file on disk: ../_extensions/blendtutor/assets/styles.css
+
+-- Installed layout: org/repo install path (issue #129 clause 3) --
+  PASS: installed layout — href uses org/repo install path
+  PASS: installed layout — no hardcoded _extensions/blendtutor/ href
+
+-- By-name install: absolute script path -> project-relative (issue #129) --
+  PASS: by-name install — absolute PANDOC_SCRIPT_FILE converted to project-relative href
+  PASS: by-name install — href passes project-relative guard: _extensions/mcmullarkey/blendtutor/assets/styles.css
+
+-- Source grep zero: no hardcoded _extensions/blendtutor/ (issue #129 clause 6) --
+  PASS: source grep zero — no literal "_extensions/blendtutor/" in blendtutor.lua
+
+-- Behavioral checks (Node.js) --
+  PASS: scanExercises exported
+  PASS: buildRegistry exported
+  PASS: start exported
+  PASS: parsePayload exported
+  PASS: Node.js behavioral tests passed (exports verified)
+
+=== Results: 46 passed, 0 failed ===

--- a/docs/evidence/129/ux-render.log
+++ b/docs/evidence/129/ux-render.log
@@ -1,0 +1,20 @@
+[1mpandoc [22m
+  to: html
+  output-file: ux.html
+  standalone: true
+  section-divs: true
+  html-math-method: mathjax
+  wrap: none
+  default-image-extension: png
+  
+[1mmetadata[22m
+  document-css: false
+  link-citations: true
+  date-format: long
+  lang: en
+  extensions:
+    - blendtutor
+  title: Exercise UX polish test fixture
+  
+Output created: ux.html
+

--- a/rodney-probes/exercise-ux.js
+++ b/rodney-probes/exercise-ux.js
@@ -157,12 +157,17 @@ function generateBlankPage() {
 
 function ensureAssetSymlink() {
   // Create a symlink quarto-fixture/_extensions -> ../_extensions so that
-  // relative paths injected by blendtutor.lua (e.g. _extensions/blendtutor/
-  // assets/styles.css) resolve correctly when the fixture HTML is served
-  // from quarto-fixture/. Without this, the browser resolves the relative
-  // path to quarto-fixture/_extensions/... which 404s, and CSS never loads
-  // — causing getComputedStyle() checks (clause-5 cursor:not-allowed) to
-  // fail because the stylesheet was never applied.
+  // asset URLs emitted by blendtutor.lua resolve when the fixture HTML is
+  // served from quarto-fixture/. Since issue #129 the filter derives asset
+  // paths from its own location (PANDOC_SCRIPT_FILE, ADR-0018), so ux.qmd's
+  // filter reference "../_extensions/blendtutor/blendtutor.lua" produces
+  // hrefs like "../_extensions/blendtutor/assets/styles.css" that resolve
+  // up one level to the repo-root _extensions/ — the symlink is a belt-and-
+  // suspenders fallback for older rendered fixtures that still carry the
+  // pre-#129 hardcoded href, which would otherwise resolve to
+  // quarto-fixture/_extensions/... and 404 (getComputedStyle() checks for
+  // clause-5 cursor:not-allowed would fail because the stylesheet never
+  // applied).
   const linkPath = path.join(WORKTREE, "quarto-fixture", "_extensions");
   const target = "../_extensions";
   try {

--- a/scripts/tests/test_quarto_ux.py
+++ b/scripts/tests/test_quarto_ux.py
@@ -25,6 +25,7 @@ Usage: python3 scripts/tests/test_quarto_ux.py
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -347,34 +348,55 @@ def check_css_hints_solution(css: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Rendered HTML checks (styles.css <link> injection)
+# Rendered HTML checks (asset path injection, issue #129)
 # ---------------------------------------------------------------------------
+
+
+def _find_quarto() -> str | None:
+    """Locate a quarto binary (PATH, or the /private/tmp dev fallback)."""
+    quarto_bin = shutil_which("quarto")
+    if not quarto_bin:
+        candidate = "/private/tmp/quarto/bin/quarto"
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            quarto_bin = candidate
+    return quarto_bin
+
+
+def _render_qmd(quarto_bin: str, qmd_path: Path, cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Render a .qmd to HTML with quarto, returning the completed process."""
+    return subprocess.run(
+        [quarto_bin, "render", str(qmd_path), "--to", "html"],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+        timeout=60,
+        check=False,
+    )
+
+
+# Emitted asset URLs must be project-relative (spec clause 4): match ^\.\.?/,
+# no leading /, no //, no file:, no drive letter, no backslash. This rejects
+# an absolute PANDOC_SCRIPT_FILE leaking into the href (browser 404s).
+PROJECT_RELATIVE_URL_RE = re.compile(r"^\.\.?/[^/\\][^\\]*$")
+
+# Asset basenames the filter injects into <head>.
+ASSET_BASENAMES = ("styles.css", "coi-serviceworker.js")
 
 
 def check_styles_css_loaded() -> None:
     """Verify styles.css is loaded in rendered Quarto HTML.
 
     Renders ux.qmd to HTML and checks that a <link> tag for styles.css
-    is present in the <head>. This test would fail if the Lua filter
-    does not inject styles.css — the bug fixed in this commit.
+    is present in the <head>, with a project-relative href derived from
+    the filter's own location (issue #129). This test would fail if the
+    Lua filter does not inject styles.css — the bug fixed in this commit.
     """
-    quarto_bin = shutil_which("quarto")
-    if not quarto_bin:
-        candidate = "/private/tmp/quarto/bin/quarto"
-        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
-            quarto_bin = candidate
+    quarto_bin = _find_quarto()
     if not quarto_bin:
         ko("styles.css loaded in rendered HTML — quarto not installed")
         return
 
-    result = subprocess.run(
-        [quarto_bin, "render", str(QMD_PATH), "--to", "html"],
-        capture_output=True,
-        text=True,
-        cwd=str(REPO_ROOT),
-        timeout=60,
-        check=False,
-    )
+    result = _render_qmd(quarto_bin, QMD_PATH, REPO_ROOT)
     if result.returncode != 0:
         ko(
             f"styles.css loaded in rendered HTML — render failed (exit {result.returncode})"
@@ -389,10 +411,198 @@ def check_styles_css_loaded() -> None:
         return
 
     html = html_path.read_text()
-    if 'href="_extensions/blendtutor/assets/styles.css"' in html:
-        ok("styles.css <link> present in rendered HTML")
+    # ux.qmd lives in quarto-fixture/ and references the filter via the
+    # ../_extensions/ path; the emitted href must mirror that shape (clause 1).
+    if 'href="../_extensions/blendtutor/assets/styles.css"' in html:
+        ok("styles.css <link> present in rendered HTML (project-relative href)")
     else:
         ko("styles.css <link> present in rendered HTML — not found in rendered output")
+
+
+def check_coi_script_path() -> None:
+    """Verify coi-serviceworker.js is injected with a project-relative src.
+
+    Renders coi-true.qmd and asserts the exact ../_extensions/... src
+    (spec clause 2). The coi-true fixture renders to quarto-fixture/ so the
+    script href resolves up one level, mirroring the filter's own location.
+    """
+    quarto_bin = _find_quarto()
+    if not quarto_bin:
+        ko("coi script src project-relative — quarto not installed")
+        return
+
+    result = _render_qmd(quarto_bin, REPO_ROOT / "quarto-fixture" / "coi-true.qmd", REPO_ROOT)
+    if result.returncode != 0:
+        ko(f"coi script src project-relative — render failed (exit {result.returncode})")
+        return
+
+    html_path = REPO_ROOT / "quarto-fixture" / "coi-true.html"
+    if not html_path.exists():
+        ko("coi script src project-relative — output file not found")
+        return
+
+    html = html_path.read_text()
+    if 'src="../_extensions/blendtutor/assets/coi-serviceworker.js"' in html:
+        ok("coi script src present in rendered HTML (project-relative src)")
+    else:
+        ko("coi script src present in rendered HTML — not found in rendered output")
+
+
+def check_asset_urls_behavioral() -> None:
+    """Verify every emitted asset URL is project-relative AND resolvable.
+
+    Spec clauses 4-5: render ux.qmd + coi-true.qmd, extract all href/src
+    referencing blendtutor assets, assert each URL (a) matches the
+    project-relative shape and (b) resolves to an existing file relative to
+    the rendered HTML's directory. Behavioral — not constant-equality.
+    """
+    quarto_bin = _find_quarto()
+    if not quarto_bin:
+        ko("asset URLs project-relative — quarto not installed")
+        return
+
+    rendered: list[tuple[Path, Path]] = [
+        (REPO_ROOT / "quarto-fixture" / "ux.qmd", REPO_ROOT / "quarto-fixture" / "ux.html"),
+        (REPO_ROOT / "quarto-fixture" / "coi-true.qmd", REPO_ROOT / "quarto-fixture" / "coi-true.html"),
+    ]
+
+    url_pat = re.compile(r'(?:href|src)="([^"]*(?:styles\.css|coi-serviceworker\.js)[^"]*)"')
+    seen_urls: set[str] = set()
+    for qmd, html_path in rendered:
+        result = _render_qmd(quarto_bin, qmd, REPO_ROOT)
+        if result.returncode != 0:
+            ko(f"asset URLs project-relative — render {qmd.name} failed (exit {result.returncode})")
+            continue
+        if not html_path.exists():
+            ko(f"asset URLs project-relative — {html_path.name} not found")
+            continue
+        for match in url_pat.finditer(html_path.read_text()):
+            seen_urls.add(match.group(1))
+
+    if not seen_urls:
+        ko("asset URLs project-relative — no blendtutor asset URLs found")
+        return
+
+    for url in sorted(seen_urls):
+        if PROJECT_RELATIVE_URL_RE.match(url):
+            ok(f"asset URL project-relative: {url}")
+        else:
+            ko(f"asset URL project-relative: {url} — must match ^../ or ^./ with no /, //, file:, drive letter, backslash")
+
+        # Clause 5: resolve from the rendered HTML's directory → file on disk.
+        resolved = (REPO_ROOT / "quarto-fixture" / url).resolve()
+        if resolved.is_file():
+            ok(f"asset URL resolves to file on disk: {url}")
+        else:
+            ko(f"asset URL resolves to file on disk: {url} -> {resolved} (browser 404)")
+
+
+def _install_layout(qmd_filter_ref: str, use_extension_yml: bool) -> Path | None:
+    """Create a temp-dir installed layout and render a minimal exercise.
+
+    Copies the real filter + assets into <tmp>/_extensions/mcmullarkey/
+    blendtutor/ (the `quarto add mcmullarkey/blendtutor` install path) and
+    renders a qmd that references it either by explicit path or by name via
+    _extension.yml contributes.filters. Returns the temp dir (with test.html)
+    or None on setup/render failure.
+    """
+    quarto_bin = _find_quarto()
+    if not quarto_bin:
+        ko("installed-layout asset path — quarto not installed")
+        return None
+
+    tmp = Path(tempfile.mkdtemp(prefix="bt-install-"))
+    ext_dir = tmp / "_extensions" / "mcmullarkey" / "blendtutor"
+    (ext_dir / "assets").mkdir(parents=True, exist_ok=True)
+
+    shutil_copy = __import__("shutil").copy2
+    shutil_copy(str(REPO_ROOT / "_extensions" / "blendtutor" / "blendtutor.lua"), str(ext_dir / "blendtutor.lua"))
+    shutil_copy(str(REPO_ROOT / "_extensions" / "blendtutor" / "assets" / "styles.css"), str(ext_dir / "assets" / "styles.css"))
+    if use_extension_yml:
+        shutil_copy(str(REPO_ROOT / "_extensions" / "blendtutor" / "_extension.yml"), str(ext_dir / "_extension.yml"))
+
+    qmd = tmp / "test.qmd"
+    qmd.write_text(
+        "---\n"
+        f"filters: [{qmd_filter_ref}]\n"
+        "---\n\n"
+        '::: {.blendtutor language="r"}\n'
+        "Write code.\n\n"
+        "```r\n"
+        "x <- 1\n"
+        "```\n"
+        ":::\n"
+    )
+
+    result = _render_qmd(quarto_bin, qmd, tmp)
+    if result.returncode != 0:
+        ko(f"installed-layout render failed (exit {result.returncode})")
+        if result.stderr:
+            print(f"  stderr: {result.stderr}", file=sys.stderr)
+        return None
+    return tmp
+
+
+def check_installed_layout_asset_path() -> None:
+    """Installed-layout probe (spec clause 3): filter at org/repo path.
+
+    Copies the filter to <tmp>/_extensions/mcmullarkey/blendtutor/ and
+    renders a qmd referencing it by explicit path. The emitted href must use
+    the actual install location, NOT the hardcoded _extensions/blendtutor/.
+    """
+    tmp = _install_layout("_extensions/mcmullarkey/blendtutor/blendtutor.lua", use_extension_yml=False)
+    if tmp is None:
+        return
+    html = (tmp / "test.html").read_text()
+    if 'href="_extensions/mcmullarkey/blendtutor/assets/styles.css"' in html:
+        ok("installed layout — href uses org/repo install path")
+    else:
+        ko("installed layout — href missing org/repo install path")
+    if 'href="_extensions/blendtutor/assets/styles.css"' in html:
+        ko("installed layout — href still hardcoded _extensions/blendtutor/")
+    else:
+        ok("installed layout — no hardcoded _extensions/blendtutor/ href")
+
+
+def check_by_name_install_absolute_path() -> None:
+    """By-name install probe (clause 4 negative guard).
+
+    Quarto passes an ABSOLUTE PANDOC_SCRIPT_FILE for by-name installs
+    (filters: [blendtutor] via _extension.yml contributes.filters). The
+    emitted href must be converted back to project-relative — an absolute
+    /abs/.../styles.css href lstat-passes but browser-404s.
+    """
+    tmp = _install_layout("blendtutor", use_extension_yml=True)
+    if tmp is None:
+        return
+    html = (tmp / "test.html").read_text()
+    url_pat = re.compile(r'href="([^"]*styles\.css[^"]*)"')
+    match = url_pat.search(html)
+    if not match:
+        ko("by-name install — no styles.css href found in rendered HTML")
+        return
+    url = match.group(1)
+    if url == "_extensions/mcmullarkey/blendtutor/assets/styles.css":
+        ok("by-name install — absolute PANDOC_SCRIPT_FILE converted to project-relative href")
+    else:
+        ko(f"by-name install — expected project-relative href, got: {url}")
+    if PROJECT_RELATIVE_URL_RE.match(url):
+        ok(f"by-name install — href passes project-relative guard: {url}")
+    else:
+        ko(f"by-name install — href fails project-relative guard (absolute leak): {url}")
+
+
+def check_source_grep_zero() -> None:
+    """Source grep zero (spec clause 6): no literal "_extensions/blendtutor/".
+
+    The Lua filter must derive asset paths from PANDOC_SCRIPT_FILE; a
+    retained hardcoded constant (even as fallback) is rejected.
+    """
+    lua_src = (REPO_ROOT / "_extensions" / "blendtutor" / "blendtutor.lua").read_text()
+    if '"_extensions/blendtutor/' in lua_src:
+        ko("source grep zero — literal \"_extensions/blendtutor/\" found in blendtutor.lua")
+    else:
+        ok("source grep zero — no literal \"_extensions/blendtutor/\" in blendtutor.lua")
 
 
 # ---------------------------------------------------------------------------
@@ -632,6 +842,21 @@ def main() -> int:
 
     print("\n-- Rendered HTML: styles.css <link> injection --")
     check_styles_css_loaded()
+
+    print("\n-- Rendered HTML: coi script src project-relative (issue #129) --")
+    check_coi_script_path()
+
+    print("\n-- Asset URLs project-relative + resolvable (issue #129 clauses 4-5) --")
+    check_asset_urls_behavioral()
+
+    print("\n-- Installed layout: org/repo install path (issue #129 clause 3) --")
+    check_installed_layout_asset_path()
+
+    print("\n-- By-name install: absolute script path -> project-relative (issue #129) --")
+    check_by_name_install_absolute_path()
+
+    print("\n-- Source grep zero: no hardcoded _extensions/blendtutor/ (issue #129 clause 6) --")
+    check_source_grep_zero()
 
     print("\n-- Behavioral checks (Node.js) --")
     check_node_behavioral()

--- a/scripts/tests/test_quarto_ux.py
+++ b/scripts/tests/test_quarto_ux.py
@@ -374,13 +374,27 @@ def _render_qmd(quarto_bin: str, qmd_path: Path, cwd: Path) -> subprocess.Comple
     )
 
 
-# Emitted asset URLs must be project-relative (spec clause 4): match ^\.\.?/,
-# no leading /, no //, no file:, no drive letter, no backslash. This rejects
-# an absolute PANDOC_SCRIPT_FILE leaking into the href (browser 404s).
-PROJECT_RELATIVE_URL_RE = re.compile(r"^\.\.?/[^/\\][^\\]*$")
-
-# Asset basenames the filter injects into <head>.
-ASSET_BASENAMES = ("styles.css", "coi-serviceworker.js")
+# Emitted asset URLs must be project-relative (spec clause 4): no leading /,
+# no //, no file:, no drive letter, no backslash. Accepts ./ and ../ prefixes
+# AND bare relative paths — the installed layout legitimately emits
+# "_extensions/mcmullarkey/..." (clause 3), which has no dot-prefix. The guard
+# rejects an absolute PANDOC_SCRIPT_FILE leak ("/abs/proj/..."), which
+# lstat-passes but browser-404s.
+def is_project_relative_url(url: str) -> bool:
+    """True if url is a browser-usable project-relative URL."""
+    if not url:
+        return False
+    if url.startswith(("/", "\\")):
+        return False
+    if "//" in url:
+        return False
+    if "\\" in url:
+        return False
+    if url.startswith("file:"):
+        return False
+    if re.match(r"^[A-Za-z]:", url):
+        return False
+    return True
 
 
 def check_styles_css_loaded() -> None:
@@ -484,10 +498,10 @@ def check_asset_urls_behavioral() -> None:
         return
 
     for url in sorted(seen_urls):
-        if PROJECT_RELATIVE_URL_RE.match(url):
+        if is_project_relative_url(url):
             ok(f"asset URL project-relative: {url}")
         else:
-            ko(f"asset URL project-relative: {url} — must match ^../ or ^./ with no /, //, file:, drive letter, backslash")
+            ko(f"asset URL project-relative: {url} — must be project-relative (no leading /, no //, no file:, no drive letter, no backslash)")
 
         # Clause 5: resolve from the rendered HTML's directory → file on disk.
         resolved = (REPO_ROOT / "quarto-fixture" / url).resolve()
@@ -586,7 +600,7 @@ def check_by_name_install_absolute_path() -> None:
         ok("by-name install — absolute PANDOC_SCRIPT_FILE converted to project-relative href")
     else:
         ko(f"by-name install — expected project-relative href, got: {url}")
-    if PROJECT_RELATIVE_URL_RE.match(url):
+    if is_project_relative_url(url):
         ok(f"by-name install — href passes project-relative guard: {url}")
     else:
         ko(f"by-name install — href fails project-relative guard (absolute leak): {url}")


### PR DESCRIPTION
## Summary

Fixes issue #129: `blendtutor.lua` hardcoded asset paths (`_extensions/blendtutor/` at former lines 54/58), which broke under real `quarto add mcmullarkey/blendtutor` installs — Quarto installs to `_extensions/mcmullarkey/blendtutor/` (org/repo path), so the emitted `href`/`src` pointed at a non-existent directory and the browser 404'd (`lstat NotFound` on `assets/styles.css`).

Replaced the hardcoded constants with a pure `resolve_asset_path(script_file, filename)` (ADR-0018) that derives asset URLs from `PANDOC_SCRIPT_FILE`:

- **Explicit YAML filter paths** (as-written, relative): emitted href mirrors the script's location — `../_extensions/blendtutor/assets/...` from `quarto-fixture/`, `_extensions/mcmullarkey/blendtutor/assets/...` from an installed project root.
- **By-name `_extension.yml` installs** (absolute `PANDOC_SCRIPT_FILE`): converted back to project-relative by slicing from `_extensions/` (robust against macOS `/private/var` vs `/var` root mismatch; `$PWD`-prefix strip as last resort). Quarto does not rewrite `in-header` hrefs, so this conversion is required or the browser 404s.
- Windows-safe `[/\\]` dir-extraction + backslash→`/` href normalization (own regex — `pandoc.path` is POSIX-only and `quarto.utils.relative_to` does not exist in Quarto 1.10.18).

## Issue

Closes #129

## ACs implemented

- [x] Resolve asset paths relative to the filter script's own location (PANDOC_SCRIPT_FILE directory + assets/) instead of hardcoded `_extensions/blendtutor/` prefix
- [x] Works under in-repo, installed org/repo, and demo-book `../` references
- [x] Tests updated to assert the new href/src strings behaviorally (clauses 4–5), not constant-equality

## Spec clauses

1. `quarto render quarto-fixture/ux.qmd` → exit 0, `href="../_extensions/blendtutor/assets/styles.css"` — **PASS** (`docs/evidence/129/emitted-urls.log`)
2. `quarto render quarto-fixture/coi-true.qmd` → exit 0, `src="../_extensions/blendtutor/assets/coi-serviceworker.js"` — **PASS**
3. Installed-layout temp-dir probe → `href="_extensions/mcmullarkey/blendtutor/assets/styles.css"`, NOT `_extensions/blendtutor/` — **PASS** (`docs/evidence/129/installed-layout-probe.log`)
4. Emitted URLs project-relative (no leading `/`, no `//`, no `file:`, no drive letter, no backslash) — **PASS** (`check_asset_urls_behavioral` + `check_by_name_install_absolute_path`)
5. Each href resolves to an existing file on disk — **PASS**
6. `blendtutor.lua` source-grep zero — **PASS** (`docs/evidence/129/source-grep-zero.log`)
7. `test_quarto_ux.py` updated behaviorally — **PASS** (46/46 checks)

## Test plan

- [x] `test_quarto_ux.py`: 46 passed, 0 failed (11 new issue-#129 checks)
- [x] Regression: `test_coi_filter.sh` 15/15, `test_quarto_filter.sh` 17/17, `test_quarto_render.sh` 12/12, `test_quarto_distribution.sh` 23/23, `test_sync_assets.sh` 12/12, `test_quarto_feedback.py` 32/32, `test_pyodide_adapter.sh` 11/11
- [x] `cargo nextest run --locked`: 301/301
- [x] `quarto render demo-book --to html` exits 0; emits `../_extensions/blendtutor/assets/styles.css` + `src="../_extensions/blendtutor/assets/coi-serviceworker.js"`
- [x] E2E evidence committed to `docs/evidence/129/`

## Self-Review

- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested
- [x] Verification medium satisfied (code — no rodney/screenshots)
- [x] Design intent respected (pure resolver, effectful emission in Pandoc(), fix contained in blendtutor.lua)
- [x] No scope creep
