### PR TITLE
[fix] Remove clause-6 copy hack; add hermetic working-tree install-path render test (AC-2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,13 +139,21 @@ jobs:
           test -f _extensions/mcmullarkey/blendtutor/blendtutor.lua
 
       # Issue #115 — Author docs, demo book, and distribution verification.
-      # Validates the 14-clause predicate: README content (install command,
-      # syntax both languages, BYOK, min Quarto, demo link), demo book (render
-      # exits 0, ≥2 exercises per language, non-empty content, mixed-language,
-      # no llm_evaluation_prompt, COI config), and CI (quarto add in temp dir,
+      # Validates the 15-clause predicate: README content (install command,
+      # syntax both languages, BYOK, min Quarto, demo link, install path),
+      # demo book (render exits 0 + asset href targets file-checked, ≥2
+      # exercises per language, non-empty content, mixed-language, no
+      # llm_evaluation_prompt, COI config), and CI (quarto add in temp dir,
       # setup@v2, no continue-on-error).
       - name: Quarto distribution test
         run: bash scripts/tests/test_quarto_distribution.sh
+
+      # Issue #130 — Hermetic working-tree install-path render test. Simulates
+      # the org/repo install layout (_extensions/mcmullarkey/blendtutor/) from
+      # the PR's OWN working tree (not GitHub main) and asserts the filter
+      # loads, assets resolve, and the old non-org path never leaks.
+      - name: Quarto install render test
+        run: bash scripts/tests/test_quarto_install_render.sh
 
       - name: Render demo book
         run: quarto render demo-book --to html

--- a/docs/evidence/130/distribution.log
+++ b/docs/evidence/130/distribution.log
@@ -1,0 +1,64 @@
+== Group 1: README ==
+== Clause 1: install command ==
+  PASS: install command present (quarto add mcmullarkey/blendtutor)
+== Clause 2: syntax both languages ==
+  PASS: R exercise syntax shown in README
+  PASS: Python exercise syntax shown in README
+== Clause 3: BYOK ==
+  PASS: BYOK mentioned in README
+== Clause 4: minimum Quarto version ==
+  PASS: minimum Quarto version stated in README
+== Clause 5: demo book link ==
+  PASS: demo book link present in README
+== Clause 6: install path contract ==
+  PASS: install command present (quarto add mcmullarkey/blendtutor)
+  PASS: install path stated (_extensions/mcmullarkey/blendtutor/)
+  PASS: old wrong install path claim removed
+  PASS: install-path independence stated in README
+  PASS: ADR-0017 annotated with org/repo install path (CI actually + _extensions/mcmullarkey/blendtutor/)
+
+== Group 2: Demo book ==
+== Clause 7: render exits 0 ==
+  PASS: quarto render demo-book exits 0
+  PASS: asset href target exists: ../_extensions/blendtutor/assets/coi-serviceworker.js
+  PASS: asset href target exists: ../_extensions/blendtutor/assets/styles.css
+== Clause 8: ≥2 exercises per language ==
+  PASS: ≥2 R exercises (2 found)
+  PASS: ≥2 Python exercises (2 found)
+== Clause 9: non-empty content ==
+  PASS: non-empty content (no empty exercise divs)
+  PASS: non-empty content (code blocks present: 4)
+== Clause 10: mixed-language ==
+  PASS: mixed-language (R: 2, Python: 2)
+== Clause 11: no llm_evaluation_prompt ==
+  PASS: no llm_evaluation_prompt (0 occurrences)
+== Clause 12: COI config ==
+  PASS: COI config present (coi="true" or coi: true)
+
+== P9: demo-book side-effect free ==
+  PASS: demo-book side-effect free — no extension-dir residue in demo-book
+
+== Group 3: CI ==
+== Clause 13: quarto add in temp dir ==
+  PASS: quarto add mcmullarkey/blendtutor present in CI
+  PASS: temp dir creation in CI
+  PASS: test -f paths use _extensions/mcmullarkey/blendtutor/ (actual install path)
+== Clause 14: setup@v2 ==
+  PASS: quarto-dev/quarto-actions/setup@v2 present in CI
+== Clause 15: no continue-on-error ==
+  PASS: no continue-on-error in quarto-distribution job
+
+== Negative cases ==
+== Negative 1: correct org/repo ==
+  PASS: correct org/repo (mcmullarkey/blendtutor)
+== Negative 2: no empty JSON (exercises have content) ==
+  PASS: no empty JSON (all exercises have content)
+== Negative 3: CI does not use _extensions: copy ==
+  PASS: CI does not use _extensions: copy (uses quarto add instead)
+== Negative 4: README mentions BYOK ==
+  PASS: README mentions BYOK
+
+=========================================
+  Results: 31 passed, 0 failed
+=========================================
+All tests passed.

--- a/docs/evidence/130/install-render.log
+++ b/docs/evidence/130/install-render.log
@@ -1,0 +1,24 @@
+== P1: copy hack removed from test_quarto_distribution.sh ==
+  PASS: hack removed — no masking copy in scripts/tests/test_quarto_distribution.sh
+== P2: no masking copy in render path (only org/repo install simulation) ==
+  PASS: no masking copy in render path (only the working-tree install simulation)
+== P3: install-render test sources from working tree ==
+  PASS: working-tree source — extension copied from repo checkout, no quarto add
+== P10: CI wiring (quarto-distribution job) ==
+  PASS: CI wiring — quarto-distribution job runs install render test
+  PASS: CI wiring — quarto add step retained (distribution-only proof)
+  PASS: CI wiring — Render demo book step retained
+  PASS: CI wiring — no continue-on-error in quarto-distribution job
+  PASS: CI wiring — no '|| true' on render steps in CI
+
+== P4-P8: hermetic working-tree install-path render ==
+  PASS: P4: quarto render --to html exits 0 (org/repo install path)
+  PASS: P5: filter ran — bt-exercise widget present in HTML
+  PASS: P6: styles.css resolved — HTML references _extensions/mcmullarkey/blendtutor/assets/styles.css and file exists
+  PASS: P7: no old-path leak — no _extensions/blendtutor/assets in HTML
+  PASS: P8: coi-serviceworker.js resolved — HTML references _extensions/mcmullarkey/blendtutor/assets/coi-serviceworker.js and file exists
+
+=========================================
+  Results: 13 passed, 0 failed, 0 skipped
+=========================================
+All tests passed.

--- a/docs/evidence/130/negative-control-hack.log
+++ b/docs/evidence/130/negative-control-hack.log
@@ -1,0 +1,26 @@
+=== NEGATIVE CONTROL 1: masking copy reintroduced at non-org path ===
+expect: P1 FAIL, P2 FAIL (install-render); P9 FAIL (distribution)
+
+== P1: copy hack removed from test_quarto_distribution.sh ==
+  FAIL: hack removed — masking copy still present in scripts/tests/test_quarto_distribution.sh
+== P2: no masking copy in render path (only org/repo install simulation) ==
+  FAIL: no masking copy — disallowed match: scripts/tests/test_quarto_distribution.sh:53:  cp -r _extensions/blendtutor "$DEMO_BOOK_DIR/_extensions/"
+== P3: install-render test sources from working tree ==
+  PASS: working-tree source — extension copied from repo checkout, no quarto add
+== P10: CI wiring (quarto-distribution job) ==
+  PASS: CI wiring — quarto-distribution job runs install render test
+  PASS: CI wiring — quarto add step retained (distribution-only proof)
+  PASS: CI wiring — Render demo book step retained
+  PASS: CI wiring — no continue-on-error in quarto-distribution job
+  PASS: CI wiring — no '|| true' on render steps in CI
+
+== P4-P8: hermetic working-tree install-path render ==
+  PASS: P4: quarto render --to html exits 0 (org/repo install path)
+  PASS: P5: filter ran — bt-exercise widget present in HTML
+  PASS: P6: styles.css resolved — HTML references _extensions/mcmullarkey/blendtutor/assets/styles.css and file exists
+  PASS: P7: no old-path leak — no _extensions/blendtutor/assets in HTML
+  PASS: P8: coi-serviceworker.js resolved — HTML references _extensions/mcmullarkey/blendtutor/assets/coi-serviceworker.js and file exists
+
+=========================================
+  Results: 11 passed, 2 failed, 0 skipped
+=========================================

--- a/docs/evidence/130/negative-control-hardcoded.log
+++ b/docs/evidence/130/negative-control-hardcoded.log
@@ -1,0 +1,26 @@
+=== NEGATIVE CONTROL 2: pre-AC-1 hardcoded asset paths reintroduced in blendtutor.lua ===
+expect: P6 FAIL, P7 FAIL, P8 FAIL (install-render)
+
+== P1: copy hack removed from test_quarto_distribution.sh ==
+  PASS: hack removed — no masking copy in scripts/tests/test_quarto_distribution.sh
+== P2: no masking copy in render path (only org/repo install simulation) ==
+  PASS: no masking copy in render path (only the working-tree install simulation)
+== P3: install-render test sources from working tree ==
+  PASS: working-tree source — extension copied from repo checkout, no quarto add
+== P10: CI wiring (quarto-distribution job) ==
+  PASS: CI wiring — quarto-distribution job runs install render test
+  PASS: CI wiring — quarto add step retained (distribution-only proof)
+  PASS: CI wiring — Render demo book step retained
+  PASS: CI wiring — no continue-on-error in quarto-distribution job
+  PASS: CI wiring — no '|| true' on render steps in CI
+
+== P4-P8: hermetic working-tree install-path render ==
+  PASS: P4: quarto render --to html exits 0 (org/repo install path)
+  PASS: P5: filter ran — bt-exercise widget present in HTML
+  FAIL: P6: styles.css resolved — HTML does not reference _extensions/mcmullarkey/blendtutor/assets/styles.css
+  FAIL: P7: no old-path leak — HTML contains _extensions/blendtutor/assets
+  FAIL: P8: coi-serviceworker.js resolved — HTML does not reference _extensions/mcmullarkey/blendtutor/assets/coi-serviceworker.js (coi="true" not honored)
+
+=========================================
+  Results: 10 passed, 3 failed, 0 skipped
+=========================================

--- a/docs/evidence/130/probe.log
+++ b/docs/evidence/130/probe.log
@@ -1,0 +1,88 @@
+== Group 1: README ==
+== Clause 1: install command ==
+  PASS: install command present (quarto add mcmullarkey/blendtutor)
+== Clause 2: syntax both languages ==
+  PASS: R exercise syntax shown in README
+  PASS: Python exercise syntax shown in README
+== Clause 3: BYOK ==
+  PASS: BYOK mentioned in README
+== Clause 4: minimum Quarto version ==
+  PASS: minimum Quarto version stated in README
+== Clause 5: demo book link ==
+  PASS: demo book link present in README
+== Clause 6: install path contract ==
+  PASS: install command present (quarto add mcmullarkey/blendtutor)
+  PASS: install path stated (_extensions/mcmullarkey/blendtutor/)
+  PASS: old wrong install path claim removed
+  PASS: install-path independence stated in README
+  PASS: ADR-0017 annotated with org/repo install path (CI actually + _extensions/mcmullarkey/blendtutor/)
+
+== Group 2: Demo book ==
+== Clause 7: render exits 0 ==
+  PASS: quarto render demo-book exits 0
+  PASS: asset href target exists: ../_extensions/blendtutor/assets/coi-serviceworker.js
+  PASS: asset href target exists: ../_extensions/blendtutor/assets/styles.css
+== Clause 8: ≥2 exercises per language ==
+  PASS: ≥2 R exercises (2 found)
+  PASS: ≥2 Python exercises (2 found)
+== Clause 9: non-empty content ==
+  PASS: non-empty content (no empty exercise divs)
+  PASS: non-empty content (code blocks present: 4)
+== Clause 10: mixed-language ==
+  PASS: mixed-language (R: 2, Python: 2)
+== Clause 11: no llm_evaluation_prompt ==
+  PASS: no llm_evaluation_prompt (0 occurrences)
+== Clause 12: COI config ==
+  PASS: COI config present (coi="true" or coi: true)
+
+== P9: demo-book side-effect free ==
+  PASS: demo-book side-effect free — no extension-dir residue in demo-book
+
+== Group 3: CI ==
+== Clause 13: quarto add in temp dir ==
+  PASS: quarto add mcmullarkey/blendtutor present in CI
+  PASS: temp dir creation in CI
+  PASS: test -f paths use _extensions/mcmullarkey/blendtutor/ (actual install path)
+== Clause 14: setup@v2 ==
+  PASS: quarto-dev/quarto-actions/setup@v2 present in CI
+== Clause 15: no continue-on-error ==
+  PASS: no continue-on-error in quarto-distribution job
+
+== Negative cases ==
+== Negative 1: correct org/repo ==
+  PASS: correct org/repo (mcmullarkey/blendtutor)
+== Negative 2: no empty JSON (exercises have content) ==
+  PASS: no empty JSON (all exercises have content)
+== Negative 3: CI does not use _extensions: copy ==
+  PASS: CI does not use _extensions: copy (uses quarto add instead)
+== Negative 4: README mentions BYOK ==
+  PASS: README mentions BYOK
+
+=========================================
+  Results: 31 passed, 0 failed
+=========================================
+All tests passed.
+== P1: copy hack removed from test_quarto_distribution.sh ==
+  PASS: hack removed — no masking copy in scripts/tests/test_quarto_distribution.sh
+== P2: no masking copy in render path (only org/repo install simulation) ==
+  PASS: no masking copy in render path (only the working-tree install simulation)
+== P3: install-render test sources from working tree ==
+  PASS: working-tree source — extension copied from repo checkout, no quarto add
+== P10: CI wiring (quarto-distribution job) ==
+  PASS: CI wiring — quarto-distribution job runs install render test
+  PASS: CI wiring — quarto add step retained (distribution-only proof)
+  PASS: CI wiring — Render demo book step retained
+  PASS: CI wiring — no continue-on-error in quarto-distribution job
+  PASS: CI wiring — no '|| true' on render steps in CI
+
+== P4-P8: hermetic working-tree install-path render ==
+  PASS: P4: quarto render --to html exits 0 (org/repo install path)
+  PASS: P5: filter ran — bt-exercise widget present in HTML
+  PASS: P6: styles.css resolved — HTML references _extensions/mcmullarkey/blendtutor/assets/styles.css and file exists
+  PASS: P7: no old-path leak — no _extensions/blendtutor/assets in HTML
+  PASS: P8: coi-serviceworker.js resolved — HTML references _extensions/mcmullarkey/blendtutor/assets/coi-serviceworker.js and file exists
+
+=========================================
+  Results: 13 passed, 0 failed, 0 skipped
+=========================================
+All tests passed.

--- a/docs/evidence/130/test-suite.log
+++ b/docs/evidence/130/test-suite.log
@@ -1,0 +1,319 @@
+=== quarto-render job regression suite (mirrors ci.yml quarto-render job) ===
+
+---- scripts/tests/test_quarto_render.sh ----
+== Assertion 1: contributes.filters present in _extension.yml ==
+  PASS: contributes.filters key present
+  PASS: blendtutor.lua listed in contributes.filters
+== Assertion 2: blendtutor.lua is valid Pandoc filter ==
+  PASS: blendtutor.lua defines Pandoc function
+  PASS: blendtutor.lua returns doc unmodified
+== Assertion 2b: .qmd YAML declares explicit filter path ==
+  PASS: filter path declared in .qmd YAML
+== Assertions 3-7: quarto render + content survival + filter load ==
+  PASS: quarto render exits 0
+  PASS: standard content survived (Hello from Quarto)
+  PASS: blendtutor content survived (add(a, b))
+  PASS: blendtutor content survived (stopifnot(add(1, 2) == 3))
+  PASS: filter loaded (bt-exercise widget present in HTML)
+== Assertion 8: CI setup@v2 + no continue-on-error ==
+  PASS: CI uses quarto-dev/quarto-actions/setup@v2
+  PASS: no continue-on-error in quarto-render job
+
+=========================================
+  Results: 12 passed, 0 failed
+=========================================
+All tests passed.
+
+---- scripts/tests/test_quarto_filter.sh ----
+Using render tool: quarto
+== Structural guard: .qmd YAML declares explicit filter path ==
+  PASS: filter path declared in filter.qmd YAML
+== Assertions 1-6: HTML render + JSON contract ==
+  PASS: render exits 0
+All assertions passed (4 widgets verified)
+  PASS: >=3 bt-exercise widgets with all 9 keys
+  PASS: full exercise values correct (prompt <code>, code_template <-, checks len 2, solution 'a + b', hints <-, gotchas null, packages [])
+  PASS: minimal Python: packages parsed, all 9 keys present
+  PASS: empty exercise: all 9 keys present (null/[] for absent)
+  PASS: IDs distinct, titles non-empty
+  PASS: llm_evaluation_prompt ABSENT
+== Assertion 7: non-HTML format skips widget emission ==
+  PASS: non-HTML render exits 0
+  PASS: no bt-exercise in non-HTML output
+  PASS: warning emitted for non-HTML format
+== Assertion 8: invalid language warning + skip ==
+  PASS: invalid-lang render exits 0
+  PASS: no bt-exercise for invalid language
+  PASS: warning for invalid language
+== Assertion 9: missing language warning + skip ==
+  PASS: missing-lang render exits 0
+  PASS: no bt-exercise for missing language
+  PASS: warning for missing language
+
+=========================================
+  Results: 17 passed, 0 failed
+=========================================
+All tests passed.
+
+---- scripts/tests/test_pyodide_adapter.sh ----
+== Part 1: Node.js validation ==
+
+=== AC-6 Pyodide Adapter Validation Results ===
+Passed: 60
+Failed: 0
+All validations passed.
+  PASS: Node.js validation passed
+== Part 2: Quarto render pyodide.qmd ==
+Using render tool: quarto
+  PASS: pyodide.qmd render exits 0
+  PASS: >=2 bt-exercise widgets in pyodide.qmd (2 found)
+  PASS: CDN script tag injected for Python exercises
+  PASS: exactly one pyodide.js CDN script tag
+  PASS: mixed-lang.qmd render exits 0
+  PASS: >=2 bt-exercise widgets in mixed-lang.qmd (2 found)
+  PASS: CDN script tag injected for mixed-lang (Python present)
+== Part 3: Negative case — no CDN for R-only ==
+  PASS: r-only.qmd render exits 0
+  PASS: >=2 bt-exercise widgets in r-only.qmd (2 found)
+  PASS: CDN NOT injected for R-only — pyodide.js CDN URL absent from HTML
+
+=========================================
+  Results: 11 passed, 0 failed
+=========================================
+All tests passed.
+
+---- scripts/tests/test_quarto_feedback.py ----
+scripts/tests/test_quarto_feedback.py: line 26: Executable spec for issue #112 — Per-exercise BYOK LLM feedback.
+
+Verifies the 9-clause predicate from AC-7:
+  1. key entered once — shared sessionStorage key slot (provider-scoped, not
+     exercise-scoped); entered once, reused across exercises.
+  2. per-exercise scoping — each exercise has its own feedback container; no
+     singleton getElementById(feedback).
+  3. key reused — readKey reads from the shared slot; second exercise skips
+     the key prompt.
+  4. provider switch — PROVIDERS map + storeProvider/readProvider; the provider
+     chooser renders a <select data-byok=provider>.
+  5. ?provider= override — providerBaseUrl honors a localhost-only override and
+     rejects non-local / credentialed overrides.
+  6. llm_evaluation_prompt ABSENT — never in the JS source or the qmd fixture.
+  7. fetch spy (STUDENT_CODE fences) — buildPrompt emits STUDENT_CODE fences;
+     the backend calls fetch with the prompt body.
+  8. concurrent — per-exercise concurrent feedback guard prevents overlapping
+     requests.
+  9. UI visibility — feedback button + container mounted per-exercise.
+
+Negative: silently skips fetch (no fetch call). Cross-exercise bleed (key
+re-prompted per exercise). llm_evaluation_prompt leaks into the browser.
+
+Usage: python3 scripts/tests/test_quarto_feedback.py
+: File name too long
+scripts/tests/test_quarto_feedback.py: line 28: from: command not found
+scripts/tests/test_quarto_feedback.py: line 30: import: command not found
+scripts/tests/test_quarto_feedback.py: line 31: import: command not found
+scripts/tests/test_quarto_feedback.py: line 32: import: command not found
+scripts/tests/test_quarto_feedback.py: line 33: import: command not found
+scripts/tests/test_quarto_feedback.py: line 34: from: command not found
+scripts/tests/test_quarto_feedback.py: line 36: syntax error near unexpected token `('
+scripts/tests/test_quarto_feedback.py: line 36: `REPO_ROOT = Path(__file__).resolve().parent.parent.parent'
+=== AC-7 Per-exercise BYOK LLM feedback — test_quarto_feedback.py ===
+
+  PASS: exercise-feedback.js exists
+  PASS: feedback.qmd exists
+-- Clause 6: llm_evaluation_prompt ABSENT --
+  PASS: llm_evaluation_prompt ABSENT from exercise-feedback.js
+  PASS: llm_evaluation_prompt ABSENT from feedback.qmd
+
+-- Source-pattern checks --
+  PASS: pure function exported: neutralize
+  PASS: pure function exported: buildPrompt
+  PASS: pure function exported: parseModels
+  PASS: pure function exported: modelRoster
+  PASS: pure function exported: feedbackRequest
+  PASS: pure function exported: toVerdict
+  PASS: pure function exported: fireworksRequest
+  PASS: pure function exported: fireworksToVerdict
+  PASS: pure function exported: providerBaseUrl
+  PASS: STUDENT_CODE fences present in source
+  PASS: PROVIDERS map has fireworks + anthropic
+  PASS: provider-scoped key slots present (fireworks_api_key, anthropic_api_key)
+  PASS: key slot is provider-scoped (not exercise-scoped)
+  PASS: storeKey + readKey present (shared key handling)
+  PASS: no singleton getElementById('feedback') — per-exercise scoping
+  PASS: no window.__bt singleton access (uses __btExercises registry)
+  PASS: ?provider= override parsed via URLSearchParams
+  PASS: localhost-only gate present (non-local override rejected)
+  PASS: per-exercise concurrent feedback guard present
+  PASS: mountFeedback/mountAllFeedback present (per-exercise mount)
+  PASS: feedback UI elements carry data-byok/data-feedback markers
+  PASS: fetch() called in backends (feedback is not silently skipped)
+  PASS: no module-level applyEmbeddedKey() call (pure layer importable)
+
+-- Behavioral checks (Node.js) --
+  PASS: buildPrompt emits STUDENT_CODE_BEGIN fence
+  PASS: buildPrompt emits STUDENT_CODE_END fence
+  PASS: buildPrompt includes task
+  PASS: buildPrompt includes student code
+  PASS: buildPrompt includes captured output
+  PASS: buildPrompt includes checks
+  PASS: neutralize strips forged STUDENT_CODE_BEGIN
+  PASS: neutralize replaces with marker
+  PASS: key reused from shared sessionStorage slot (entered once)
+  PASS: provider switched to anthropic
+  PASS: provider switched back to fireworks
+  PASS: localhost override honored
+  PASS: non-local override rejected (key exfil prevented)
+  PASS: non-local override falls back to provider base URL
+  PASS: credentialed override rejected
+  PASS: parseModels extracts model ids
+  PASS: modelRoster falls back when list empty
+  PASS: feedbackRequest embeds prompt in messages
+  PASS: feedbackRequest forces feedback tool
+  PASS: toVerdict maps Anthropic tool call to Verdict
+  PASS: fireworksToVerdict maps OpenAI tool call to Verdict
+  PASS: Node.js behavioral tests passed (all pure-function assertions)
+
+-- feedback.qmd structure --
+  PASS: feedback.qmd has 2 exercises (>=2 for key-reuse test)
+  PASS: feedback.qmd imports exercise-feedback.js
+  PASS: feedback.qmd imports exercise-runtime.js (AC-4 dependency)
+  PASS: feedback.qmd calls mountFeedback/mountAllFeedback
+
+=== Results: 32 passed, 0 failed ===
+
+---- scripts/tests/test_coi_filter.sh ----
+Using render tool: quarto
+== Clause 1: coi="true" activates ==
+  PASS: coi-true.qmd render exits 0
+  PASS: coi="true" activates — script tag present
+== Clause 2: false/yes/empty rejected ==
+  PASS: coi="false" rejected — no script tag
+  PASS: coi="yes" rejected — no script tag
+  PASS: coi="" rejected — no script tag
+== Clause 3: dedup (one script tag for multiple coi="true" divs) ==
+  PASS: dedup — exactly one script tag (1 found)
+== Clause 4: byte-parity (vendored == source) ==
+  PASS: byte-parity — vendored coi-serviceworker.js byte-identical to source
+== Clause 5: per-page isolation ==
+  PASS: structural guard — no _quarto.yml in coi-book/ (standalone render)
+  PASS: per-page isolation — coi chapter has script tag
+  PASS: per-page isolation — no-coi chapter has no script tag
+  PASS: per-page isolation — index has no script tag
+== Clause 6: no R exercises still registers ==
+  PASS: no R exercises still registers — coi script tag present
+== Clause 7: coi-yaml (document-level YAML activates) ==
+  PASS: coi-yaml — script tag present (YAML coi: true activates)
+== Negative: script src does NOT 404 ==
+  PASS: script src resolves — coi-serviceworker.js exists at _extensions/blendtutor/assets/coi-serviceworker.js
+== Negative: filter does NOT hardcode script tag ==
+  PASS: no hardcode — no script tag when coi attribute absent
+
+=========================================
+  Results: 15 passed, 0 failed
+=========================================
+All tests passed.
+
+---- scripts/tests/test_quarto_ux.py ----
+scripts/tests/test_quarto_ux.py: line 23: Executable spec for issue #113 — Exercise UX polish.
+
+Verifies the 7-clause predicate from AC-8:
+  1. hints visible/absent — exercises with hints render a <details> toggle;
+     exercises without hints do not.
+  2. solution button click inserts text — a Show: No such file or directory
+scripts/tests/test_quarto_ux.py: line 25: from: command not found
+scripts/tests/test_quarto_ux.py: line 27: import: command not found
+scripts/tests/test_quarto_ux.py: line 28: import: command not found
+scripts/tests/test_quarto_ux.py: line 29: import: command not found
+scripts/tests/test_quarto_ux.py: line 30: import: command not found
+scripts/tests/test_quarto_ux.py: line 31: import: command not found
+scripts/tests/test_quarto_ux.py: line 32: from: command not found
+scripts/tests/test_quarto_ux.py: line 34: syntax error near unexpected token `('
+scripts/tests/test_quarto_ux.py: line 34: `REPO_ROOT = Path(__file__).resolve().parent.parent.parent'
+=== AC-8 Exercise UX polish — test_quarto_ux.py ===
+
+  PASS: exercise-runtime.js exists
+  PASS: ux.qmd exists
+-- ux.qmd structure --
+  PASS: ux.qmd has 3 exercises (>=3 for UX polish test)
+  PASS: ux.qmd has a .solution code block (solution reveal test)
+  PASS: ux.qmd has a hints div (hints toggle test)
+  PASS: ux.qmd has .checks code block (check button test)
+  PASS: ux.qmd imports exercise-runtime.js
+
+-- Clause 1: hints visible/absent --
+  PASS: hints <details> toggle present in exercise-runtime.js
+  PASS: hints rendering is conditional on payload.hints
+
+-- Clause 2: solution button click inserts text --
+  PASS: solution rendering references payload.solution
+  PASS: solution button creation present in exercise-runtime.js
+  PASS: solution button calls setEditorContent
+
+-- Clause 3: check button absent when no checks --
+  PASS: check button creation is conditional on checks length
+  PASS: check button referenced in exercise-runtime.js
+
+-- Clause 4: Run disables ex-0 only (per-exercise) --
+  PASS: per-exercise Run button reference found
+  PASS: button disable/enable mechanism present
+  PASS: no singleton getElementById('run') — per-exercise Run button
+
+-- Clause 5: cursor=not-allowed --
+  PASS: cursor: not-allowed present in styles.css
+  PASS: disabled button selector present in styles.css
+
+-- Clause 6: data-status closed set --
+  PASS: data-status closed set referenced (4/4 values found)
+  PASS: data-status attribute mechanism present
+  PASS: data-status="idle" selector present in styles.css
+  PASS: data-status="running" selector present in styles.css
+  PASS: data-status="pass" selector present in styles.css
+  PASS: data-status="fail" selector present in styles.css
+
+-- Clause 7: buttons re-enabled on pass --
+  PASS: button re-enable mechanism present (disabled = false or finally)
+
+-- Regression: Check/Solution disabled during run --
+  PASS: entry.checkBtn ref stored for runSubmission access
+  PASS: entry.solutionBtn ref stored for runSubmission access
+  PASS: Check button disabled during runSubmission
+  PASS: Solution button disabled during runSubmission
+  PASS: Check button re-enabled after runSubmission
+  PASS: Solution button re-enabled after runSubmission
+
+-- CSS: hints + solution styling --
+  PASS: hints styling present in styles.css
+  PASS: solution button styling present in styles.css
+
+-- Rendered HTML: styles.css <link> injection --
+  PASS: styles.css <link> present in rendered HTML (project-relative href)
+
+-- Rendered HTML: coi script src project-relative (issue #129) --
+  PASS: coi script src present in rendered HTML (project-relative src)
+
+-- Asset URLs project-relative + resolvable (issue #129 clauses 4-5) --
+  PASS: asset URL project-relative: ../_extensions/blendtutor/assets/coi-serviceworker.js
+  PASS: asset URL resolves to file on disk: ../_extensions/blendtutor/assets/coi-serviceworker.js
+  PASS: asset URL project-relative: ../_extensions/blendtutor/assets/styles.css
+  PASS: asset URL resolves to file on disk: ../_extensions/blendtutor/assets/styles.css
+
+-- Installed layout: org/repo install path (issue #129 clause 3) --
+  PASS: installed layout — href uses org/repo install path
+  PASS: installed layout — no hardcoded _extensions/blendtutor/ href
+
+-- By-name install: absolute script path -> project-relative (issue #129) --
+  PASS: by-name install — absolute PANDOC_SCRIPT_FILE converted to project-relative href
+  PASS: by-name install — href passes project-relative guard: _extensions/mcmullarkey/blendtutor/assets/styles.css
+
+-- Source grep zero: no hardcoded _extensions/blendtutor/ (issue #129 clause 6) --
+  PASS: source grep zero — no literal "_extensions/blendtutor/" in blendtutor.lua
+
+-- Behavioral checks (Node.js) --
+  PASS: scanExercises exported
+  PASS: buildRegistry exported
+  PASS: start exported
+  PASS: parsePayload exported
+  PASS: Node.js behavioral tests passed (exports verified)
+
+=== Results: 46 passed, 0 failed ===
+

--- a/scripts/tests/test_quarto_distribution.sh
+++ b/scripts/tests/test_quarto_distribution.sh
@@ -1,27 +1,32 @@
 #!/usr/bin/env bash
 # Executable spec for issue #115 — Author docs, demo book, quarto add install verification.
 #
-# Verifies the 14-clause predicate from AC-10 in 3 groups:
+# Verifies the 15-clause predicate from AC-10 in 3 groups:
 #
-#   Group 1 — README (5 clauses):
+#   Group 1 — README (6 clauses):
 #     1. Install command present (quarto add mcmullarkey/blendtutor)
 #     2. Syntax shown for both languages (R and Python)
 #     3. BYOK (bring your own key) mentioned
 #     4. Minimum Quarto version stated
 #     5. Demo book link present
+#     6. Install path contract (org/repo path, per AC-3)
 #
 #   Group 2 — Demo book (6 clauses):
-#     6. quarto render demo-book exits 0
-#     7. ≥2 exercises per language (R and Python)
-#     8. Non-empty content (no empty exercise divs / empty JSON)
-#     9. Mixed-language (both R and Python present)
-#    10. No llm_evaluation_prompt field
-#    11. COI config present (coi="true" or coi: true)
+#     7. quarto render demo-book exits 0 + asset href targets file-checked
+#     8. ≥2 exercises per language (R and Python)
+#     9. Non-empty content (no empty exercise divs / empty JSON)
+#    10. Mixed-language (both R and Python present)
+#    11. No llm_evaluation_prompt field
+#    12. COI config present (coi="true" or coi: true)
 #
 #   Group 3 — CI (3 clauses):
-#    12. quarto add in temp dir
-#    13. setup@v2
-#    14. No continue-on-error
+#    13. quarto add in temp dir
+#    14. setup@v2
+#    15. No continue-on-error
+#
+# P9 (issue #130): the demo-book render path must be side-effect free — the
+# suite never creates an extension dir under demo-book (the old clause-6 copy
+# hack's residue is asserted absent at the end of Group 2).
 #
 # Negative cases:
 #   - Wrong org/repo (must be mcmullarkey/blendtutor)
@@ -184,8 +189,8 @@ if [ -d "$DEMO_BOOK_DIR" ]; then
   done < <(find "$DEMO_BOOK_DIR" -name '*.qmd' -print0)
 fi
 
-# Clause 6: quarto render demo-book exits 0
-echo "== Clause 6: render exits 0 =="
+# Clause 7: quarto render demo-book exits 0 + asset href targets file-checked
+echo "== Clause 7: render exits 0 =="
 if [ ! -d "$DEMO_BOOK_DIR" ]; then
   ko "render exits 0 — demo-book directory not found"
 elif [ ${#DEMO_QMD_FILES[@]} -eq 0 ]; then
@@ -201,16 +206,11 @@ else
       ko "render exits 0 — _quarto.yml missing in demo-book/"
     fi
   else
-    # Quarto resolves extension assets relative to the project directory
-    # (demo-book/), not the filter path (../_extensions/blendtutor/). The
-    # demo-book _quarto.yml references the filter via a relative path, but
-    # Quarto still looks for assets in demo-book/_extensions/blendtutor/.
-    # Copy the extension so the render can find styles.css and other assets.
-    if [ -d "_extensions/blendtutor" ] && [ ! -d "$DEMO_BOOK_DIR/_extensions/blendtutor" ]; then
-      mkdir -p "$DEMO_BOOK_DIR/_extensions"
-      cp -r _extensions/blendtutor "$DEMO_BOOK_DIR/_extensions/"
-    fi
-    # Render the demo book
+    # Render the demo book. No extension copy here (the old clause-6 copy
+    # hack masked the install-path bug by copying the extension dir into
+    # demo-book): post-AC-1 the filter derives asset paths from
+    # PANDOC_SCRIPT_FILE, so the emitted hrefs resolve relative to the
+    # project dir (demo-book/) into the repo checkout.
     RENDER_OUTPUT=$(quarto render "$DEMO_BOOK_DIR" --to html 2>&1) && RENDER_RC=0 || RENDER_RC=$?
     if [ "$RENDER_RC" -eq 0 ]; then
       ok "quarto render demo-book exits 0"
@@ -218,11 +218,37 @@ else
       ko "quarto render demo-book exits 0 — exit code $RENDER_RC"
       echo "  render output: $RENDER_OUTPUT" >&2
     fi
+
+    # Asset href file check (P9): Quarto does NOT validate emitted hrefs at
+    # render — exit 0 alone is insufficient. Extract every blendtutor asset
+    # href/src from the rendered HTML and file-check its target resolved
+    # relative to the project directory (demo-book/), where the filter's
+    # ../_extensions/... prefix is anchored.
+    RENDER_HTML_DIR="$DEMO_BOOK_DIR/_output"
+    HREF_FOUND=0
+    HREF_MISSING=0
+    if [ -d "$RENDER_HTML_DIR" ]; then
+      while IFS= read -r href; do
+        [ -z "$href" ] && continue
+        HREF_FOUND=1
+        if ( cd "$DEMO_BOOK_DIR" && test -f "$href" ); then
+          ok "asset href target exists: $href"
+        else
+          ko "asset href target missing: $href"
+          HREF_MISSING=1
+        fi
+      done < <(grep -hoE '(href|src)="[^"]*blendtutor/[^"]*"' "$RENDER_HTML_DIR"/*.html 2>/dev/null | sed -E 's/^[^"]*"([^"]*)"/\1/' | sort -u)
+      if [ "$HREF_FOUND" -eq 0 ]; then
+        ko "asset href file check — no blendtutor asset hrefs found in rendered HTML"
+      fi
+    else
+      ko "asset href file check — rendered HTML dir not found: $RENDER_HTML_DIR"
+    fi
   fi
 fi
 
-# Clause 7: ≥2 exercises per language
-echo "== Clause 7: ≥2 exercises per language =="
+# Clause 8: ≥2 exercises per language
+echo "== Clause 8: ≥2 exercises per language =="
 
 # Count R exercises (language="r") across all demo-book .qmd files
 R_COUNT=0
@@ -246,8 +272,8 @@ else
   ko "≥2 Python exercises — found $PYTHON_COUNT (need ≥2)"
 fi
 
-# Clause 8: Non-empty content (no empty exercise divs)
-echo "== Clause 8: non-empty content =="
+# Clause 9: Non-empty content (no empty exercise divs)
+echo "== Clause 9: non-empty content =="
 EMPTY_DIVS=0
 for f in ${DEMO_QMD_FILES[@]+"${DEMO_QMD_FILES[@]}"}; do
   # Check for empty blendtutor divs: ::: {.blendtutor ...} immediately followed by :::
@@ -283,16 +309,16 @@ else
   ko "non-empty content — only $CODE_BLOCKS code blocks (need ≥4 for 2+ exercises per language)"
 fi
 
-# Clause 9: Mixed-language (both R and Python present)
-echo "== Clause 9: mixed-language =="
+# Clause 10: Mixed-language (both R and Python present)
+echo "== Clause 10: mixed-language =="
 if [ "$R_COUNT" -ge 1 ] && [ "$PYTHON_COUNT" -ge 1 ]; then
   ok "mixed-language (R: $R_COUNT, Python: $PYTHON_COUNT)"
 else
   ko "mixed-language — R: $R_COUNT, Python: $PYTHON_COUNT (need both ≥1)"
 fi
 
-# Clause 10: No llm_evaluation_prompt
-echo "== Clause 10: no llm_evaluation_prompt =="
+# Clause 11: No llm_evaluation_prompt
+echo "== Clause 11: no llm_evaluation_prompt =="
 LLM_PROMPT_COUNT=0
 for f in ${DEMO_QMD_FILES[@]+"${DEMO_QMD_FILES[@]}"}; do
   count=$(grep -c 'llm_evaluation_prompt' "$f" 2>/dev/null) || count=0
@@ -311,8 +337,8 @@ else
   ko "no llm_evaluation_prompt — $LLM_PROMPT_COUNT occurrence(s) found"
 fi
 
-# Clause 11: COI config present
-echo "== Clause 11: COI config =="
+# Clause 12: COI config present
+echo "== Clause 12: COI config =="
 COI_FOUND=0
 for f in ${DEMO_QMD_FILES[@]+"${DEMO_QMD_FILES[@]}"}; do
   # Check for coi="true" (div attribute) or coi: true (YAML metadata)
@@ -336,14 +362,32 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# P9 — Demo-book side-effect free (issue #130)
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "== P9: demo-book side-effect free =="
+
+# The old clause-6 copy hack created an extension dir under demo-book as a
+# render side effect (masking the install-path bug). The path is assembled
+# from fragments so the structural no-masking-copy scan (P2) does not
+# false-positive on this guard's own source line.
+DB_EXT_DIR="$DEMO_BOOK_DIR/_""extensions"
+if [ -d "$DB_EXT_DIR" ]; then
+  ko "demo-book side-effect free — extension dir exists in demo-book (copy hack residue)"
+else
+  ok "demo-book side-effect free — no extension-dir residue in demo-book"
+fi
+
+# ---------------------------------------------------------------------------
 # Group 3 — CI (3 clauses)
 # ---------------------------------------------------------------------------
 
 echo ""
 echo "== Group 3: CI =="
 
-# Clause 12: quarto add in temp dir
-echo "== Clause 12: quarto add in temp dir =="
+# Clause 13: quarto add in temp dir
+echo "== Clause 13: quarto add in temp dir =="
 if [ ! -f "$CI_FILE" ]; then
   ko "quarto add in temp dir — CI file not found: $CI_FILE"
 else
@@ -372,8 +416,8 @@ else
   fi
 fi
 
-# Clause 13: setup@v2
-echo "== Clause 13: setup@v2 =="
+# Clause 14: setup@v2
+echo "== Clause 14: setup@v2 =="
 if [ ! -f "$CI_FILE" ]; then
   ko "setup@v2 — CI file not found"
 else
@@ -384,8 +428,8 @@ else
   fi
 fi
 
-# Clause 14: No continue-on-error in distribution job
-echo "== Clause 14: no continue-on-error =="
+# Clause 15: No continue-on-error in distribution job
+echo "== Clause 15: no continue-on-error =="
 if [ ! -f "$CI_FILE" ]; then
   ko "no continue-on-error — CI file not found"
 else

--- a/scripts/tests/test_quarto_install_render.sh
+++ b/scripts/tests/test_quarto_install_render.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+# Executable spec for issue #130 (AC-2) — remove clause-6 copy hack, add a
+# hermetic working-tree install-path render test.
+#
+# Verifies the P1–P10 predicate from the AC-2 executable spec:
+#
+#   P1  Hack removed: no masking copy of the extension dir into demo-book
+#       anywhere in test_quarto_distribution.sh
+#   P2  No masking copy anywhere in the render path (scripts/tests +
+#       .github/workflows/ci.yml) — the ONLY permitted copy is the working-tree
+#       install simulation into the org/repo path
+#       (_extensions/mcmullarkey/blendtutor/)
+#   P3  Working-tree source: this test derives the extension from the repo
+#       checkout; it must NOT run the quarto add install command in the
+#       render path (quarto add installs GitHub main, not the PR's own code)
+#   P4  Real install-path render: minimal index.qmd in $TMP with
+#       filters: [_extensions/mcmullarkey/blendtutor/blendtutor.lua];
+#       quarto render --to html exits 0
+#   P5  Filter ran: output HTML contains bt-exercise
+#   P6  Asset resolved, not exit-0 alone: HTML references
+#       _extensions/mcmullarkey/blendtutor/assets/styles.css AND
+#       test -f "$TMP/_extensions/mcmullarkey/blendtutor/assets/styles.css"
+#   P7  No old-path leak: HTML does NOT contain _extensions/blendtutor/assets
+#       (non-org prefix)
+#   P8  COI path covered: minimal .qmd div sets coi="true"; HTML references
+#       _extensions/mcmullarkey/blendtutor/assets/coi-serviceworker.js AND
+#       the file exists in $TMP
+#   P9  (asserted by test_quarto_distribution.sh) demo-book side-effect free:
+#       no extension-dir residue in demo-book after the distribution suite runs
+#   P10 CI wiring: quarto-distribution job runs this test; `quarto add`
+#       temp-dir step retained (distribution-only proof); `Render demo book`
+#       step retained; no continue-on-error / || true on render steps
+#
+# Negative cases:
+#   - Render inside clause-12's GitHub temp dir → tests published code,
+#     not working tree → P3 + P7 catch
+#   - Hack reintroduced at non-org path → P2 / P7 (and P1 for the
+#     distribution script)
+#   - Pre-AC-1 hardcoded asset paths → P6 / P8 RED
+#   - Filter not loaded → no bt-exercise → P5 fails
+#   - Exit-0-only assertions → P6 / P8 file checks catch (Quarto does not
+#     validate emitted hrefs at render)
+#
+# Usage: bash scripts/tests/test_quarto_install_render.sh
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+ok() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+ko() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+skip_note() { echo "  SKIP: $1"; SKIP=$((SKIP + 1)); }
+
+# ---------------------------------------------------------------------------
+# P1 — Hack removed from test_quarto_distribution.sh
+# ---------------------------------------------------------------------------
+
+echo "== P1: copy hack removed from test_quarto_distribution.sh =="
+
+DIST_SCRIPT="scripts/tests/test_quarto_distribution.sh"
+
+# Patterns are assembled from fragments so this test file itself never
+# contains the literal regex or install command — otherwise the structural
+# self-scans (P1/P2/P3) would false-positive on their own source lines.
+CP_PAT="cp .*_""extensions"
+DB_PAT="demo-book/_""extensions"
+QADD_PAT="quarto add mcmullarkey/""blendtutor"
+
+if [ ! -f "$DIST_SCRIPT" ]; then
+  ko "hack removed — distribution test script not found: $DIST_SCRIPT"
+else
+  if grep -qE "$CP_PAT|$DB_PAT" "$DIST_SCRIPT"; then
+    ko "hack removed — masking copy still present in $DIST_SCRIPT"
+  else
+    ok "hack removed — no masking copy in $DIST_SCRIPT"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# P2 — No masking copy anywhere in the render path
+# ---------------------------------------------------------------------------
+
+echo "== P2: no masking copy in render path (only org/repo install simulation) =="
+
+# rg exits 1 when nothing matches — that IS the success case; the '|| true'
+# here only guards empty input and is not a render step (P10).
+P2_MATCHES=$(rg -n "${CP_PAT}|${DB_PAT}" scripts/tests .github/workflows/ci.yml || true)
+
+if [ -z "$P2_MATCHES" ]; then
+  ok "no masking copy in render path"
+else
+  P2_BAD=0
+  while IFS= read -r line; do
+    if ! grep -qF '_extensions/mcmullarkey/blendtutor/' <<< "$line"; then
+      ko "no masking copy — disallowed match: $line"
+      P2_BAD=1
+    fi
+  done <<< "$P2_MATCHES"
+  if [ "$P2_BAD" -eq 0 ]; then
+    ok "no masking copy in render path (only the working-tree install simulation)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# P3 — Working-tree source (no quarto add in the render path)
+# ---------------------------------------------------------------------------
+
+echo "== P3: install-render test sources from working tree =="
+
+if grep -qF "$QADD_PAT" "$0"; then
+  ko "working-tree source — this test must not run the quarto add install command"
+else
+  ok "working-tree source — extension copied from repo checkout, no quarto add"
+fi
+
+# ---------------------------------------------------------------------------
+# P10 — CI wiring (always checked)
+# ---------------------------------------------------------------------------
+
+echo "== P10: CI wiring (quarto-distribution job) =="
+
+CI_FILE=".github/workflows/ci.yml"
+
+if [ ! -f "$CI_FILE" ]; then
+  ko "CI wiring — CI file not found: $CI_FILE"
+else
+  if grep -qF 'bash scripts/tests/test_quarto_install_render.sh' "$CI_FILE"; then
+    ok "CI wiring — quarto-distribution job runs install render test"
+  else
+    ko "CI wiring — quarto-distribution job must run test_quarto_install_render.sh"
+  fi
+
+  if grep -qF "$QADD_PAT" "$CI_FILE"; then
+    ok "CI wiring — quarto add step retained (distribution-only proof)"
+  else
+    ko "CI wiring — quarto add step missing from CI"
+  fi
+
+  if grep -qF 'Render demo book' "$CI_FILE"; then
+    ok "CI wiring — Render demo book step retained"
+  else
+    ko "CI wiring — Render demo book step missing from CI"
+  fi
+
+  # No continue-on-error in the quarto-distribution job section.
+  DIST_JOB_LINE=$(grep -n 'quarto-distribution' "$CI_FILE" | head -1 | cut -d: -f1)
+  if [ -z "$DIST_JOB_LINE" ]; then
+    ko "CI wiring — quarto-distribution job not found in CI"
+  else
+    REMAINING=$(tail -n +"$DIST_JOB_LINE" "$CI_FILE")
+    if echo "$REMAINING" | grep -qE '^[[:space:]]*continue-on-error[[:space:]]*:'; then
+      ko "CI wiring — continue-on-error found in quarto-distribution job"
+    else
+      ok "CI wiring — no continue-on-error in quarto-distribution job"
+    fi
+  fi
+
+  # No '|| true' on render steps — only real run: lines count, not comments.
+  if grep -E '\|\|[[:space:]]*true' "$CI_FILE" | grep -vE '^[[:space:]]*#' | grep -q .; then
+    ko "CI wiring — '|| true' found in CI (must fail loudly on render steps)"
+  else
+    ok "CI wiring — no '|| true' on render steps in CI"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# P4–P8 — Hermetic real install-path render (requires quarto)
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "== P4-P8: hermetic working-tree install-path render =="
+
+if ! command -v quarto &>/dev/null; then
+  skip_note "quarto not installed locally — render assertions skipped"
+  skip_note "(CI installs quarto via quarto-dev/quarto-actions/setup@v2)"
+else
+  # Hermetic fixture: simulate the quarto add org/repo install layout
+  # from the PR's OWN working tree (the repo checkout), NOT GitHub
+  # main. Quarto installs GitHub-sourced extensions to
+  # _extensions/<org>/<repo>/, so we copy to _extensions/mcmullarkey/blendtutor/.
+  TMP_DIR=$(mktemp -d)
+  trap 'rm -rf "$TMP_DIR"' EXIT
+
+  mkdir -p "$TMP_DIR/_extensions/mcmullarkey"
+  cp -r _extensions/blendtutor "$TMP_DIR/_extensions/mcmullarkey/blendtutor/"
+
+  # P4 fixture: minimal index.qmd exercising the real install-path filter and
+  # a blendtutor div with language="r" and coi="true" (P8).
+  cat > "$TMP_DIR/index.qmd" <<'QMD'
+---
+title: blendtutor install render fixture
+filters: [_extensions/mcmullarkey/blendtutor/blendtutor.lua]
+---
+
+## Install path render test
+
+::: {.blendtutor language="r" coi="true"}
+Write a function `add(a, b)` that returns the sum.
+
+```r
+add <- function(a, b) { a + b }
+```
+
+```{.r .checks}
+stopifnot(add(1, 2) == 3)
+```
+:::
+QMD
+
+  # P4 — quarto render --to html exits 0
+  RENDER_OUTPUT=$( (cd "$TMP_DIR" && quarto render index.qmd --to html) 2>&1 ) && RENDER_RC=0 || RENDER_RC=$?
+
+  if [ "$RENDER_RC" -eq 0 ]; then
+    ok "P4: quarto render --to html exits 0 (org/repo install path)"
+  else
+    ko "P4: quarto render --to html exits 0 — exit code $RENDER_RC"
+    echo "  render output: $RENDER_OUTPUT" >&2
+  fi
+
+  HTML_FILE="$TMP_DIR/index.html"
+
+  if [ ! -f "$HTML_FILE" ]; then
+    ko "P5: filter ran — HTML output not found: $HTML_FILE"
+    ko "P6: styles.css resolved — HTML output not found"
+    ko "P7: no old-path leak — HTML output not found"
+    ko "P8: coi-serviceworker.js resolved — HTML output not found"
+  else
+    HTML_CONTENT=$(cat "$HTML_FILE")
+
+    # P5 — filter actually loaded: bt-exercise widget is only emitted by the
+    # loaded blendtutor filter. Content-survival checks pass trivially when
+    # the filter never runs, so this is the load-proving guard.
+    if grep -qF 'bt-exercise' <<< "$HTML_CONTENT"; then
+      ok "P5: filter ran — bt-exercise widget present in HTML"
+    else
+      ko "P5: filter ran — bt-exercise not found; filter never loaded"
+    fi
+
+    # P6 — styles.css referenced at the org/repo path AND the file exists
+    # (exit-0 alone is insufficient: Quarto does not validate emitted hrefs).
+    CSS_REF='_extensions/mcmullarkey/blendtutor/assets/styles.css'
+    CSS_FILE="$TMP_DIR/_extensions/mcmullarkey/blendtutor/assets/styles.css"
+    if grep -qF "$CSS_REF" <<< "$HTML_CONTENT"; then
+      if [ -f "$CSS_FILE" ]; then
+        ok "P6: styles.css resolved — HTML references $CSS_REF and file exists"
+      else
+        ko "P6: styles.css resolved — HTML references $CSS_REF but file missing: $CSS_FILE"
+      fi
+    else
+      ko "P6: styles.css resolved — HTML does not reference $CSS_REF"
+    fi
+
+    # P7 — no old-path leak (non-org _extensions/blendtutor/assets prefix).
+    if grep -qF '_extensions/blendtutor/assets' <<< "$HTML_CONTENT"; then
+      ko "P7: no old-path leak — HTML contains _extensions/blendtutor/assets"
+    else
+      ok "P7: no old-path leak — no _extensions/blendtutor/assets in HTML"
+    fi
+
+    # P8 — coi-serviceworker.js referenced at the org/repo path AND file exists.
+    COI_REF='_extensions/mcmullarkey/blendtutor/assets/coi-serviceworker.js'
+    COI_FILE="$TMP_DIR/_extensions/mcmullarkey/blendtutor/assets/coi-serviceworker.js"
+    if grep -qF "$COI_REF" <<< "$HTML_CONTENT"; then
+      if [ -f "$COI_FILE" ]; then
+        ok "P8: coi-serviceworker.js resolved — HTML references $COI_REF and file exists"
+      else
+        ko "P8: coi-serviceworker.js resolved — HTML references $COI_REF but file missing: $COI_FILE"
+      fi
+    else
+      ko "P8: coi-serviceworker.js resolved — HTML does not reference $COI_REF (coi=\"true\" not honored)"
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "========================================="
+echo "  Results: $PASS passed, $FAIL failed, $SKIP skipped"
+echo "========================================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+
+echo "All tests passed."


### PR DESCRIPTION
## Summary

Removes the clause-6 copy hack in `scripts/tests/test_quarto_distribution.sh` (which copied `_extensions/blendtutor` into `demo-book/_extensions/` before rendering, masking the install-path bug) and adds a hermetic working-tree render test that exercises the real org/repo install layout using the PR's own code.

**New `scripts/tests/test_quarto_install_render.sh`** asserts the P1–P10 predicate:
- **P1/P2** no masking copy anywhere in the render path (only the permitted working-tree install simulation into `_extensions/mcmullarkey/blendtutor/`)
- **P3** sources from the repo checkout — no `quarto add` in the render path (that would install GitHub main, not the PR's fix)
- **P4–P8** real install-path render in `$TMP`: filter loads (`bt-exercise`), `styles.css` + `coi-serviceworker.js` referenced at the org/repo path AND file-checked (Quarto does not validate emitted hrefs — exit-0 alone is insufficient), no old non-org path leak
- **P10** CI wiring checks

**Reworked `test_quarto_distribution.sh`**: removed the copy hack; render clause (now 7) asserts exit 0 **and** file-checks every blendtutor asset href target resolved relative to the project dir; added P9 demo-book side-effect guard (no extension-dir residue). Per AC-3 review carryover: fixed stale "5 clauses" header (now 6) and renumbered Group 2 clauses 7–12 / Group 3 clauses 13–15 to kill the "Clause 6" naming collision.

**CI**: quarto-distribution job runs the new render test; `quarto add` temp-dir step retained (distribution-only proof); `Render demo book` retained; no `continue-on-error` / `|| true` on render steps.

## Issue

Closes #130

## ACs implemented
- [x] Copy hack removed (P1/P2 structural greps)
- [x] New hermetic render test passes P4–P8 (real org/repo install path, bt-exercise present, styles.css + coi-serviceworker.js resolved and file-checked, no old-path leak)
- [x] Demo-book render side-effect free (P9)
- [x] CI wiring updated, no continue-on-error/`|| true` on render steps (P10)

## Test plan
- [x] All tests pass — probe: distribution 31 + install-render 13, 0 failed
- [x] Negative controls prove discrimination: reintroduced hack → P1/P2/P9 RED; pre-AC-1 hardcoded paths → P6/P7/P8 RED
- [x] Regression: quarto-render job suite green (render 12, filter 17, pyodide 11, feedback 32, coi 15, ux 46)
- [x] E2E evidence at `docs/evidence/130/` (probe.log, distribution.log, install-render.log, negative-control-*.log, test-suite.log)

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec (P1–P10)
- [x] Negative case tested (2 discrimination controls)
- [x] Verification medium satisfied (code — shell test suite, CI-gated)
- [x] Design intent respected (org/repo path invariant P6/P7, no side effects P9, two concerns separated)
- [x] No scope creep (diff limited to conflict set + evidence)
