### PR TITLE
[feature] Filter emits data-language attribute on exercise widgets (filter-runtime-bootstrap AC-1)

### DIFF
--- a/_extensions/blendtutor/blendtutor.lua
+++ b/_extensions/blendtutor/blendtutor.lua
@@ -318,9 +318,10 @@ end
 
 --- Emit the widget HTML as a Pandoc RawBlock.
 -- @param payload The JSON string
+-- @param lang The validated exercise language ("r" or "python")
 -- @return A pandoc.RawBlock("html", ...) element
-local function emit_widget(payload)
-  local html = '<div class="bt-exercise">\n'
+local function emit_widget(payload, lang)
+  local html = '<div class="bt-exercise" data-language="' .. lang .. '">\n'
     .. '<script type="application/json">' .. payload .. "</script>\n"
     .. "</div>"
   return pandoc.RawBlock("html", html)
@@ -388,7 +389,9 @@ function Div(div)
   exercise_count = exercise_count + 1
 
   local payload = build_payload(index, parsed, packages)
-  return emit_widget(payload)
+  -- lang validated to {r, python} above (:364-368) — attribute is the
+  -- sole language carrier (payload has no language key, AC-1 §3).
+  return emit_widget(payload, lang)
 end
 
 --- Reset counters and inject CDN script tag at document level.

--- a/docs/evidence/135/probe.log
+++ b/docs/evidence/135/probe.log
@@ -1,0 +1,118 @@
+===================================================================
+Issue #135 AC-1: data-language attribute emission — E2E probes
+Date: 2026-08-03T06:19:53Z
+Tool: quarto 1.10.18
+===================================================================
+
+>>> quarto render quarto-fixture/filter.qmd --to html
+[1mpandoc [22m
+  to: html
+  output-file: filter.html
+  standalone: true
+  section-divs: true
+  html-math-method: mathjax
+  wrap: none
+  default-image-extension: png
+  
+[1mmetadata[22m
+  document-css: false
+  link-citations: true
+  date-format: long
+  lang: en
+  extensions:
+    - blendtutor
+  title: Filter test fixture
+  
+Output created: filter.html
+
+render rc=0
+
+===================================================================
+CLAUSE 1: attr-tolerant regex extracts >=4 widgets; 9-key contract
+===================================================================
+attr-tolerant regex: 4 widgets extracted
+9-key JSON payload contract intact for all widgets
+CLAUSE 1: PASS
+
+===================================================================
+CLAUSE 2: EVERY div exactly one data-language r|python; count===widgets
+===================================================================
+widget count=4  data-language attr count=4
+every div carries exactly one data-language in {r,python}: ['r', 'python', 'r', 'r']
+CLAUSE 2: PASS
+
+===================================================================
+CLAUSE 3: per-index pairing matches filter.qmd order [r, python, r, r]
+===================================================================
+per-index langs: ['r', 'python', 'r', 'r']
+expected      : ['r', 'python', 'r', 'r']
+idx 1 (filter.qmd:36 Minimal Python exercise) IS python — hardcoded-r fake would fail here
+CLAUSE 3: PASS
+
+===================================================================
+CLAUSE 4: static pin — runtime reads entry.element.dataset.language
+===================================================================
+419:    const language = entry.element.dataset.language || runtime.language || "r";
+CLAUSE 4: PASS
+
+===================================================================
+CLAUSE 5: static pin — verifier has no exact <div class="bt-exercise"> matcher
+===================================================================
+exact matcher absent from scripts/tests/verify_filter_output.py (attr-tolerant regex only)
+CLAUSE 5: PASS
+
+===================================================================
+CLAUSE 6: refusal arms — invalid + missing lang: zero bt-exercise + WARNING
+===================================================================
+--- filter-invalid-lang.qmd (language="ruby") ---
+[1mpandoc [22m
+  to: html
+  output-file: filter-invalid-lang.html
+  standalone: true
+  section-divs: true
+  html-math-method: mathjax
+  wrap: none
+  default-image-extension: png
+  
+[1mmetadata[22m
+  document-css: false
+  link-citations: true
+  date-format: long
+  lang: en
+  extensions:
+    - blendtutor
+  title: Invalid language test
+  
+[blendtutor] WARNING: unsupported language "ruby"; supported: r, python. Skipping.
+Output created: filter-invalid-lang.html
+
+bt-exercise count in invalid-lang output: 0
+CLAUSE 6 invalid: PASS (zero bt-exercise)
+--- filter-missing-lang.qmd (no language attr) ---
+[1mpandoc [22m
+  to: html
+  output-file: filter-missing-lang.html
+  standalone: true
+  section-divs: true
+  html-math-method: mathjax
+  wrap: none
+  default-image-extension: png
+  
+[1mmetadata[22m
+  document-css: false
+  link-citations: true
+  date-format: long
+  lang: en
+  extensions:
+    - blendtutor
+  title: Missing language test
+  
+[blendtutor] WARNING: blendtutor div missing language attribute; skipping.
+Output created: filter-missing-lang.html
+
+bt-exercise count in missing-lang output: 0
+CLAUSE 6 missing: PASS (zero bt-exercise)
+
+===================================================================
+E2E RESULT: all 6 clauses PASS
+===================================================================

--- a/docs/evidence/135/test-suite.log
+++ b/docs/evidence/135/test-suite.log
@@ -4,7 +4,7 @@ Using render tool: quarto
 == Assertions 1-6: HTML render + JSON contract ==
   PASS: render exits 0
 All assertions passed (4 widgets verified)
-  PASS: >=3 bt-exercise widgets with all 9 keys
+  PASS: >=4 bt-exercise widgets with all 9 keys
   PASS: full exercise values correct (prompt <code>, code_template <-, checks len 2, solution 'a + b', hints <-, gotchas null, packages [])
   PASS: minimal Python: packages parsed, all 9 keys present
   PASS: empty exercise: all 9 keys present (null/[] for absent)

--- a/docs/evidence/135/test-suite.log
+++ b/docs/evidence/135/test-suite.log
@@ -1,0 +1,36 @@
+Using render tool: quarto
+== Structural guard: .qmd YAML declares explicit filter path ==
+  PASS: filter path declared in filter.qmd YAML
+== Assertions 1-6: HTML render + JSON contract ==
+  PASS: render exits 0
+All assertions passed (4 widgets verified)
+  PASS: >=3 bt-exercise widgets with all 9 keys
+  PASS: full exercise values correct (prompt <code>, code_template <-, checks len 2, solution 'a + b', hints <-, gotchas null, packages [])
+  PASS: minimal Python: packages parsed, all 9 keys present
+  PASS: empty exercise: all 9 keys present (null/[] for absent)
+  PASS: IDs distinct, titles non-empty
+  PASS: llm_evaluation_prompt ABSENT
+== Assertions 10-11: data-language emission ==
+  PASS: data-language=r emitted
+  PASS: data-language=python emitted
+  PASS: >=4 data-language attrs emitted (found 4)
+== Assertions 12-13: static pins (runtime read + verifier shape) ==
+  PASS: runtime reads entry.element.dataset.language ||
+  PASS: verifier dropped exact matcher — no <div class="bt-exercise"> in verify_filter_output.py
+== Assertion 14: non-HTML format skips widget emission ==
+  PASS: non-HTML render exits 0
+  PASS: no bt-exercise in non-HTML output
+  PASS: warning emitted for non-HTML format
+== Assertion 15: invalid language warning + skip ==
+  PASS: invalid-lang render exits 0
+  PASS: no bt-exercise for invalid language
+  PASS: warning for invalid language
+== Assertion 16: missing language warning + skip ==
+  PASS: missing-lang render exits 0
+  PASS: no bt-exercise for missing language
+  PASS: warning for missing language
+
+=========================================
+  Results: 22 passed, 0 failed
+=========================================
+All tests passed.

--- a/scripts/tests/test_quarto_filter.sh
+++ b/scripts/tests/test_quarto_filter.sh
@@ -130,7 +130,7 @@ else
   # Run Python JSON assertions (covers assertions 1-6)
   python3 scripts/tests/verify_filter_output.py "$HTML_FILE" 2>&1 && PY_RC=0 || PY_RC=$?
   if [ "$PY_RC" -eq 0 ]; then
-    ok ">=3 bt-exercise widgets with all 9 keys"
+    ok ">=4 bt-exercise widgets with all 9 keys"
     ok "full exercise values correct (prompt <code>, code_template <-, checks len 2, solution 'a + b', hints <-, gotchas null, packages [])"
     ok "minimal Python: packages parsed, all 9 keys present"
     ok "empty exercise: all 9 keys present (null/[] for absent)"

--- a/scripts/tests/test_quarto_filter.sh
+++ b/scripts/tests/test_quarto_filter.sh
@@ -161,7 +161,7 @@ if [ -f "$HTML_FILE" ]; then
     ko "data-language=python emitted — not found in $HTML_FILE"
   fi
 
-  DATA_LANG_COUNT=$(grep -o 'data-language="[rp]"' <<< "$HTML_CONTENT" | wc -l | tr -d ' ' || true)
+  DATA_LANG_COUNT=$(grep -o 'data-language="[^"]*"' <<< "$HTML_CONTENT" | wc -l | tr -d ' ' || true)
   if [ "$DATA_LANG_COUNT" -ge 4 ]; then
     ok ">=4 data-language attrs emitted (found $DATA_LANG_COUNT)"
   else

--- a/scripts/tests/test_quarto_filter.sh
+++ b/scripts/tests/test_quarto_filter.sh
@@ -13,9 +13,14 @@
 #   8. Invalid language: warning + skip (no bt-exercise)
 #   9. Missing language: warning + skip (no bt-exercise)
 #
-# Negative: filter emits llm_evaluation_prompt, hardcodes JSON,
-#           omits packages/gotchas, non-HTML emits widget,
-#           silent default for invalid language.
+#   Negative: filter emits llm_evaluation_prompt, hardcodes JSON,
+#             omits packages/gotchas, non-HTML emits widget,
+#             silent default for invalid language.
+#   AC-1 (issue #135) additions:
+#   10. EVERY bt-exercise div carries data-language="r|python";
+#       count === widget count (all-or-none), pairing [r, python, r, r]
+#   11. Static pin: exercise-runtime.js reads entry.element.dataset.language
+#   12. Static pin: verify_filter_output.py has no exact <div class="bt-exercise"> matcher
 #
 # Usage: bash scripts/tests/test_quarto_filter.sh
 set -euo pipefail
@@ -137,10 +142,61 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Assertion 7: Non-HTML format — no bt-exercise + warning
+# Assertions 10-11: data-language emission (AC-1 clause 2-3 shell-level check)
 # ---------------------------------------------------------------------------
 
-echo "== Assertion 7: non-HTML format skips widget emission =="
+echo "== Assertions 10-11: data-language emission =="
+
+if [ -f "$HTML_FILE" ]; then
+  HTML_CONTENT=$(cat "$HTML_FILE")
+  if grep -q 'data-language="r"' <<< "$HTML_CONTENT"; then
+    ok "data-language=r emitted"
+  else
+    ko "data-language=r emitted — not found in $HTML_FILE"
+  fi
+
+  if grep -q 'data-language="python"' <<< "$HTML_CONTENT"; then
+    ok "data-language=python emitted"
+  else
+    ko "data-language=python emitted — not found in $HTML_FILE"
+  fi
+
+  DATA_LANG_COUNT=$(grep -o 'data-language="[rp]"' <<< "$HTML_CONTENT" | wc -l | tr -d ' ' || true)
+  if [ "$DATA_LANG_COUNT" -ge 4 ]; then
+    ok ">=4 data-language attrs emitted (found $DATA_LANG_COUNT)"
+  else
+    ko ">=4 data-language attrs emitted — found $DATA_LANG_COUNT"
+  fi
+else
+  ko "data-language=r emitted — HTML missing"
+  ko "data-language=python emitted — HTML missing"
+  ko ">=4 data-language attrs emitted — HTML missing"
+fi
+
+# ---------------------------------------------------------------------------
+# Assertions 12-13: static pins (AC-1 clauses 4-5)
+# ---------------------------------------------------------------------------
+
+echo "== Assertions 12-13: static pins (runtime read + verifier shape) =="
+
+RUNTIME_JS="_extensions/blendtutor/assets/exercise-runtime.js"
+if grep -qF 'entry.element.dataset.language ||' "$RUNTIME_JS"; then
+  ok "runtime reads entry.element.dataset.language ||"
+else
+  ko "runtime reads entry.element.dataset.language || — pattern not found in $RUNTIME_JS"
+fi
+
+if grep -qF '<div class="bt-exercise">' scripts/tests/verify_filter_output.py; then
+  ko "verifier dropped exact matcher — '<div class=\"bt-exercise\">' still present in verify_filter_output.py"
+else
+  ok "verifier dropped exact matcher — no <div class=\"bt-exercise\"> in verify_filter_output.py"
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 14: Non-HTML format — no bt-exercise + warning
+# ---------------------------------------------------------------------------
+
+echo "== Assertion 14: non-HTML format skips widget emission =="
 
 LATEX_FILE="$FIXTURE_DIR/filter.tex"
 rm -f "$LATEX_FILE"
@@ -178,7 +234,7 @@ fi
 # Assertion 8: Invalid language — warning + skip
 # ---------------------------------------------------------------------------
 
-echo "== Assertion 8: invalid language warning + skip =="
+echo "== Assertion 15: invalid language warning + skip =="
 
 INVALID_HTML="$FIXTURE_DIR/filter-invalid-lang.html"
 rm -f "$INVALID_HTML"
@@ -215,7 +271,7 @@ fi
 # Assertion 9: Missing language — warning + skip
 # ---------------------------------------------------------------------------
 
-echo "== Assertion 9: missing language warning + skip =="
+echo "== Assertion 16: missing language warning + skip =="
 
 MISSING_HTML="$FIXTURE_DIR/filter-missing-lang.html"
 rm -f "$MISSING_HTML"

--- a/scripts/tests/verify_filter_output.py
+++ b/scripts/tests/verify_filter_output.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
-"""Verify filter output: assert 9-key SiteLesson JSON contract.
+"""Verify filter output: assert 9-key SiteLesson JSON contract + data-language.
 
-Reads an HTML file, extracts all bt-exercise widget JSON payloads,
-and asserts the contract from AC-2's executable spec.
+Reads an HTML file, extracts all bt-exercise widget JSON payloads and their
+data-language attributes, and asserts:
+  - the 9-key SiteLesson contract from AC-2's executable spec
+  - every bt-exercise div carries exactly one data-language="r|python"
+    (all-or-none: attribute count must equal widget count)
+  - per-index language pairing matches quarto-fixture/filter.qmd order
+    [r, python, r, r] (AC-1) — catches hardcoded-"r" fakes.
 
 Usage: python3 verify_filter_output.py <html-file>
 """
@@ -32,22 +37,50 @@ REQUIRED_KEYS: set[str] = {
 # and must never be shipped to the browser (ADR-0008).
 FORBIDDEN_KEYS: set[str] = {"llm_evaluation_prompt"}
 
+# The only languages the filter may emit (validate_language in blendtutor.lua).
+ALLOWED_LANGUAGES: set[str] = {"r", "python"}
+
+# Per-index expected language, matching quarto-fixture/filter.qmd exercise
+# order (4-exercise order is load-bearing — do not reorder):
+#   0: Full R exercise        -> "r"
+#   1: Minimal Python exercise -> "python"
+#   2: Empty exercise         -> "r"
+#   3: XSS + gotchas exercise -> "r"
+EXPECTED_LANGUAGES: list[str] = ["r", "python", "r", "r"]
+
 
 def extract_widgets(html: str) -> list[dict[str, Any]]:
     """Extract all bt-exercise widget JSON payloads from HTML.
 
     The filter emits:
-        <div class="bt-exercise">
+        <div class="bt-exercise" data-language="r|python">
         <script type="application/json">{...}</script>
         </div>
+
+    The div opener is matched attr-tolerantly (`[^>]*`), so the JSON is
+    found regardless of which attributes the filter emits on the div.
 
     Returns a list of parsed JSON dicts, one per widget.
     """
     pattern = (
-        r'<div class="bt-exercise">\s*<script type="application/json">(.*?)</script>'
+        r'<div class="bt-exercise"[^>]*>\s*<script type="application/json">(.*?)</script>'
     )
     matches = re.findall(pattern, html, re.DOTALL)
     return [json.loads(m) for m in matches]
+
+
+def extract_widget_languages(html: str) -> list[str | None]:
+    """Extract the data-language attribute from each bt-exercise div opener.
+
+    Returns one entry per widget div in document order. A div carrying zero
+    (or more than one) data-language attributes yields None — the all-or-none
+    contract requires exactly one per div.
+    """
+    langs: list[str | None] = []
+    for div in re.findall(r'<div class="bt-exercise"[^>]*>', html):
+        attrs = re.findall(r'\bdata-language="([^"]*)"', div)
+        langs.append(attrs[0] if len(attrs) == 1 else None)
+    return langs
 
 
 def assert_full_exercise(data: dict[str, Any], errors: list[str]) -> None:
@@ -211,9 +244,9 @@ def main() -> int:
         print(f"  FAIL: JSON decode error in widget payload: {e}", file=sys.stderr)
         return 1
 
-    # Assertion: >=3 exercises
-    if len(widgets) < 3:
-        errors.append(f"Expected >=3 bt-exercise widgets, found {len(widgets)}")
+    # Assertion: >=4 exercises (filter.qmd has 4 — order load-bearing)
+    if len(widgets) < 4:
+        errors.append(f"Expected >=4 bt-exercise widgets, found {len(widgets)}")
 
     # For each widget: 9 keys present, no forbidden keys, title non-empty
     for i, data in enumerate(widgets):
@@ -255,6 +288,24 @@ def main() -> int:
         if "llm_evaluation_prompt" in data:
             errors.append(
                 f"Exercise {i}: llm_evaluation_prompt present (FORBIDDEN by ADR-0008)"
+            )
+
+    # data-language: all-or-none + per-index pairing (AC-1 clauses 2-3)
+    langs = extract_widget_languages(html)
+    if len(langs) != len(widgets):
+        errors.append(
+            f"data-language attrs ({len(langs)}) must equal widget count "
+            f"({len(widgets)}) — every div must carry exactly one (all-or-none)"
+        )
+    for i, lang in enumerate(langs):
+        if lang not in ALLOWED_LANGUAGES:
+            errors.append(
+                f"Exercise {i}: data-language must be 'r' or 'python', got: {lang!r}"
+            )
+        elif i < len(EXPECTED_LANGUAGES) and lang != EXPECTED_LANGUAGES[i]:
+            errors.append(
+                f"Exercise {i}: data-language should be '{EXPECTED_LANGUAGES[i]}' "
+                f"(filter.qmd order), got: {lang!r}"
             )
 
     if errors:


### PR DESCRIPTION
## Summary
`emit_widget()` in `_extensions/blendtutor/blendtutor.lua` now emits `data-language="r|python"` on every `bt-exercise` div. The language was previously dropped at emission, so the runtime fell back to its `"r"` default — wrong editor language on mixed pages.

- `emit_widget(payload, lang)` widens 1→2 params; `Div()` threads the already-validated `lang` (closed set {r, python} via `validate_language`) at the call site. Injection-safe by construction — no re-validation, no payload change.
- `data-language` is the SOLE language carrier: the 9-key JSON payload contract is untouched (no `language` key added).
- `verify_filter_output.py`: attr-tolerant div regex (`<div class="bt-exercise"[^>]*>`) + per-index language assertions `[r, python, r, r]` + all-or-none count (attrs === widgets). Catches hardcoded-"r" fakes.
- `test_quarto_filter.sh`: data-language emission block + static pins (runtime reads `entry.element.dataset.language ||` at exercise-runtime.js:419; verifier has no exact `<div class="bt-exercise">` matcher). Refusal arms (invalid/missing lang → warn + skip, zero bt-exercise) unchanged and pinned.

## Issue
Closes #135

## ACs implemented
- [x] Widgets extract with attr-tolerant regex; ≥4 widgets; 9-key JSON payload contract intact.
- [x] EVERY bt-exercise div carries exactly one data-language="r" or "python"; count === widget count (all-or-none).
- [x] PER-INDEX pairing matches filter.qmd order [r, python, r, r] — idx 1 MUST be python.
- [x] Static pin: exercise-runtime.js still reads `entry.element.dataset.language ||` at :419.
- [x] Static pin: verify_filter_output.py no longer contains exact matcher `<div class="bt-exercise">`.
- [x] Refusal arms unchanged: invalid/missing lang render zero bt-exercise + WARNING, div passthrough.

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested (omit attr → clause 2 red; hardcode r → clause 3 red at idx 1; runtime read removed → static pin; latex leak → harness assertion 14)
- [x] Verification medium satisfied (code)
- [x] Design intent respected (§1-§5)
- [x] No scope creep

## Test plan
- [x] Canonical harness: `bash scripts/tests/test_quarto_filter.sh` → 22 passed, 0 failed
- [x] All quarto-render CI harnesses green (render, filter, pyodide, coi, feedback, ux)
- [x] Rust: cargo fmt --check + clippy -D warnings + nextest 301/301
- [x] E2E evidence: `docs/evidence/135/probe.log` (all 6 predicate clauses) + `docs/evidence/135/test-suite.log`
