### PR TITLE
[feature] Runtime: adapter-map dispatch by data-language + synchronous double-start guard

### DIFF
--- a/_extensions/blendtutor/assets/exercise-feedback.js
+++ b/_extensions/blendtutor/assets/exercise-feedback.js
@@ -667,7 +667,7 @@ export function mountFeedback(entry) {
 }
 
 // Mount feedback UI for every exercise in the registry. Called by the page
-// AFTER start(registry, adapter) boots the runtime — each exercise already has
+// AFTER start(registry, adapters) boots the runtime — each exercise already has
 // its editor + Run button wired by exercise-runtime.js. This adds the feedback
 // button + container per-exercise, using the shared sessionStorage key.
 export function mountAllFeedback(registry) {

--- a/_extensions/blendtutor/assets/exercise-runtime.js
+++ b/_extensions/blendtutor/assets/exercise-runtime.js
@@ -5,6 +5,8 @@
 //        Run button disable/enable, data-status state machine.
 // WHERE: _extensions/blendtutor/assets/exercise-runtime.js
 // NOT:   NOT execution (delegated to adapter), NOT feedback (AC-7), NOT filter (AC-2).
+//        NOT adapter loading (AC-3 bootstrap owns that), NOT language defaulting —
+//        missing data-language exercises are skipped, never defaulted.
 //
 // FORK of lesson-runner-core.js — kills 3 singletons:
 //   1. Module-level `editorView` (line 147) → per-exercise editorView in registry entry.
@@ -43,10 +45,13 @@ import {
 // CM6 extensions (reused from lesson-runner-core.js — identical configuration)
 // ---------------------------------------------------------------------------
 
-// Language extension lookup: closed set keyed by the runtime adapter's
-// `language` field or the div's `data-language` attribute. An unknown
-// language yields no extension (the editor still works, just without syntax
-// highlighting). This is NOT a string match on `runtime.name` (§1.5).
+// Language extension lookup: closed set keyed by the div's `data-language`
+// attribute. An unknown language yields no extension (the editor still works,
+// just without syntax highlighting). This is NOT a string match on
+// `runtime.name` (§1.5). data-language is dual-consumed: it selects the
+// LANG_EXT highlighting here AND the dispatch adapter in start() — a language
+// present in the adapter map but absent from LANG_EXT mounts an editor without
+// highlighting but still executes.
 const LANG_EXT = { r: r(), python: python() };
 
 // Custom HighlightStyle with deterministic `.tok-*` class names. CM6's
@@ -402,30 +407,88 @@ function wireExercise(entry, runtime) {
 }
 
 // ---------------------------------------------------------------------------
-// Main entry point — adapter injection seam (§3.2, §5.1)
+// Main entry point — adapter-map injection seam (§3.2, §5.1)
 // ---------------------------------------------------------------------------
 
+// Double-start guard: set SYNCHRONOUSLY at the top of start(), before the
+// mount loop, window.__btExercises, and any await. Two fire-and-forget
+// start() calls in the same tick therefore see the flag already set — the
+// second call warns and returns without re-mounting or re-booting. A guard
+// set after the first await would let the second call race through (negative
+// case (b) in AC-2).
+let started = false;
+
 /**
- * Boot the multi-exercise runtime. Mounts editors, wires buttons, boots the
- * runtime adapter, and exposes the registry as window.__btExercises.
+ * Boot the multi-exercise runtime. Accepts an adapter MAP keyed by language
+ * string ONLY (single-adapter signature removed). Dispatches each exercise
+ * to the adapter registered for its data-language attribute; exercises with
+ * no data-language or no registered adapter are skipped with a warning —
+ * never defaulted. Boots every usable adapter exactly once via Promise.all.
  *
  * @param {Array} registry — Registry from buildRegistry(scanExercises()).
- * @param {Object} runtime — Runtime adapter { name, language, boot(), run() }.
- * @returns {Promise<Array>} — Resolves to the registry after runtime.boot().
+ * @param {Object} adapters — Map { [language]: { name, language, boot(), run() } }.
+ * @returns {Promise<Array>} — Resolves to the mounted (filtered) registry.
  */
-export async function start(registry, runtime) {
-  // Mount editors and wire exercises
-  for (const entry of registry) {
-    const language = entry.element.dataset.language || runtime.language || "r";
-    mountEditor(entry, language);
-    wireExercise(entry, runtime);
+export async function start(registry, adapters) {
+  // Synchronous guard at entry — BEFORE mount loop, window.__btExercises,
+  // and any await.
+  if (started) {
+    console.warn("[blendtutor] start() called twice — runtime already started, ignoring.");
+    return window.__btExercises || registry;
+  }
+  started = true;
+
+  // Validate the adapter map once (§1.2, §3.4): reject non-function
+  // boot()/run() and map-key ≠ adapter.language entries with console.error
+  // and skip them entirely (no dispatch, no boot).
+  const usable = new Map();
+  for (const [language, adapter] of Object.entries(adapters)) {
+    if (typeof adapter.boot !== "function" || typeof adapter.run !== "function") {
+      console.error(
+        `[blendtutor] Adapter for language "${language}" is missing boot()/run() functions, skipping.`,
+      );
+      continue;
+    }
+    if (adapter.language !== language) {
+      console.error(
+        `[blendtutor] Adapter language mismatch: map key "${language}" but adapter.language is "${adapter.language}", skipping.`,
+      );
+      continue;
+    }
+    usable.set(language, adapter);
   }
 
-  // Expose registry globally (replaces window.__bt singleton)
-  window.__btExercises = registry;
+  // Mount editors and wire exercises — dispatch per data-language. Skipped
+  // exercises stay out of window.__btExercises (never defaulted, never
+  // exposed as mounted).
+  const mounted = [];
+  for (const entry of registry) {
+    const language = entry.element.dataset.language;
+    if (!language) {
+      console.warn(
+        `[blendtutor] Exercise "${entry.id}" has no data-language attribute, skipping (never defaulted).`,
+      );
+      continue;
+    }
+    const adapter = usable.get(language);
+    if (!adapter) {
+      console.warn(
+        `[blendtutor] No adapter registered for language "${language}", skipping exercise "${entry.id}".`,
+      );
+      continue;
+    }
+    mountEditor(entry, language);
+    wireExercise(entry, adapter);
+    mounted.push(entry);
+  }
 
-  // Boot the runtime adapter
-  await runtime.boot();
+  // Expose the mounted registry globally (replaces window.__bt singleton).
+  const exposed = mounted.slice();
+  exposed.get = registry.get;
+  window.__btExercises = exposed;
 
-  return registry;
+  // Boot every usable adapter exactly once, concurrently (§5).
+  await Promise.all([...new Set(usable.values())].map((adapter) => adapter.boot()));
+
+  return exposed;
 }

--- a/docs/adr/0014-per-exercise-byok-feedback.md
+++ b/docs/adr/0014-per-exercise-byok-feedback.md
@@ -52,7 +52,7 @@ shell is rewritten: `currentSubmissionForExercise(entry)` reads from
 `entry.getSubmission()` (the AC-4 registry), `handleSubmitForExercise(entry)`
 renders into `entry.feedbackContainer` (per-exercise), and
 `mountAllFeedback(registry)` is the single entry point the page calls after
-`start(registry, adapter)`.
+`start(registry, { r: adapter })`.
 
 - **No module-level effectful code (§2.1).** The old `applyEmbeddedKey()` bare
   call and submit-button wiring moved into `mountAllFeedback`. Pure functions
@@ -75,9 +75,9 @@ renders into `entry.feedbackContainer` (per-exercise), and
   cost. A future refactor could extract the pure layer into a shared module
   imported by both, but that is out of scope for AC-7 (the extension assets are
   vendored, not shared at runtime — ADR-0010).
-- `mountAllFeedback` must be called AFTER `start(registry, adapter)` resolves,
-  because it reads `entry.element` (populated by mountEditor) and
+- `mountAllFeedback` must be called AFTER `start(registry, { r: adapter })`
+  resolves, because it reads `entry.element` (populated by mountEditor) and
   `entry.getSubmission` (wired by wireExercise). Calling it before boot would
   mount feedback UI on exercises whose editors aren't ready.
 - The `feedback.qmd` fixture demonstrates the wiring: `start(registry,
-  adapter).then(() => mountAllFeedback(registry))`.
+  { r: adapter }).then(() => mountAllFeedback(registry))`.

--- a/docs/evidence/136/probe-report.json
+++ b/docs/evidence/136/probe-report.json
@@ -1,0 +1,79 @@
+{
+  "issue": 136,
+  "branch": "136-adapter-map-dispatch",
+  "worktree": "/Users/carbonite/Documents/coding/portfolio/worktree-issue-136",
+  "timestamp": "2026-08-03T06:36:59.459Z",
+  "probes": [
+    {
+      "name": "clause-1: R Run routes to mockR only",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-1: python Run routes to mockPy only",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-1: two R exercises route to SAME mockR instance",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-2: exactly one double-start console.warn",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-2: each adapter booted exactly once (bootCount === 1)",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-2: no re-mount (.cm-editor count stays 3)",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-2: start() resolves without throw",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-3: attribute-less exercise skipped with warn",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-3: attribute-less exercise absent from window.__btExercises",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-5: every adapter booted exactly once (Promise.all)",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-4: unknown language skipped with warn, others mount, start() resolves",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-4: map key != adapter.language -> console.error + skip that adapter",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-4: non-function boot/run -> console.error + skip",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-4: valid adapters still boot exactly once",
+      "status": "PASS",
+      "details": "assertion passed"
+    }
+  ],
+  "verdict": "PROBES_PASS"
+}

--- a/docs/evidence/136/probe-run.log
+++ b/docs/evidence/136/probe-run.log
@@ -1,0 +1,18 @@
+[PASS] clause-1: R Run routes to mockR only: assertion passed
+[PASS] clause-1: python Run routes to mockPy only: assertion passed
+[PASS] clause-1: two R exercises route to SAME mockR instance: assertion passed
+[PASS] clause-2: exactly one double-start console.warn: assertion passed
+[PASS] clause-2: each adapter booted exactly once (bootCount === 1): assertion passed
+[PASS] clause-2: no re-mount (.cm-editor count stays 3): assertion passed
+[PASS] clause-2: start() resolves without throw: assertion passed
+[PASS] clause-3: attribute-less exercise skipped with warn: assertion passed
+[PASS] clause-3: attribute-less exercise absent from window.__btExercises: assertion passed
+[PASS] clause-5: every adapter booted exactly once (Promise.all): assertion passed
+[PASS] clause-4: unknown language skipped with warn, others mount, start() resolves: assertion passed
+[PASS] clause-4: map key != adapter.language -> console.error + skip that adapter: assertion passed
+[PASS] clause-4: non-function boot/run -> console.error + skip: assertion passed
+[PASS] clause-4: valid adapters still boot exactly once: assertion passed
+
+=== PROBES_PASS ===
+report: /Users/carbonite/Documents/coding/portfolio/worktree-issue-136/docs/evidence/136/probe-report.json
+log:    /Users/carbonite/Documents/coding/portfolio/worktree-issue-136/docs/evidence/136/rodney.log

--- a/docs/evidence/136/rodney.log
+++ b/docs/evidence/136/rodney.log
@@ -1,0 +1,32 @@
+# Rodney probes for issue #136
+verdict: PROBES_PASS
+timestamp: 2026-08-03T06:36:59.459Z
+
+- PASS: clause-1: R Run routes to mockR only
+  assertion passed
+- PASS: clause-1: python Run routes to mockPy only
+  assertion passed
+- PASS: clause-1: two R exercises route to SAME mockR instance
+  assertion passed
+- PASS: clause-2: exactly one double-start console.warn
+  assertion passed
+- PASS: clause-2: each adapter booted exactly once (bootCount === 1)
+  assertion passed
+- PASS: clause-2: no re-mount (.cm-editor count stays 3)
+  assertion passed
+- PASS: clause-2: start() resolves without throw
+  assertion passed
+- PASS: clause-3: attribute-less exercise skipped with warn
+  assertion passed
+- PASS: clause-3: attribute-less exercise absent from window.__btExercises
+  assertion passed
+- PASS: clause-5: every adapter booted exactly once (Promise.all)
+  assertion passed
+- PASS: clause-4: unknown language skipped with warn, others mount, start() resolves
+  assertion passed
+- PASS: clause-4: map key != adapter.language -> console.error + skip that adapter
+  assertion passed
+- PASS: clause-4: non-function boot/run -> console.error + skip
+  assertion passed
+- PASS: clause-4: valid adapters still boot exactly once
+  assertion passed

--- a/docs/evidence/136/test-suite.log
+++ b/docs/evidence/136/test-suite.log
@@ -1,0 +1,190 @@
+
+=== AC-4 Validation Results ===
+Passed: 49
+Failed: 0
+All validations passed.
+
+=== AC-6 Pyodide Adapter Validation Results ===
+Passed: 60
+Failed: 0
+All validations passed.
+
+=== AC-5 webR Adapter Validation Results ===
+Passed: 83
+Failed: 0
+All validations passed.
+=== AC-8 Exercise UX polish — test_quarto_ux.py ===
+
+  PASS: exercise-runtime.js exists
+  PASS: ux.qmd exists
+-- ux.qmd structure --
+  PASS: ux.qmd has 3 exercises (>=3 for UX polish test)
+  PASS: ux.qmd has a .solution code block (solution reveal test)
+  PASS: ux.qmd has a hints div (hints toggle test)
+  PASS: ux.qmd has .checks code block (check button test)
+  PASS: ux.qmd imports exercise-runtime.js
+
+-- Clause 1: hints visible/absent --
+  PASS: hints <details> toggle present in exercise-runtime.js
+  PASS: hints rendering is conditional on payload.hints
+
+-- Clause 2: solution button click inserts text --
+  PASS: solution rendering references payload.solution
+  PASS: solution button creation present in exercise-runtime.js
+  PASS: solution button calls setEditorContent
+
+-- Clause 3: check button absent when no checks --
+  PASS: check button creation is conditional on checks length
+  PASS: check button referenced in exercise-runtime.js
+
+-- Clause 4: Run disables ex-0 only (per-exercise) --
+  PASS: per-exercise Run button reference found
+  PASS: button disable/enable mechanism present
+  PASS: no singleton getElementById('run') — per-exercise Run button
+
+-- Clause 5: cursor=not-allowed --
+  PASS: cursor: not-allowed present in styles.css
+  PASS: disabled button selector present in styles.css
+
+-- Clause 6: data-status closed set --
+  PASS: data-status closed set referenced (4/4 values found)
+  PASS: data-status attribute mechanism present
+  PASS: data-status="idle" selector present in styles.css
+  PASS: data-status="running" selector present in styles.css
+  PASS: data-status="pass" selector present in styles.css
+  PASS: data-status="fail" selector present in styles.css
+
+-- Clause 7: buttons re-enabled on pass --
+  PASS: button re-enable mechanism present (disabled = false or finally)
+
+-- Regression: Check/Solution disabled during run --
+  PASS: entry.checkBtn ref stored for runSubmission access
+  PASS: entry.solutionBtn ref stored for runSubmission access
+  PASS: Check button disabled during runSubmission
+  PASS: Solution button disabled during runSubmission
+  PASS: Check button re-enabled after runSubmission
+  PASS: Solution button re-enabled after runSubmission
+
+-- CSS: hints + solution styling --
+  PASS: hints styling present in styles.css
+  PASS: solution button styling present in styles.css
+
+-- Rendered HTML: styles.css <link> injection --
+  PASS: styles.css <link> present in rendered HTML (project-relative href)
+
+-- Rendered HTML: coi script src project-relative (issue #129) --
+  PASS: coi script src present in rendered HTML (project-relative src)
+
+-- Asset URLs project-relative + resolvable (issue #129 clauses 4-5) --
+  PASS: asset URL project-relative: ../_extensions/blendtutor/assets/coi-serviceworker.js
+  PASS: asset URL resolves to file on disk: ../_extensions/blendtutor/assets/coi-serviceworker.js
+  PASS: asset URL project-relative: ../_extensions/blendtutor/assets/styles.css
+  PASS: asset URL resolves to file on disk: ../_extensions/blendtutor/assets/styles.css
+
+-- Installed layout: org/repo install path (issue #129 clause 3) --
+  PASS: installed layout — href uses org/repo install path
+  PASS: installed layout — no hardcoded _extensions/blendtutor/ href
+
+-- By-name install: absolute script path -> project-relative (issue #129) --
+  PASS: by-name install — absolute PANDOC_SCRIPT_FILE converted to project-relative href
+  PASS: by-name install — href passes project-relative guard: _extensions/mcmullarkey/blendtutor/assets/styles.css
+
+-- Source grep zero: no hardcoded _extensions/blendtutor/ (issue #129 clause 6) --
+  PASS: source grep zero — no literal "_extensions/blendtutor/" in blendtutor.lua
+
+-- Behavioral checks (Node.js) --
+  PASS: scanExercises exported
+  PASS: buildRegistry exported
+  PASS: start exported
+  PASS: parsePayload exported
+  PASS: Node.js behavioral tests passed (exports verified)
+
+=== Results: 46 passed, 0 failed ===
+=== AC-7 Per-exercise BYOK LLM feedback — test_quarto_feedback.py ===
+
+  PASS: exercise-feedback.js exists
+  PASS: feedback.qmd exists
+-- Clause 6: llm_evaluation_prompt ABSENT --
+  PASS: llm_evaluation_prompt ABSENT from exercise-feedback.js
+  PASS: llm_evaluation_prompt ABSENT from feedback.qmd
+
+-- Source-pattern checks --
+  PASS: pure function exported: neutralize
+  PASS: pure function exported: buildPrompt
+  PASS: pure function exported: parseModels
+  PASS: pure function exported: modelRoster
+  PASS: pure function exported: feedbackRequest
+  PASS: pure function exported: toVerdict
+  PASS: pure function exported: fireworksRequest
+  PASS: pure function exported: fireworksToVerdict
+  PASS: pure function exported: providerBaseUrl
+  PASS: STUDENT_CODE fences present in source
+  PASS: PROVIDERS map has fireworks + anthropic
+  PASS: provider-scoped key slots present (fireworks_api_key, anthropic_api_key)
+  PASS: key slot is provider-scoped (not exercise-scoped)
+  PASS: storeKey + readKey present (shared key handling)
+  PASS: no singleton getElementById('feedback') — per-exercise scoping
+  PASS: no window.__bt singleton access (uses __btExercises registry)
+  PASS: ?provider= override parsed via URLSearchParams
+  PASS: localhost-only gate present (non-local override rejected)
+  PASS: per-exercise concurrent feedback guard present
+  PASS: mountFeedback/mountAllFeedback present (per-exercise mount)
+  PASS: feedback UI elements carry data-byok/data-feedback markers
+  PASS: fetch() called in backends (feedback is not silently skipped)
+  PASS: no module-level applyEmbeddedKey() call (pure layer importable)
+
+-- Behavioral checks (Node.js) --
+  PASS: buildPrompt emits STUDENT_CODE_BEGIN fence
+  PASS: buildPrompt emits STUDENT_CODE_END fence
+  PASS: buildPrompt includes task
+  PASS: buildPrompt includes student code
+  PASS: buildPrompt includes captured output
+  PASS: buildPrompt includes checks
+  PASS: neutralize strips forged STUDENT_CODE_BEGIN
+  PASS: neutralize replaces with marker
+  PASS: key reused from shared sessionStorage slot (entered once)
+  PASS: provider switched to anthropic
+  PASS: provider switched back to fireworks
+  PASS: localhost override honored
+  PASS: non-local override rejected (key exfil prevented)
+  PASS: non-local override falls back to provider base URL
+  PASS: credentialed override rejected
+  PASS: parseModels extracts model ids
+  PASS: modelRoster falls back when list empty
+  PASS: feedbackRequest embeds prompt in messages
+  PASS: feedbackRequest forces feedback tool
+  PASS: toVerdict maps Anthropic tool call to Verdict
+  PASS: fireworksToVerdict maps OpenAI tool call to Verdict
+  PASS: Node.js behavioral tests passed (all pure-function assertions)
+
+-- feedback.qmd structure --
+  PASS: feedback.qmd has 2 exercises (>=2 for key-reuse test)
+  PASS: feedback.qmd imports exercise-feedback.js
+  PASS: feedback.qmd imports exercise-runtime.js (AC-4 dependency)
+  PASS: feedback.qmd calls mountFeedback/mountAllFeedback
+
+=== Results: 32 passed, 0 failed ===
+
+=== Regression summary (this session, issue #136 branch) ===
+# validate-runtime.js: 49 passed, 0 failed
+# validate-pyodide-adapter.js: 60 passed, 0 failed
+# validate-webr-adapter.js: 83 passed, 0 failed
+# test_quarto_ux.py: 46 passed, 0 failed
+# test_quarto_feedback.py: 32 passed, 0 failed
+# test_pyodide_adapter.sh: 11 passed, 0 failed
+# test_quarto_render.sh: 12 passed, 0 failed
+# test_quarto_filter.sh: 17 passed, 0 failed
+# test_coi_filter.sh: 15 passed, 0 failed
+# test_sync_assets.sh: 12 passed, 0 failed
+# test_quarto_distribution.sh: 31 passed, 0 failed
+# test_quarto_install_render.sh: 13 passed, 0 failed
+# rodney exercise-ux.js (AC-1 output simulated on rendered ux.html): 7 clauses PASS
+# rodney feedback-probe.js (AC-1 output simulated on rendered feedback.html): 13 clauses PASS
+# rodney mixed-runtime.js (this issue): 14 assertions PASS, verdict PROBES_PASS
+
+NOTE (merge coupling): existing rodney probes exercise-ux.js + feedback-probe.js
+fail on this branch WITHOUT the AC-1 filter change (blendtutor.lua does not yet
+emit data-language; pre-AC-1 HTML has no data-language -> skipped, never
+defaulted). Verified they pass when the AC-1 output shape is simulated
+(data-language="r" on rendered exercise divs). Director manages the AC-1+AC-2
+same-batch merge (issue #135 + #136).

--- a/quarto-fixture/feedback.qmd
+++ b/quarto-fixture/feedback.qmd
@@ -42,7 +42,7 @@ stopifnot(add(1, 2) == 3)
   });
   const registry = buildRegistry(scanExercises());
   window.__btWebRAdapter = adapter;
-  start(registry, adapter).then(() => {
+  start(registry, { r: adapter }).then(() => {
     // Mount per-exercise feedback AFTER the runtime boots — each exercise
     // gets its own feedback button + container. The key is shared via
     // sessionStorage: entered once on exercise 1, reused on exercise 2.

--- a/quarto-fixture/ux.qmd
+++ b/quarto-fixture/ux.qmd
@@ -51,5 +51,5 @@ Write any R expression below.
   const adapter = createMockAdapter();
   const registry = buildRegistry(scanExercises());
   window.__btTestAdapter = adapter;
-  start(registry, adapter);
+  start(registry, { r: adapter });
 </script>

--- a/quarto-fixture/webr.qmd
+++ b/quarto-fixture/webr.qmd
@@ -35,5 +35,5 @@ print(exists("x"))
   });
   const registry = buildRegistry(scanExercises());
   window.__btWebRAdapter = adapter;
-  start(registry, adapter);
+  start(registry, { r: adapter });
 </script>

--- a/rodney-probes/feedback-probe.js
+++ b/rodney-probes/feedback-probe.js
@@ -202,7 +202,7 @@ function generateProbeHtml() {
   };
   const registry = buildRegistry(scanExercises());
   window.__btWebRAdapter = mockAdapter;
-  start(registry, mockAdapter).then(() => mountAllFeedback(registry));
+  start(registry, { r: mockAdapter }).then(() => mountAllFeedback(registry));
 </script>`;
   const out = src.replace(/<script type="module">[\s\S]*?<\/script>/, mockScript);
   fs.writeFileSync(

--- a/rodney-probes/mixed-runtime.js
+++ b/rodney-probes/mixed-runtime.js
@@ -1,0 +1,390 @@
+#!/usr/bin/env node
+/**
+ * Rodney probe harness for issue #136 — AC-2 adapter-map dispatch.
+ *
+ * Verifies the 6-clause predicate from AC-2 against tests/fixtures/mixed-runtime.html
+ * (plus a harness-generated map-validation page for clause 4) in a headless
+ * browser driven by uvx rodney. The fixture calls start() twice unawaited
+ * (race probe), spies console.warn/error BEFORE start, and exposes both mocks
+ * on window so the probe can assert calls/bootCount/warns.
+ *
+ * Assertions (from AC-2 spec):
+ *   1. routing — R Run → mockR.calls grows, mockPy unchanged; python Run →
+ *      mockPy grows, mockR unchanged; two R exercises route to SAME mockR.
+ *   2. double-start guard — module-level flag set SYNCHRONOUSLY at entry;
+ *      two fire-and-forget start() calls → each adapter bootCount === 1,
+ *      exactly one console.warn matching /called twice|already started/,
+ *      no re-mount (.cm-editor count stays 3), resolves without throw.
+ *   3. fallback removal — attribute-less exercise SKIPPED with warn, absent
+ *      from window.__btExercises.
+ *   4. map validation — unknown language → skip + warn, others mount, start()
+ *      resolves; map key ≠ adapter.language → console.error + skip; non-function
+ *      boot/run → console.error + skip.
+ *   5. boot — every adapter gets exactly one boot() via Promise.all.
+ *   6. (source greps — validated in scripts/tests/validate-runtime.js)
+ *
+ * Usage:
+ *   uv run node rodney-probes/mixed-runtime.js
+ *
+ * Environment:
+ *   STATIC_PORT - port for static fixture server (default: 8084)
+ */
+
+const { execFileSync, spawn } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const WORKTREE = path.resolve(__dirname, "..");
+const EVIDENCE_DIR = path.join(WORKTREE, "docs", "evidence", "136");
+const STATIC_PORT = parseInt(process.env.STATIC_PORT || "8084", 10);
+
+const BASE_URL = `http://localhost:${STATIC_PORT}`;
+const BLANK_URL = `${BASE_URL}/quarto-fixture/_probe-blank.html`;
+const MIXED_URL = `${BASE_URL}/tests/fixtures/mixed-runtime.html`;
+const VALIDATION_URL = `${BASE_URL}/quarto-fixture/_mixed-validation.html`;
+
+const STATIC_SERVER_PY = `#!/usr/bin/env python3
+import http.server, socketserver, sys
+PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 8084
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, fmt, *args): pass
+socketserver.ThreadingTCPServer.allow_reuse_address = True
+with socketserver.ThreadingTCPServer(("", PORT), Handler) as httpd:
+    print(f"static server on port {PORT}", flush=True)
+    httpd.serve_forever()
+`;
+
+const servers = [];
+let rodneyStarted = false;
+const probeLog = [];
+
+function sleep(seconds) {
+  if (seconds > 0) {
+    execFileSync("sleep", [String(seconds)]);
+  }
+}
+
+function writeTempScript(name, code) {
+  const file = path.join(os.tmpdir(), `mixed-runtime-${name}.py`);
+  fs.writeFileSync(file, code);
+  return file;
+}
+
+function waitForPort(port, timeoutSeconds = 10) {
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  while (Date.now() < deadline) {
+    try {
+      execFileSync("curl", ["-s", "-o", "/dev/null", `http://localhost:${port}/`], {
+        timeout: 500,
+      });
+      return true;
+    } catch (_) {
+      sleep(0.2);
+    }
+  }
+  return false;
+}
+
+function startServer() {
+  const script = writeTempScript("serve", STATIC_SERVER_PY);
+  const proc = spawn("python3", [script, String(STATIC_PORT)], {
+    cwd: WORKTREE,
+    detached: true,
+    stdio: "ignore",
+  });
+  proc.unref();
+  servers.push(proc);
+  if (!waitForPort(STATIC_PORT)) {
+    throw new Error(`Static server did not start on port ${STATIC_PORT}`);
+  }
+}
+
+function stopServers() {
+  for (const proc of servers) {
+    try {
+      process.kill(-proc.pid, "SIGTERM");
+    } catch (_) {}
+  }
+}
+
+function rodney(args) {
+  const out = execFileSync("uvx", ["rodney", ...args], {
+    cwd: WORKTREE,
+    encoding: "utf8",
+    timeout: 60000,
+  });
+  return out.trim();
+}
+
+function record(name, passed, details) {
+  const status = passed ? "PASS" : "FAIL";
+  probeLog.push({ name, status, details });
+  console.log(`[${status}] ${name}: ${details}`);
+}
+
+function rodneyJs(code) {
+  return rodney(["js", code]);
+}
+
+function rodneyAssert(name, expr) {
+  // Evaluate a boolean expression via `rodney js` and record the result.
+  const wrapped = `(() => { ${expr}; })()`;
+  let raw;
+  try {
+    raw = rodneyJs(wrapped);
+  } catch (err) {
+    record(name, false, err.stderr || err.message || "rodney js failed");
+    return;
+  }
+  const passed = raw === "true";
+  record(name, passed, passed ? "assertion passed" : `assertion returned: ${raw}`);
+}
+
+function generateBlankPage() {
+  fs.writeFileSync(
+    path.join(WORKTREE, "quarto-fixture", "_probe-blank.html"),
+    "<!DOCTYPE html><html><body></body></html>",
+  );
+}
+
+function generateValidationPage() {
+  // Clause-4 page: exercises in languages r, python, julia (unknown),
+  // bad (map key ≠ adapter.language), broken (non-function boot/run).
+  // Written to a gitignored path (quarto-fixture/*.html) so it is never
+  // committed — the committed fixture stays exactly as spec'd (4 exercises).
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AC-2 Map Validation Fixture (generated)</title>
+</head>
+<body>
+  <div class="bt-exercise" data-language="r"><script type="application/json">{"id":"val-0","title":"R","code_template":"x <- 1","checks":[],"packages":[],"solution":null,"hints":null,"gotchas":null}</script></div>
+  <div class="bt-exercise" data-language="python"><script type="application/json">{"id":"val-1","title":"Python","code_template":"print(1)","checks":[],"packages":[],"solution":null,"hints":null,"gotchas":null}</script></div>
+  <div class="bt-exercise" data-language="julia"><script type="application/json">{"id":"val-2","title":"Unknown lang","code_template":"x = 1","checks":[],"packages":[],"solution":null,"hints":null,"gotchas":null}</script></div>
+  <div class="bt-exercise" data-language="bad"><script type="application/json">{"id":"val-3","title":"Mismatched map key","code_template":"x = 1","checks":[],"packages":[],"solution":null,"hints":null,"gotchas":null}</script></div>
+  <div class="bt-exercise" data-language="broken"><script type="application/json">{"id":"val-4","title":"Non-function adapter","code_template":"x = 1","checks":[],"packages":[],"solution":null,"hints":null,"gotchas":null}</script></div>
+  <script type="module">
+    import { scanExercises, buildRegistry, start } from "../_extensions/blendtutor/assets/exercise-runtime.js";
+    import { createMockAdapter } from "../tests/fixtures/mock-adapter.js";
+
+    window.__btValWarns = [];
+    window.__btValErrors = [];
+    const origWarn = console.warn.bind(console);
+    const origError = console.error.bind(console);
+    console.warn = (...args) => {
+      window.__btValWarns.push(args.map(String).join(" "));
+      origWarn(...args);
+    };
+    console.error = (...args) => {
+      window.__btValErrors.push(args.map(String).join(" "));
+      origError(...args);
+    };
+
+    const mockR = createMockAdapter({ name: "mockR", language: "r" });
+    const mockPy = createMockAdapter({ name: "mockPy", language: "python" });
+    // Map key "bad" ≠ adapter.language ("r") — must be rejected with console.error.
+    const mismatch = createMockAdapter({ name: "mismatch", language: "r" });
+    // Non-function boot/run — must be rejected with console.error.
+    const broken = { language: "broken", boot: 42, run: 42 };
+    window.__btValMocks = { r: mockR, python: mockPy, mismatch, broken };
+
+    const registry = buildRegistry(scanExercises());
+    window.__btValResolved = false;
+    start(registry, { r: mockR, python: mockPy, bad: mismatch, broken }).then(() => {
+      window.__btValResolved = true;
+    });
+  </script>
+</body>
+</html>
+`;
+  fs.writeFileSync(
+    path.join(WORKTREE, "quarto-fixture", "_mixed-validation.html"),
+    html,
+  );
+}
+
+function navigateToFixture(url) {
+  rodney(["open", BLANK_URL]);
+  rodneyJs(`window.location.href = '${url}'`);
+  sleep(3);
+}
+
+function waitForExpr(expr, timeoutSeconds = 20) {
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  while (Date.now() < deadline) {
+    try {
+      const raw = rodneyJs(expr);
+      if (raw === "true") return true;
+    } catch (_) {}
+    sleep(0.2);
+  }
+  return false;
+}
+
+function clickRun(exerciseIndex) {
+  rodneyJs(
+    `document.querySelectorAll('.bt-exercise')[${exerciseIndex}].querySelector('.bt-run-btn').click()`,
+  );
+}
+
+function runProbes() {
+  // ------------------------------------------------------------------
+  // Boot
+  // ------------------------------------------------------------------
+  rodney(["start"]);
+  rodneyStarted = true;
+
+  // ------------------------------------------------------------------
+  // Primary page: clauses 1, 2, 3, 5 (mixed-runtime.html)
+  // ------------------------------------------------------------------
+  navigateToFixture(MIXED_URL);
+  if (!waitForExpr("window.__btExercises !== undefined && window.__btStartResolved === true")) {
+    throw new Error("Runtime did not boot or registry was not populated");
+  }
+
+  // Clause 1: routing
+  clickRun(0); // R exercise 0
+  if (!waitForExpr("window.__btMocks.r.calls.length === 1")) {
+    throw new Error("mockR.calls did not grow after Run on R exercise 0");
+  }
+  rodneyAssert(
+    "clause-1: R Run routes to mockR only",
+    "return window.__btMocks.r.calls.length === 1 && window.__btMocks.python.calls.length === 0",
+  );
+
+  clickRun(1); // python exercise 1
+  if (!waitForExpr("window.__btMocks.python.calls.length === 1")) {
+    throw new Error("mockPy.calls did not grow after Run on python exercise 1");
+  }
+  rodneyAssert(
+    "clause-1: python Run routes to mockPy only",
+    "return window.__btMocks.python.calls.length === 1 && window.__btMocks.r.calls.length === 1",
+  );
+
+  clickRun(2); // R exercise 2
+  if (!waitForExpr("window.__btMocks.r.calls.length === 2")) {
+    throw new Error("mockR.calls did not grow after Run on R exercise 2");
+  }
+  rodneyAssert(
+    "clause-1: two R exercises route to SAME mockR instance",
+    "return window.__btMocks.r.calls.length === 2 && window.__btMocks.python.calls.length === 1",
+  );
+
+  // Clause 2: double-start guard
+  rodneyAssert(
+    "clause-2: exactly one double-start console.warn",
+    "return window.__btWarns.filter(w => /called twice|already started/.test(w)).length === 1",
+  );
+  rodneyAssert(
+    "clause-2: each adapter booted exactly once (bootCount === 1)",
+    "return window.__btMocks.r.bootCount === 1 && window.__btMocks.python.bootCount === 1",
+  );
+  rodneyAssert(
+    "clause-2: no re-mount (.cm-editor count stays 3)",
+    "return document.querySelectorAll('.cm-editor').length === 3",
+  );
+  rodneyAssert(
+    "clause-2: start() resolves without throw",
+    "return window.__btStartResolved === true",
+  );
+
+  // Clause 3: fallback removal
+  rodneyAssert(
+    "clause-3: attribute-less exercise skipped with warn",
+    "return window.__btWarns.some(w => /data-language/.test(w))",
+  );
+  rodneyAssert(
+    "clause-3: attribute-less exercise absent from window.__btExercises",
+    "return window.__btExercises.length === 3 && !window.__btExercises.some(e => e.id === 'bt-exercise-3')",
+  );
+
+  // Clause 5: boot via Promise.all (every adapter booted exactly once)
+  rodneyAssert(
+    "clause-5: every adapter booted exactly once (Promise.all)",
+    "return window.__btMocks.r.bootCount === 1 && window.__btMocks.python.bootCount === 1",
+  );
+
+  // ------------------------------------------------------------------
+  // Validation page: clause 4 (map validation)
+  // ------------------------------------------------------------------
+  navigateToFixture(VALIDATION_URL);
+  if (!waitForExpr("window.__btValResolved === true")) {
+    throw new Error("Validation page start() did not resolve");
+  }
+
+  rodneyAssert(
+    "clause-4: unknown language skipped with warn, others mount, start() resolves",
+    "return document.querySelectorAll('.cm-editor').length === 2 && " +
+      "window.__btValWarns.some(w => /julia/.test(w)) && window.__btValResolved === true",
+  );
+  rodneyAssert(
+    "clause-4: map key != adapter.language -> console.error + skip that adapter",
+    "return window.__btValErrors.some(e => /mismatch/.test(e)) && window.__btValMocks.mismatch.bootCount === 0",
+  );
+  rodneyAssert(
+    "clause-4: non-function boot/run -> console.error + skip",
+    "return window.__btValErrors.some(e => /boot/.test(e))",
+  );
+  rodneyAssert(
+    "clause-4: valid adapters still boot exactly once",
+    "return window.__btValMocks.r.bootCount === 1 && window.__btValMocks.python.bootCount === 1",
+  );
+}
+
+function writeReport() {
+  fs.mkdirSync(EVIDENCE_DIR, { recursive: true });
+  const failed = probeLog.filter((p) => p.status === "FAIL");
+  const verdict = failed.length === 0 ? "PROBES_PASS" : "PROBES_FAIL";
+
+  const report = {
+    issue: 136,
+    branch: "136-adapter-map-dispatch",
+    worktree: WORKTREE,
+    timestamp: new Date().toISOString(),
+    probes: probeLog,
+    verdict,
+  };
+
+  fs.writeFileSync(
+    path.join(EVIDENCE_DIR, "probe-report.json"),
+    JSON.stringify(report, null, 2),
+  );
+
+  const lines = [
+    `# Rodney probes for issue #136`,
+    `verdict: ${verdict}`,
+    `timestamp: ${report.timestamp}`,
+    "",
+    ...probeLog.map((p) => `- ${p.status}: ${p.name}\n  ${p.details}`),
+  ];
+  fs.writeFileSync(path.join(EVIDENCE_DIR, "rodney.log"), lines.join("\n"));
+
+  console.log(`\n=== ${verdict} ===`);
+  console.log(`report: ${path.join(EVIDENCE_DIR, "probe-report.json")}`);
+  console.log(`log:    ${path.join(EVIDENCE_DIR, "rodney.log")}`);
+}
+
+function main() {
+  try {
+    generateBlankPage();
+    generateValidationPage();
+    startServer();
+    runProbes();
+  } catch (err) {
+    console.error("Probe harness failed:", err.message);
+    record("harness", false, err.message);
+  } finally {
+    if (rodneyStarted) {
+      try {
+        rodney(["stop"]);
+      } catch (_) {}
+    }
+    stopServers();
+    writeReport();
+  }
+}
+
+main();

--- a/rodney-probes/pyodide-adapter.js
+++ b/rodney-probes/pyodide-adapter.js
@@ -7,7 +7,7 @@
 // Rodney executes this script in a browser context after loading
 // tests/fixtures/pyodide.html which imports pyodide-adapter.js, creates
 // the adapter, sets window.__btPyodideAdapter = adapter, and calls
-// exercise-runtime.js start(registry, adapter). The script waits for
+// exercise-runtime.js start(registry, { python: adapter }). The script waits for
 // Pyodide to boot, then runs assertions.
 //
 // FIX (vacuous-pass vulnerability): The probe MUST assert

--- a/scripts/tests/runtime-probe.js
+++ b/scripts/tests/runtime-probe.js
@@ -20,7 +20,7 @@
 //   10. mock not leaked (window.__bt undefined)
 //   11. no global #submission
 //   12. concurrent run safety
-//   13. adapter injection seam (start(registry, runtime) signature)
+//   13. adapter injection seam (start(registry, adapters) map signature)
 
 async function waitFor(condFn, timeoutMs = 5000) {
   const start = Date.now();
@@ -103,20 +103,26 @@ async function runProbe() {
   });
 
   // 6. per-exercise Check sends correct checks
+  //    AC-2 (issue #136): dispatch is per-language via the adapter map, so
+  //    exercise 0 (R) routes to window.__btTestAdapter and exercise 1
+  //    (python) routes to window.__btTestAdapterPy.
   await asyncTest("6. per-exercise Check sends correct checks", async () => {
     const adapter = window.__btTestAdapter;
+    const adapterPy = window.__btTestAdapterPy;
     const callsBefore = adapter.calls.length;
     // Run exercise 0 (R with 2 checks)
     await reg[0].runSubmission();
     const callsAfter0 = adapter.calls.length;
-    assert(callsAfter0 === callsBefore + 1, "exercise 0 run did not call adapter");
+    assert(callsAfter0 === callsBefore + 1, "exercise 0 run did not call R adapter");
     const lastCall0 = adapter.calls[adapter.calls.length - 1];
     assert(lastCall0.checks.length === 2, `exercise 0 should send 2 checks, got ${lastCall0.checks.length}`);
     assert(lastCall0.checks[0] === "stopifnot(add(1, 2) == 3)", "exercise 0 check[0] mismatch");
 
-    // Run exercise 1 (Python with 1 check)
+    // Run exercise 1 (Python with 1 check) — routed to the python mock
+    const pyCallsBefore = adapterPy.calls.length;
     await reg[1].runSubmission();
-    const lastCall1 = adapter.calls[adapter.calls.length - 1];
+    assert(adapterPy.calls.length === pyCallsBefore + 1, "exercise 1 run did not call python adapter");
+    const lastCall1 = adapterPy.calls[adapterPy.calls.length - 1];
     assert(lastCall1.checks.length === 1, `exercise 1 should send 1 check, got ${lastCall1.checks.length}`);
     assert(lastCall1.packages.includes("numpy"), "exercise 1 should send numpy package");
   });
@@ -146,19 +152,22 @@ async function runProbe() {
     assert(sub1.includes("print"), `exercise 1 submission should contain 'print', got: ${sub1}`);
   });
 
-  // 9. per-exercise run isolation
+  // 9. per-exercise run isolation (AC-2: dispatch is per-language, so each
+  //    exercise's run lands on ITS language's adapter)
   await asyncTest("9. per-exercise run isolation", async () => {
     const adapter = window.__btTestAdapter;
+    const adapterPy = window.__btTestAdapterPy;
     const callsBefore = adapter.calls.length;
-    // Run exercise 0
+    const pyCallsBefore = adapterPy.calls.length;
+    // Run exercise 0 (R)
     await reg[0].runSubmission();
-    // Run exercise 1
+    // Run exercise 1 (python)
     await reg[1].runSubmission();
-    const callsAfter = adapter.calls.length;
-    assert(callsAfter === callsBefore + 2, "running 2 exercises should produce 2 adapter calls");
-    // Verify each call used the correct exercise's code
+    assert(adapter.calls.length === callsBefore + 1, "exercise 0 should produce 1 R-adapter call");
+    assert(adapterPy.calls.length === pyCallsBefore + 1, "exercise 1 should produce 1 python-adapter call");
+    // Verify each call used the correct exercise's code on the right adapter
     const call0 = adapter.calls[callsBefore];
-    const call1 = adapter.calls[callsBefore + 1];
+    const call1 = adapterPy.calls[pyCallsBefore];
     assert(call0.code.includes("add"), "exercise 0 run used wrong code");
     assert(call1.code.includes("print"), "exercise 1 run used wrong code");
   });
@@ -187,13 +196,16 @@ async function runProbe() {
     assert(callsAfter === callsBefore + 1, `concurrent run should produce 1 call, got ${callsAfter - callsBefore}`);
   });
 
-  // 13. adapter injection seam (start(registry, runtime) signature)
+  // 13. adapter injection seam (start(registry, adapters) map signature)
   test("13. adapter injection seam", () => {
-    // Verify the mock adapter was injected and is accessible
+    // Verify the mock adapters were injected and are accessible
     assert(window.__btTestAdapter !== undefined, "mock adapter not accessible");
     assert(window.__btTestAdapter.name === "mock", "mock adapter name mismatch");
-    // Verify registry entries use the injected adapter (calls were recorded)
-    assert(window.__btTestAdapter.calls.length > 0, "adapter was never called — injection seam broken");
+    assert(window.__btTestAdapterPy !== undefined, "python mock adapter not accessible");
+    assert(window.__btTestAdapterPy.name === "mockPy", "python mock adapter name mismatch");
+    // Verify registry entries use the injected adapters (calls were recorded)
+    assert(window.__btTestAdapter.calls.length > 0, "R adapter was never called — injection seam broken");
+    assert(window.__btTestAdapterPy.calls.length > 0, "python adapter was never called — injection seam broken");
   });
 
   return results;

--- a/scripts/tests/validate-pyodide-adapter.js
+++ b/scripts/tests/validate-pyodide-adapter.js
@@ -263,8 +263,8 @@ assert(
   "fixture imports pyodideAdapter from pyodide-adapter.js",
 );
 assert(
-  fixtureSrc.includes("start(registry, pyodideAdapter)"),
-  "fixture calls start(registry, pyodideAdapter)",
+  fixtureSrc.includes("start(registry, { python: pyodideAdapter })"),
+  "fixture calls start(registry, { python: pyodideAdapter })",
 );
 
 // ---------------------------------------------------------------------------

--- a/scripts/tests/validate-runtime.js
+++ b/scripts/tests/validate-runtime.js
@@ -75,6 +75,35 @@ validateHtmlFixture(
   "runtime-edge.html",
 );
 
+// AC-2 mixed-runtime fixture: 4 exercises but only 3 data-language attrs
+// (the 4th is intentionally attribute-less — the skip/never-default case).
+const mixedHtml = readFileSync(
+  join(repoRoot, "tests", "fixtures", "mixed-runtime.html"),
+  "utf-8",
+);
+const mixedExercises = (mixedHtml.match(/class="bt-exercise"/g) || []).length;
+assert(
+  mixedExercises === 4,
+  `mixed-runtime.html: expected 4 bt-exercise divs, got ${mixedExercises}`,
+);
+const mixedDataLang = (mixedHtml.match(/data-language="/g) || []).length;
+assert(
+  mixedDataLang === 3,
+  `mixed-runtime.html: expected 3 data-language attrs (1 attribute-less), got ${mixedDataLang}`,
+);
+assert(
+  mixedHtml.includes("start(registry, { r: mockR, python: mockPy })"),
+  "mixed-runtime.html calls start() with the adapter map (twice — race probe)",
+);
+assert(
+  (mixedHtml.match(/start\(registry, \{ r: mockR, python: mockPy \}\)/g) || []).length === 2,
+  "mixed-runtime.html must call start() twice unawaited (double-start race probe)",
+);
+
+// AC-2 rodney probe exists and covers the mixed fixture
+const mixedProbePath = join(repoRoot, "rodney-probes", "mixed-runtime.js");
+assert(existsSync(mixedProbePath), "rodney-probes/mixed-runtime.js exists");
+
 // ---------------------------------------------------------------------------
 // 3. Module exports validation (grep the source for export statements)
 // ---------------------------------------------------------------------------
@@ -93,8 +122,43 @@ assert(!runtimeSrc.match(/^let editorView\s*=/m), "exercise-runtime.js must NOT 
 assert(runtimeSrc.includes("window.__btExercises"), "exercise-runtime.js must set window.__btExercises");
 assert(runtimeSrc.includes("registry.get ="), "exercise-runtime.js must define registry.get(id)");
 
-// Verify adapter injection seam
-assert(runtimeSrc.includes("start(registry, runtime)"), "exercise-runtime.js must have start(registry, runtime) signature");
+// Verify adapter injection seam (AC-2: start(registry, adapters) map signature)
+assert(runtimeSrc.includes("start(registry, adapters)"), "exercise-runtime.js must have start(registry, adapters) signature");
+
+// Verify AC-2 clause-6 source greps:
+//   - the `|| runtime.language || "r"` fallback is gone (never default)
+//   - the double-start guard flag is set SYNCHRONOUSLY at entry, before the
+//     mount loop, window.__btExercises, and the boot await
+//   - no static import of webr-adapter/pyodide-adapter (adapter-agnostic)
+assert(
+  !runtimeSrc.includes('runtime.language || "r"'),
+  "exercise-runtime.js must NOT default language via || runtime.language || \"r\"",
+);
+const guardIdx = runtimeSrc.indexOf("started = true");
+assert(guardIdx !== -1, "exercise-runtime.js must have a module-level double-start guard flag");
+const mountLoopIdx = runtimeSrc.indexOf("for (const entry of registry)");
+const exercisesIdx = runtimeSrc.indexOf("window.__btExercises =");
+const bootIdx = runtimeSrc.indexOf("await Promise.all");
+assert(
+  guardIdx < mountLoopIdx,
+  "guard assignment must precede the mount loop (synchronous at entry)",
+);
+assert(
+  guardIdx < exercisesIdx,
+  "guard assignment must precede window.__btExercises assignment",
+);
+assert(
+  guardIdx < bootIdx,
+  "guard assignment must precede the boot await (Promise.all)",
+);
+assert(
+  !/import\s+[\s\S]*?webr-adapter\.js/.test(runtimeSrc),
+  "exercise-runtime.js must NOT statically import webr-adapter",
+);
+assert(
+  !/import\s+[\s\S]*?pyodide-adapter\.js/.test(runtimeSrc),
+  "exercise-runtime.js must NOT statically import pyodide-adapter",
+);
 
 // Verify per-exercise degradation
 assert(runtimeSrc.includes("data-cm-fail"), "exercise-runtime.js must check data-cm-fail for graceful degradation");
@@ -122,7 +186,9 @@ assert(edgeAssertions >= 3, `runtime-edge-probe.js should have >=3 assertions, f
 // ---------------------------------------------------------------------------
 const mockSrc = readFileSync(mockAdapterPath, "utf-8");
 assert(mockSrc.includes("createMockAdapter"), "mock-adapter.js exports createMockAdapter");
-assert(mockSrc.includes("name: \"mock\""), "mock-adapter.js has name: 'mock'");
+assert(mockSrc.includes('name = "mock"'), "mock-adapter.js createMockAdapter has name default 'mock'");
+assert(mockSrc.includes('language = "r"'), "mock-adapter.js createMockAdapter has language default 'r'");
+assert(mockSrc.includes("bootCount"), "mock-adapter.js tracks bootCount (double-start guard probe)");
 assert(mockSrc.includes("async boot()"), "mock-adapter.js has async boot()");
 assert(mockSrc.includes("async run("), "mock-adapter.js has async run()");
 assert(mockSrc.includes("calls"), "mock-adapter.js records calls");

--- a/tests/fixtures/mixed-runtime.html
+++ b/tests/fixtures/mixed-runtime.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AC-2 Adapter-Map Dispatch Test Fixture</title>
+  <link rel="stylesheet" href="../../_extensions/blendtutor/assets/styles.css">
+</head>
+<body>
+  <!--
+    AC-2 adapter-map dispatch fixture: 3 attributed exercises (R, python, R) +
+    1 attribute-less exercise. The inline module calls start() twice
+    fire-and-forget (race probe for the synchronous double-start guard),
+    spies console.warn/error BEFORE start, and exposes both mocks on window.
+  -->
+
+  <h1>AC-2 Adapter-Map Dispatch Test</h1>
+
+  <!-- Exercise 0: R exercise -->
+  <div class="bt-exercise" data-language="r">
+    <script type="application/json">{
+      "id": "bt-exercise-0",
+      "title": "R Exercise 1",
+      "prompt": "Write an R expression.",
+      "code_template": "x <- 1",
+      "checks": [],
+      "packages": [],
+      "solution": null,
+      "hints": null,
+      "gotchas": null
+    }</script>
+  </div>
+
+  <!-- Exercise 1: Python exercise -->
+  <div class="bt-exercise" data-language="python">
+    <script type="application/json">{
+      "id": "bt-exercise-1",
+      "title": "Python Exercise",
+      "prompt": "Write a Python expression.",
+      "code_template": "print('hello')",
+      "checks": [],
+      "packages": [],
+      "solution": null,
+      "hints": null,
+      "gotchas": null
+    }</script>
+  </div>
+
+  <!-- Exercise 2: Second R exercise (must route to the SAME mockR instance) -->
+  <div class="bt-exercise" data-language="r">
+    <script type="application/json">{
+      "id": "bt-exercise-2",
+      "title": "R Exercise 2",
+      "prompt": "Write another R expression.",
+      "code_template": "y <- 2",
+      "checks": [],
+      "packages": [],
+      "solution": null,
+      "hints": null,
+      "gotchas": null
+    }</script>
+  </div>
+
+  <!-- Exercise 3: attribute-less (must be SKIPPED with warn — never defaulted) -->
+  <div class="bt-exercise">
+    <script type="application/json">{
+      "id": "bt-exercise-3",
+      "title": "Attribute-less Exercise",
+      "prompt": "Has no data-language attribute.",
+      "code_template": "z <- 3",
+      "checks": [],
+      "packages": [],
+      "solution": null,
+      "hints": null,
+      "gotchas": null
+    }</script>
+  </div>
+
+  <script type="module">
+    import { scanExercises, buildRegistry, start } from "../../_extensions/blendtutor/assets/exercise-runtime.js";
+    import { createMockAdapter } from "./mock-adapter.js";
+
+    // Spy console.warn/error BEFORE start() so the probe can count warnings.
+    window.__btWarns = [];
+    window.__btErrors = [];
+    const origWarn = console.warn.bind(console);
+    const origError = console.error.bind(console);
+    console.warn = (...args) => {
+      window.__btWarns.push(args.map(String).join(" "));
+      origWarn(...args);
+    };
+    console.error = (...args) => {
+      window.__btErrors.push(args.map(String).join(" "));
+      origError(...args);
+    };
+
+    const mockR = createMockAdapter({ name: "mockR", language: "r" });
+    const mockPy = createMockAdapter({ name: "mockPy", language: "python" });
+    window.__btMocks = { r: mockR, python: mockPy };
+
+    const registry = buildRegistry(scanExercises());
+    window.__btStartResolved = false;
+
+    // Two fire-and-forget start() calls — race probe for the synchronous guard.
+    // A guard set after the first await would let both calls proceed and
+    // double-boot the adapters (bootCount === 2).
+    start(registry, { r: mockR, python: mockPy }).then(() => {
+      window.__btStartResolved = true;
+    });
+    start(registry, { r: mockR, python: mockPy }).then(() => {
+      window.__btStartResolved = true;
+    });
+  </script>
+</body>
+</html>

--- a/tests/fixtures/mock-adapter.js
+++ b/tests/fixtures/mock-adapter.js
@@ -15,21 +15,29 @@
 //
 // Call recording: every run() call pushes {code, checks, packages} to .calls.
 // The rodney probe reads adapter.calls to verify per-exercise isolation.
+//
+// AC-2 (issue #136): createMockAdapter accepts {name, language} overrides and
+// tracks bootCount (each boot() increments it) so the probe can assert the
+// double-start guard boots every adapter exactly once.
 
 /**
  * Create a mock runtime adapter for testing.
- * @returns {Object} A mock adapter with call recording.
+ * @param {Object} [options] — Optional { name, language } overrides.
+ * @param {string} [options.name="mock"] — Adapter name.
+ * @param {string} [options.language="r"] — Adapter language (editor + dispatch key).
+ * @returns {Object} A mock adapter with call recording + bootCount.
  */
-export function createMockAdapter() {
+export function createMockAdapter({ name = "mock", language = "r" } = {}) {
   const calls = [];
 
-  return {
-    name: "mock",
-    language: "r",
+  const adapter = {
+    name,
+    language,
     calls,
+    bootCount: 0,
 
     async boot() {
-      // No-op — mock needs no initialization.
+      adapter.bootCount += 1;
     },
 
     async run(code, checks, packages) {
@@ -40,4 +48,6 @@ export function createMockAdapter() {
       return { output, ok };
     },
   };
+
+  return adapter;
 }

--- a/tests/fixtures/pyodide.html
+++ b/tests/fixtures/pyodide.html
@@ -47,7 +47,7 @@
     import { pyodideAdapter } from "../../_extensions/blendtutor/assets/pyodide-adapter.js";
     window.__btPyodideAdapter = pyodideAdapter;
     const registry = buildRegistry(scanExercises());
-    start(registry, pyodideAdapter);
+    start(registry, { python: pyodideAdapter });
   </script>
 </body>
 </html>

--- a/tests/fixtures/runtime-edge.html
+++ b/tests/fixtures/runtime-edge.html
@@ -84,9 +84,10 @@
     import { createMockAdapter } from "./mock-adapter.js";
 
     const mockAdapter = createMockAdapter();
+    const mockPyAdapter = createMockAdapter({ name: "mockPy", language: "python" });
     const registry = buildRegistry(scanExercises());
     window.__btTestAdapter = mockAdapter;
-    start(registry, mockAdapter);
+    start(registry, { r: mockAdapter, python: mockPyAdapter });
   </script>
 </body>
 </html>

--- a/tests/fixtures/runtime.html
+++ b/tests/fixtures/runtime.html
@@ -65,9 +65,11 @@
     import { createMockAdapter } from "./mock-adapter.js";
 
     const mockAdapter = createMockAdapter();
+    const mockPyAdapter = createMockAdapter({ name: "mockPy", language: "python" });
     const registry = buildRegistry(scanExercises());
     window.__btTestAdapter = mockAdapter; // exposed for probe verification
-    start(registry, mockAdapter);
+    window.__btTestAdapterPy = mockPyAdapter; // python-exercise routing (AC-2 map dispatch)
+    start(registry, { r: mockAdapter, python: mockPyAdapter });
   </script>
 </body>
 </html>

--- a/tests/fixtures/webr-runtime.html
+++ b/tests/fixtures/webr-runtime.html
@@ -59,7 +59,7 @@
     });
     const registry = buildRegistry(scanExercises());
     window.__btWebRAdapter = adapter; // exposed for probe verification
-    start(registry, adapter);
+    start(registry, { r: adapter });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

start(registry, adapters) now accepts a per-language adapter map ONLY (single-adapter signature removed). Per-exercise dispatch keys off the div's data-language attribute: missing data-language -> skip + warn (the `|| runtime.language || "r"` fallback is gone), unknown language -> skip + warn, map key ≠ adapter.language -> console.error + skip, non-function boot/run -> console.error + skip. A module-level `started` flag is set SYNCHRONOUSLY at entry (before the mount loop, window.__btExercises, any await) so two fire-and-forget start() calls boot every adapter exactly once via Promise.all and never re-mount. window.__btExercises exposes only mounted exercises. Header documents "NOT adapter loading, NOT language defaulting".

## Issue

Closes #136

## ACs implemented
- [x] routing: R Run → mockR.calls grows, mockPy unchanged; python Run → mockPy grows, mockR unchanged; two R exercises route to SAME mockR instance
- [x] double-start guard: module-level flag set SYNCHRONOUSLY at entry; two fire-and-forget start() calls → each adapter bootCount === 1, exactly one console.warn matching /called twice|already started/, no re-mount (.cm-editor count stays 3), resolves without throw
- [x] fallback removal: attribute-less exercise SKIPPED with warn, absent from window.__btExercises
- [x] map validation: unknown language not in map → skip + warn, others mount, start() resolves; map key ≠ adapter.language → console.error + skip that adapter; non-function boot/run → console.error + skip
- [x] boot: every adapter gets exactly one boot() via Promise.all
- [x] source greps: `|| runtime.language || "r"` absent; `start(registry, adapters)` present; guard assignment precedes first await; no static import of webr-adapter/pyodide-adapter into exercise-runtime.js

## Test plan
- [x] rodney probe `uv run node rodney-probes/mixed-runtime.js` — 14/14 assertions PASS, verdict PROBES_PASS (evidence at docs/evidence/136/)
- [x] `uv run node scripts/tests/validate-runtime.js` — 49 passed (incl. AC-2 clause-6 source greps)
- [x] Full regression: validate-pyodide-adapter (60), validate-webr-adapter (83), test_quarto_ux.py (46), test_quarto_feedback.py (32), test_pyodide_adapter.sh (11), test_quarto_render.sh (12), test_quarto_filter.sh (17), test_coi_filter.sh (15), test_sync_assets.sh (12), test_quarto_distribution.sh (31), test_quarto_install_render.sh (13)
- [x] Existing rodney probes exercise-ux.js + feedback-probe.js pass with AC-1 output shape simulated (data-language on rendered divs); on this branch pre-AC-1 filter emits no data-language so those probes skip exercises — documented AC-1+AC-2 merge coupling (Director-managed, same batch as #135)

## Evidence
- docs/evidence/136/probe-report.json — verdict PROBES_PASS, 14 probes
- docs/evidence/136/rodney.log — per-clause PASS log
- docs/evidence/136/test-suite.log — validate + regression outputs

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested
- [x] Verification medium satisfied (rodney)
- [x] Design intent respected
- [x] No scope creep
