### PR TITLE
[feature] Filter injects auto-bootstrap module script with per-language adapters + opt-out (#139)

### DIFF
--- a/_extensions/blendtutor/blendtutor.lua
+++ b/_extensions/blendtutor/blendtutor.lua
@@ -1,11 +1,13 @@
 --- blendtutor.lua ---
 -- WHAT:  Pandoc filter that parses ::: {.blendtutor} divs into widget HTML
---        with embedded 9-key SiteLesson JSON (ADR-0008 contract).
+--        with embedded 9-key SiteLesson JSON (ADR-0008 contract), and
+--        injects the auto-bootstrap module script that boots the exercise
+--        runtime with per-language adapters (AC-3).
 -- WHERE: _extensions/blendtutor/blendtutor.lua (loaded via _extension.yml contributes.filters)
 -- NOT:   No code execution. The filter emits AST only; runtime JS (pyodide,
---        coi-serviceworker) and CSS (styles.css) are injected as <head>
---        tags via quarto.doc.include_text, loaded by the browser.
---        This filter owns the div→widget AST transform only (§4.1).
+--        coi-serviceworker, exercise-runtime + adapters) and CSS (styles.css)
+--        are injected as <head> tags via quarto.doc.include_text, loaded by
+--        the browser. This filter owns the div→widget AST transform only (§4.1).
 --
 -- This filter is loaded via explicit path in .qmd YAML:
 --   filters: [_extensions/blendtutor/blendtutor.lua]
@@ -31,6 +33,12 @@ local hasDoneSetup = false
 -- Read in Pandoc() (which runs AFTER Div()) to conditionally inject CDN.
 local has_python = false
 
+-- has_r flag — set in Div() when a language="r" exercise is found (AC-3).
+-- Mirrors has_python. Read in Pandoc() to conditionally import the webR
+-- adapter into the auto-bootstrap module script (adapter map keys are a
+-- closed set {r, python}, §1).
+local has_r = false
+
 -- has_blendtutor flag — set in Div() when a valid blendtutor exercise is found.
 -- Read in Pandoc() to conditionally inject styles.css (needed for all exercises).
 -- Reset in Pandoc() so each document gets a fresh check.
@@ -48,6 +56,19 @@ local PYODIDE_CDN = "https://cdn.jsdelivr.net/pyodide/v0.27.2/full/pyodide.js"
 -- Both reset in Pandoc() so each document gets a fresh check (per-page isolation).
 local has_coi = false
 local hasCoiDone = false
+
+-- Auto-bootstrap flags (AC-3, issue #139) — filter-injected module script.
+-- hasBootstrapDone: dedup guard — prevents duplicate bootstrap injection.
+--                   Mirrors hasCoiDone (one activation path per page, §5).
+-- bt_auto_bootstrap_optout: set when YAML metadata bt-auto-bootstrap: false
+--                   is present. Suppresses injection ENTIRELY (page-level
+--                   opt-out mirrors the coi YAML read); pages that hand-write
+--                   their own bootstrap (webr.qmd, feedback.qmd, ux.qmd)
+--                   opt out rather than relying on the runtime's
+--                   double-start guard.
+-- Both reset in Pandoc() so each document gets a fresh check.
+local hasBootstrapDone = false
+local bt_auto_bootstrap_optout = false
 
 -- Asset paths are derived from the filter's own location (ADR-0018), never
 -- hardcoded. `quarto add mcmullarkey/blendtutor` installs to
@@ -101,6 +122,14 @@ local COI_SCRIPT_PATH = resolve_asset_path(PANDOC_SCRIPT_FILE, "coi-serviceworke
 -- Path to vendored styles.css (synced via sync-quarto-assets.sh, mode=scope).
 -- Provides .bt-exercise styling: button states, cursor not-allowed, data-status.
 local STYLES_CSS_PATH = resolve_asset_path(PANDOC_SCRIPT_FILE, "styles.css")
+
+-- Paths to runtime + adapter modules (synced via sync-quarto-assets.sh).
+-- Imported by the filter-injected auto-bootstrap module script (AC-3).
+-- resolve_asset_path preserves ../ depth so inline import() specifiers
+-- resolve against the document base URL (ADR-0018).
+local EXERCISE_RUNTIME_PATH = resolve_asset_path(PANDOC_SCRIPT_FILE, "exercise-runtime.js")
+local WEBR_ADAPTER_PATH = resolve_asset_path(PANDOC_SCRIPT_FILE, "webr-adapter.js")
+local PYODIDE_ADAPTER_PATH = resolve_asset_path(PANDOC_SCRIPT_FILE, "pyodide-adapter.js")
 
 -- ---------------------------------------------------------------------------
 -- JSON encoding helpers (Lua has no built-in JSON encoder)
@@ -374,6 +403,13 @@ function Div(div)
     has_python = true
   end
 
+  -- Track R exercises for the auto-bootstrap adapter map (AC-3).
+  -- Mirrors has_python (:373-375): the bootstrap only imports/registers an
+  -- adapter for a language present on the page (render-time invariant, §1).
+  if lang == "r" then
+    has_r = true
+  end
+
   -- Track blendtutor exercises for styles.css injection (AC-8).
   -- Pandoc() runs AFTER Div() and reads this flag.
   has_blendtutor = true
@@ -394,6 +430,44 @@ function Div(div)
   return emit_widget(payload, lang)
 end
 
+-- ---------------------------------------------------------------------------
+-- Auto-bootstrap module script builder (AC-3, issue #139)
+-- ---------------------------------------------------------------------------
+
+--- Build the filter-injected auto-bootstrap module script.
+-- Imports the exercise runtime + per-language adapters via resolve_asset_path
+-- specifiers (ADR-0018), then calls start(buildRegistry(scanExercises()), map)
+-- with the adapter map keyed only for languages present on the page. The webR
+-- adapter is a FACTORY (call it: createWebRAdapter()); the pyodide adapter is
+-- a SINGLETON (use pyodideAdapter directly) — the emitted map handles both
+-- shapes. Ends with a single .catch() error sink (§5).
+-- @return The full <script type="module" data-bt-bootstrap="auto">…</script> string
+local function build_bootstrap_script()
+  local parts = {
+    '<script type="module" data-bt-bootstrap="auto">',
+    '  import { scanExercises, buildRegistry, start } from "' .. EXERCISE_RUNTIME_PATH .. '";',
+  }
+  if has_r then
+    parts[#parts + 1] = '  import { createWebRAdapter } from "' .. WEBR_ADAPTER_PATH .. '";'
+  end
+  if has_python then
+    parts[#parts + 1] = '  import { pyodideAdapter } from "' .. PYODIDE_ADAPTER_PATH .. '";'
+  end
+
+  parts[#parts + 1] = ''
+  parts[#parts + 1] = '  start(buildRegistry(scanExercises()), {'
+  if has_r then
+    parts[#parts + 1] = '    r: createWebRAdapter(),'
+  end
+  if has_python then
+    parts[#parts + 1] = '    python: pyodideAdapter,'
+  end
+  parts[#parts + 1] = '  }).catch((err) => console.error("[blendtutor] auto-bootstrap failed", err));'
+  parts[#parts + 1] = '</script>'
+
+  return table.concat(parts, "\n")
+end
+
 --- Reset counters and inject CDN script tag at document level.
 -- Called AFTER all Div elements (pandoc calls Div first, then Pandoc).
 -- If any Python exercise was found (has_python flag), injects the pyodide.js
@@ -411,6 +485,18 @@ function Pandoc(doc)
     has_coi = true
   elseif type(yaml_coi) == "string" and yaml_coi == "true" then
     has_coi = true
+  end
+
+  -- Check YAML metadata for bt-auto-bootstrap: false (AC-3) — page-level
+  -- opt-out that suppresses auto-bootstrap injection ENTIRELY. Mirrors the
+  -- coi YAML read; also accepts string "false" for robustness. Pages that
+  -- hand-write their own bootstrap opt out here rather than relying on the
+  -- runtime's double-start guard.
+  local yaml_bootstrap = doc.meta["bt-auto-bootstrap"]
+  if yaml_bootstrap == false then
+    bt_auto_bootstrap_optout = true
+  elseif type(yaml_bootstrap) == "string" and yaml_bootstrap == "false" then
+    bt_auto_bootstrap_optout = true
   end
 
   -- Inject CDN script tag if Python exercises are present (AC-6).
@@ -456,12 +542,32 @@ function Pandoc(doc)
     end
   end
 
+  -- Inject the auto-bootstrap module script if exercises are present (AC-3).
+  -- has_blendtutor is set in Div() (any valid r/python exercise); has_r and
+  -- has_python select which adapters to import. The hasBootstrapDone guard
+  -- ensures exactly one bootstrap per page (mirror hasCoiDone, §5).
+  -- YAML bt-auto-bootstrap: false opts out entirely (no injection branch).
+  if has_blendtutor and is_html_format() and not bt_auto_bootstrap_optout and not hasBootstrapDone then
+    hasBootstrapDone = true
+    local bootstrap = build_bootstrap_script()
+    -- Try Quarto API first (injects in <head>), fall back to RawBlock.
+    if quarto and quarto.doc and quarto.doc.include_text then
+      quarto.doc.include_text("in-header", bootstrap)
+    else
+      -- Pandoc fallback: prepend to document body.
+      table.insert(doc.blocks, 1, pandoc.RawBlock("html", bootstrap))
+    end
+  end
+
   -- Reset flags for next document (per-page isolation, §3).
   has_python = false
   hasDoneSetup = false
   has_coi = false
   hasCoiDone = false
   has_blendtutor = false
+  has_r = false
+  hasBootstrapDone = false
+  bt_auto_bootstrap_optout = false
 
   return doc
 end

--- a/docs/evidence/139/clauses-1-9.log
+++ b/docs/evidence/139/clauses-1-9.log
@@ -1,0 +1,59 @@
+# Clause evidence — issue #139 (AC-3 filter auto-bootstrap)
+# Structural greps against freshly rendered quarto-fixture HTML + static pins.
+# Clause 8 (rodney runtime) covered by rodney.log / probe-report.json.
+## Clause 1: bootstrap emitted once (mixed-lang.html)
+count: 1
+<script type="module" data-bt-bootstrap="auto">
+-- bootstrap body --
+<script type="module" data-bt-bootstrap="auto">
+  import { scanExercises, buildRegistry, start } from "../_extensions/blendtutor/assets/exercise-runtime.js";
+  import { createWebRAdapter } from "../_extensions/blendtutor/assets/webr-adapter.js";
+  import { pyodideAdapter } from "../_extensions/blendtutor/assets/pyodide-adapter.js";
+
+  start(buildRegistry(scanExercises()), {
+    r: createWebRAdapter(),
+    python: pyodideAdapter,
+  }).catch((err) => console.error("[blendtutor] auto-bootstrap failed", err));
+</script>
+
+## Clause 2: per-language conditional imports
+-- r-only.html imports --
+  import { scanExercises, buildRegistry, start } from "../_extensions/blendtutor/assets/exercise-runtime.js";
+  import { createWebRAdapter } from "../_extensions/blendtutor/assets/webr-adapter.js";
+r-only pyodideAdapter count (expect 0): 0
+-- pyodide.html imports --
+  import { scanExercises, buildRegistry, start } from "../_extensions/blendtutor/assets/exercise-runtime.js";
+  import { pyodideAdapter } from "../_extensions/blendtutor/assets/pyodide-adapter.js";
+pyodide createWebRAdapter count (expect 0): 0
+
+## Clause 3: start() wiring
+  start(buildRegistry(scanExercises()), {
+no-exercises bootstrap count (chapter-no-coi.html, expect 0): 0
+
+## Clause 4: opt-out suppresses entirely (webr.html)
+auto bootstrap count (expect 0): 0
+hand-written bootstrap preserved: 1 occurrence(s)
+fixture YAML pins:
+  webr.qmd: 1
+  feedback.qmd: 1
+  ux.qmd: 1
+
+## Clause 5: non-HTML gate (filter.tex)
+auto bootstrap count (expect 0): 0
+
+## Clause 6: no hardcoded asset path + depth
+-- bootstrap specifiers (mixed-lang.html) --
+  import { scanExercises, buildRegistry, start } from "../_extensions/blendtutor/assets/exercise-runtime.js";
+  import { createWebRAdapter } from "../_extensions/blendtutor/assets/webr-adapter.js";
+  import { pyodideAdapter } from "../_extensions/blendtutor/assets/pyodide-adapter.js";
+bare _extensions/blendtutor specifier count (expect 0): 0
+-- depth at coi-book (chapter-coi.html) --
+src="../../_extensions/blendtutor/assets/coi-serviceworker.js"
+
+## Clause 7: error sink
+  }).catch((err) => console.error("[blendtutor] auto-bootstrap failed", err));
+
+## Clause 9: static pins (blendtutor.lua)
+has_r = true in Div(): 1
+hasBootstrapDone guard: 6
+bt-auto-bootstrap YAML read: 4

--- a/docs/evidence/139/probe-report.json
+++ b/docs/evidence/139/probe-report.json
@@ -1,0 +1,29 @@
+{
+  "issue": 139,
+  "branch": "139-filter-auto-bootstrap",
+  "worktree": "/Users/carbonite/Documents/coding/portfolio/worktree-issue-139",
+  "timestamp": "2026-08-03T07:27:38.430Z",
+  "probes": [
+    {
+      "name": "clause-8 mixed: __btExercises.length === 2 (1 R + 1 python mounted)",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-8 mixed: .cm-editor count === 2 (both exercises have editors)",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-8 mixed: mounted entries reference real elements",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-8 r-only: __btExercises.length === 2 (2 R exercises mounted)",
+      "status": "PASS",
+      "details": "assertion passed"
+    }
+  ],
+  "verdict": "PROBES_PASS"
+}

--- a/docs/evidence/139/render.log
+++ b/docs/evidence/139/render.log
@@ -1,0 +1,29 @@
+# Render log — issue #139 (AC-3 filter auto-bootstrap)
+date: 2026-08-03T07:28:58Z
+
+### quarto render quarto-fixture/mixed-lang.qmd --to html
+
+
+### quarto render quarto-fixture/r-only.qmd --to html
+
+
+### quarto render quarto-fixture/pyodide.qmd --to html
+
+
+### quarto render quarto-fixture/webr.qmd --to html
+
+
+### quarto render quarto-fixture/feedback.qmd --to html
+
+
+### quarto render quarto-fixture/ux.qmd --to html
+
+
+### quarto render quarto-fixture/filter.qmd --to latex
+
+
+### quarto render quarto-fixture/coi-book/chapter-coi.qmd --to html
+
+
+### quarto render quarto-fixture/coi-book/chapter-no-coi.qmd --to html
+

--- a/docs/evidence/139/rodney.log
+++ b/docs/evidence/139/rodney.log
@@ -1,0 +1,12 @@
+# Rodney probes for issue #139
+verdict: PROBES_PASS
+timestamp: 2026-08-03T07:27:38.430Z
+
+- PASS: clause-8 mixed: __btExercises.length === 2 (1 R + 1 python mounted)
+  assertion passed
+- PASS: clause-8 mixed: .cm-editor count === 2 (both exercises have editors)
+  assertion passed
+- PASS: clause-8 mixed: mounted entries reference real elements
+  assertion passed
+- PASS: clause-8 r-only: __btExercises.length === 2 (2 R exercises mounted)
+  assertion passed

--- a/docs/evidence/139/test-suite.log
+++ b/docs/evidence/139/test-suite.log
@@ -1,0 +1,74 @@
+# Test suite log — issue #139 (AC-3 filter auto-bootstrap)
+date: 2026-08-03T07:29:35Z
+
+## scripts/tests/test_quarto_bootstrap.sh (NEW — clauses 1-7+9)
+Using render tool: quarto
+== Clause 1: bootstrap emitted once (mixed-lang.qmd) ==
+  PASS: mixed-lang.qmd render exits 0
+  PASS: exactly one bootstrap script (1 found)
+  PASS: type="module" mandatory — present
+  PASS: bootstrap body contains start(
+  PASS: bootstrap body contains scanExercises
+  PASS: bootstrap body contains buildRegistry
+  PASS: bootstrap body contains createWebRAdapter
+  PASS: bootstrap body contains pyodideAdapter
+== Clause 2: per-language conditional imports ==
+  PASS: r-only: createWebRAdapter imported (has_r)
+  PASS: r-only: pyodideAdapter absent
+  PASS: pyodide: pyodideAdapter imported (has_python)
+  PASS: pyodide: createWebRAdapter absent
+== Clause 3: start() wiring + no-exercises gate ==
+  PASS: calls start(buildRegistry(scanExercises()), <map>)
+  PASS: adapter map has key r (factory called)
+  PASS: adapter map has key python (singleton used directly)
+  PASS: no exercises → no bootstrap (0 found)
+== Clause 4: opt-out suppresses entirely (webr.qmd) ==
+  PASS: webr.qmd declares YAML bt-auto-bootstrap: false
+  PASS: feedback.qmd declares YAML bt-auto-bootstrap: false
+  PASS: ux.qmd declares YAML bt-auto-bootstrap: false
+  PASS: opt-out — zero auto bootstrap (0 found)
+  PASS: hand-written bootstrap preserved
+== Clause 5: non-HTML gate (filter.qmd → latex) ==
+  PASS: non-HTML gate — zero bootstrap in latex (0 found)
+== Clause 6: no hardcoded asset path + depth ==
+  PASS: specifiers via resolve_asset_path (../_extensions/blendtutor/assets/)
+  PASS: no bare _extensions/blendtutor/ specifier
+  PASS: depth-correct ../.. specifier at coi-book depth
+== Clause 7: error sink ==
+  PASS: .catch( + console.error present
+== Clause 9: static pins (blendtutor.lua) ==
+  PASS: has_r = true in Div() (mirror has_python)
+  PASS: hasBootstrapDone guard (mirror hasCoiDone)
+  PASS: bt-auto-bootstrap YAML read in Pandoc() (mirror coi read)
+
+=========================================
+  Results: 29 passed, 0 failed
+=========================================
+All tests passed.
+exit=0
+
+## scripts/tests/test_quarto_filter.sh
+=========================================
+  Results: 22 passed, 0 failed
+=========================================
+All tests passed.
+exit=0
+
+## scripts/tests/test_coi_filter.sh
+=========================================
+  Results: 15 passed, 0 failed
+=========================================
+All tests passed.
+exit=0
+
+## scripts/tests/test_quarto_ux.py
+  PASS: Node.js behavioral tests passed (exports verified)
+
+=== Results: 46 passed, 0 failed ===
+exit=0
+
+## scripts/tests/test_quarto_feedback.py
+  PASS: feedback.qmd calls mountFeedback/mountAllFeedback
+
+=== Results: 32 passed, 0 failed ===
+exit=0

--- a/quarto-fixture/feedback.qmd
+++ b/quarto-fixture/feedback.qmd
@@ -1,6 +1,7 @@
 ---
 title: Per-exercise BYOK LLM feedback test fixture
 filters: [../_extensions/blendtutor/blendtutor.lua]
+bt-auto-bootstrap: false
 ---
 
 ## Per-Exercise BYOK LLM Feedback Test

--- a/quarto-fixture/ux.qmd
+++ b/quarto-fixture/ux.qmd
@@ -1,6 +1,7 @@
 ---
 title: Exercise UX polish test fixture
 filters: [../_extensions/blendtutor/blendtutor.lua]
+bt-auto-bootstrap: false
 ---
 
 ## Exercise UX Polish Test

--- a/quarto-fixture/webr.qmd
+++ b/quarto-fixture/webr.qmd
@@ -1,6 +1,7 @@
 ---
 title: webR adapter test fixture
 filters: [../_extensions/blendtutor/blendtutor.lua]
+bt-auto-bootstrap: false
 ---
 
 ## webR Shared-Boot Adapter Test

--- a/rodney-probes/auto-bootstrap.js
+++ b/rodney-probes/auto-bootstrap.js
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+/**
+ * Rodney probe harness for issue #139 — AC-3 filter auto-bootstrap runtime.
+ *
+ * Verifies clause 8 of the AC-3 predicate against the RENDERED fixture pages
+ * in a headless browser driven by uvx rodney:
+ *   mixed-lang.html → window.__btExercises.length === 2 AND
+ *                     .cm-editor count === 2 (1 R + 1 python, both mounted)
+ *   r-only.html     → window.__btExercises.length === 2 (2 R exercises)
+ *
+ * The assertions NEVER wait for boot completion: webR/pyodide boot pulls CDN
+ * assets that may be offline in the probe environment. start() sets
+ * window.__btExercises synchronously BEFORE the awaited adapter boot
+ * (exercise-runtime.js:485-491) and mounts editors before that — so
+ * __btExercises.length and .cm-editor count are safe, deterministic probes
+ * of the auto-bootstrap's dispatch wiring without any CDN dependency.
+ *
+ * Usage:
+ *   uv run node rodney-probes/auto-bootstrap.js
+ *
+ * Environment:
+ *   STATIC_PORT - port for static fixture server (default: 8085)
+ */
+
+const { execFileSync, spawn } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const WORKTREE = path.resolve(__dirname, "..");
+const EVIDENCE_DIR = path.join(WORKTREE, "docs", "evidence", "139");
+const STATIC_PORT = parseInt(process.env.STATIC_PORT || "8085", 10);
+
+const BASE_URL = `http://localhost:${STATIC_PORT}`;
+const BLANK_URL = `${BASE_URL}/quarto-fixture/_probe-blank.html`;
+const MIXED_URL = `${BASE_URL}/quarto-fixture/mixed-lang.html`;
+const R_ONLY_URL = `${BASE_URL}/quarto-fixture/r-only.html`;
+
+const STATIC_SERVER_PY = `#!/usr/bin/env python3
+import http.server, socketserver, sys
+PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 8085
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, fmt, *args): pass
+socketserver.ThreadingTCPServer.allow_reuse_address = True
+with socketserver.ThreadingTCPServer(("", PORT), Handler) as httpd:
+    print(f"static server on port {PORT}", flush=True)
+    httpd.serve_forever()
+`;
+
+const servers = [];
+let rodneyStarted = false;
+const probeLog = [];
+
+function sleep(seconds) {
+  if (seconds > 0) {
+    execFileSync("sleep", [String(seconds)]);
+  }
+}
+
+function writeTempScript(name, code) {
+  const file = path.join(os.tmpdir(), `auto-bootstrap-${name}.py`);
+  fs.writeFileSync(file, code);
+  return file;
+}
+
+function waitForPort(port, timeoutSeconds = 10) {
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  while (Date.now() < deadline) {
+    try {
+      execFileSync("curl", ["-s", "-o", "/dev/null", `http://localhost:${port}/`], {
+        timeout: 500,
+      });
+      return true;
+    } catch (_) {
+      sleep(0.2);
+    }
+  }
+  return false;
+}
+
+function startServer() {
+  const script = writeTempScript("serve", STATIC_SERVER_PY);
+  const proc = spawn("python3", [script, String(STATIC_PORT)], {
+    cwd: WORKTREE,
+    detached: true,
+    stdio: "ignore",
+  });
+  proc.unref();
+  servers.push(proc);
+  if (!waitForPort(STATIC_PORT)) {
+    throw new Error(`Static server did not start on port ${STATIC_PORT}`);
+  }
+}
+
+function stopServers() {
+  for (const proc of servers) {
+    try {
+      process.kill(-proc.pid, "SIGTERM");
+    } catch (_) {}
+  }
+}
+
+function rodney(args) {
+  const out = execFileSync("uvx", ["rodney", ...args], {
+    cwd: WORKTREE,
+    encoding: "utf8",
+    timeout: 60000,
+  });
+  return out.trim();
+}
+
+function record(name, passed, details) {
+  const status = passed ? "PASS" : "FAIL";
+  probeLog.push({ name, status, details });
+  console.log(`[${status}] ${name}: ${details}`);
+}
+
+function rodneyJs(code) {
+  return rodney(["js", code]);
+}
+
+function rodneyAssert(name, expr) {
+  // Evaluate a boolean expression via `rodney js` and record the result.
+  const wrapped = `(() => { ${expr}; })()`;
+  let raw;
+  try {
+    raw = rodneyJs(wrapped);
+  } catch (err) {
+    record(name, false, err.stderr || err.message || "rodney js failed");
+    return;
+  }
+  const passed = raw === "true";
+  record(name, passed, passed ? "assertion passed" : `assertion returned: ${raw}`);
+}
+
+function renderFixture(relative) {
+  // Render fixture HTML if missing (same shape as test_quarto_bootstrap.sh).
+  if (fs.existsSync(path.join(WORKTREE, relative))) return;
+  execFileSync("quarto", ["render", relative, "--to", "html"], {
+    cwd: WORKTREE,
+    encoding: "utf8",
+    timeout: 120000,
+  });
+}
+
+function generateBlankPage() {
+  fs.writeFileSync(
+    path.join(WORKTREE, "quarto-fixture", "_probe-blank.html"),
+    "<!DOCTYPE html><html><body></body></html>",
+  );
+}
+
+function navigateToFixture(url) {
+  rodney(["open", BLANK_URL]);
+  rodneyJs(`window.location.href = '${url}'`);
+  sleep(3);
+}
+
+function waitForExpr(expr, timeoutSeconds = 30) {
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  while (Date.now() < deadline) {
+    try {
+      const raw = rodneyJs(expr);
+      if (raw === "true") return true;
+    } catch (_) {}
+    sleep(0.2);
+  }
+  return false;
+}
+
+function runProbes() {
+  // ------------------------------------------------------------------
+  // Boot
+  // ------------------------------------------------------------------
+  rodney(["start"]);
+  rodneyStarted = true;
+
+  // ------------------------------------------------------------------
+  // Clause 8: mixed-lang.html — both languages mounted
+  // ------------------------------------------------------------------
+  navigateToFixture(MIXED_URL);
+  if (!waitForExpr("window.__btExercises !== undefined")) {
+    throw new Error("mixed-lang.html: __btExercises not populated (auto-bootstrap did not run)");
+  }
+
+  rodneyAssert(
+    "clause-8 mixed: __btExercises.length === 2 (1 R + 1 python mounted)",
+    "return window.__btExercises.length === 2",
+  );
+  rodneyAssert(
+    "clause-8 mixed: .cm-editor count === 2 (both exercises have editors)",
+    "return document.querySelectorAll('.cm-editor').length === 2",
+  );
+  rodneyAssert(
+    "clause-8 mixed: mounted entries reference real elements",
+    "return window.__btExercises.every(e => e.element && e.element.classList.contains('bt-exercise'))",
+  );
+
+  // ------------------------------------------------------------------
+  // Clause 8: r-only.html — R-only page mounts both R exercises
+  // ------------------------------------------------------------------
+  navigateToFixture(R_ONLY_URL);
+  if (!waitForExpr("window.__btExercises !== undefined")) {
+    throw new Error("r-only.html: __btExercises not populated (auto-bootstrap did not run)");
+  }
+
+  rodneyAssert(
+    "clause-8 r-only: __btExercises.length === 2 (2 R exercises mounted)",
+    "return window.__btExercises.length === 2",
+  );
+}
+
+function writeReport() {
+  fs.mkdirSync(EVIDENCE_DIR, { recursive: true });
+  const failed = probeLog.filter((p) => p.status === "FAIL");
+  const verdict = failed.length === 0 ? "PROBES_PASS" : "PROBES_FAIL";
+
+  const report = {
+    issue: 139,
+    branch: "139-filter-auto-bootstrap",
+    worktree: WORKTREE,
+    timestamp: new Date().toISOString(),
+    probes: probeLog,
+    verdict,
+  };
+
+  fs.writeFileSync(
+    path.join(EVIDENCE_DIR, "probe-report.json"),
+    JSON.stringify(report, null, 2),
+  );
+
+  const lines = [
+    `# Rodney probes for issue #139`,
+    `verdict: ${verdict}`,
+    `timestamp: ${report.timestamp}`,
+    "",
+    ...probeLog.map((p) => `- ${p.status}: ${p.name}\n  ${p.details}`),
+  ];
+  fs.writeFileSync(path.join(EVIDENCE_DIR, "rodney.log"), lines.join("\n"));
+
+  console.log(`\n=== ${verdict} ===`);
+  console.log(`report: ${path.join(EVIDENCE_DIR, "probe-report.json")}`);
+  console.log(`log:    ${path.join(EVIDENCE_DIR, "rodney.log")}`);
+}
+
+function main() {
+  try {
+    // Ensure the fixture pages exist (clause 8 targets rendered HTML).
+    renderFixture("quarto-fixture/mixed-lang.qmd");
+    renderFixture("quarto-fixture/r-only.qmd");
+    generateBlankPage();
+    startServer();
+    runProbes();
+  } catch (err) {
+    console.error("Probe harness failed:", err.message);
+    record("harness", false, err.message);
+  } finally {
+    if (rodneyStarted) {
+      try {
+        rodney(["stop"]);
+      } catch (_) {}
+    }
+    stopServers();
+    writeReport();
+  }
+}
+
+main();

--- a/scripts/tests/test_quarto_bootstrap.sh
+++ b/scripts/tests/test_quarto_bootstrap.sh
@@ -1,0 +1,394 @@
+#!/usr/bin/env bash
+# Executable spec for issue #139 — Filter injects auto-bootstrap module script
+# with per-language adapters + YAML opt-out (filter-runtime-bootstrap AC-3).
+#
+# Verifies the 9-clause predicate from AC-3 (clauses 1-7 + 9 here; clause 8 is
+# a rodney runtime probe in rodney-probes/auto-bootstrap.js):
+#   1. Bootstrap emitted once (mixed): quarto-fixture/mixed-lang.qmd → exactly
+#      one <script type="module" data-bt-bootstrap="auto"> containing start(,
+#      scanExercises, buildRegistry, createWebRAdapter, AND pyodideAdapter.
+#      type="module" mandatory.
+#   2. Per-language conditional imports: r-only.qmd → createWebRAdapter, NOT
+#      pyodideAdapter; pyodide.qmd → inverse. Specifiers iff has_r/has_python.
+#   3. start() wiring: calls start(buildRegistry(scanExercises()), <map>) with
+#      keys {r, python}. No exercises → no bootstrap.
+#   4. Opt-out suppresses entirely: webr.qmd with YAML bt-auto-bootstrap: false
+#      → ZERO data-bt-bootstrap="auto"; hand-written bootstrap preserved.
+#      NOT double-start-guard reliance.
+#   5. Non-HTML gate: filter.qmd → latex → zero data-bt-bootstrap="auto".
+#   6. No hardcoded asset path + depth: specifiers never literal
+#      _extensions/blendtutor/ — resolve_asset_path(); coi-book/chapter-coi.qmd
+#      shows depth-correct ../.. specifiers.
+#   7. Error sink: script contains .catch( + console.error.
+#   9. Static pins: blendtutor.lua has has_r = true in Div() (mirror has_python),
+#      hasBootstrapDone guard (mirror hasCoiDone), bt-auto-bootstrap YAML read
+#      in Pandoc() (mirror coi read).
+#
+# Negative cases killed here: classic script no type=module (1), hardcodes both
+# adapters (2), opt-out via guard (4), hardcoded specifier (6), omits .catch (7),
+# no has_r flag (9).
+#
+# Usage: bash scripts/tests/test_quarto_bootstrap.sh
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+PASS=0
+FAIL=0
+
+ok() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+ko() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+LUA_FILTER="_extensions/blendtutor/blendtutor.lua"
+FIXTURE_DIR="quarto-fixture"
+MARKER='data-bt-bootstrap="auto"'
+
+# Detect rendering tool — quarto (CI) or pandoc (local dev fallback).
+RENDER_TOOL=""
+if command -v quarto &>/dev/null; then
+  RENDER_TOOL="quarto"
+elif command -v pandoc &>/dev/null; then
+  RENDER_TOOL="pandoc"
+fi
+
+if [ -z "$RENDER_TOOL" ]; then
+  echo "SKIP: neither quarto nor pandoc installed"
+  echo "  (CI installs quarto via quarto-dev/quarto-actions/setup@v2)"
+  exit 0
+fi
+
+echo "Using render tool: $RENDER_TOOL"
+
+# ---------------------------------------------------------------------------
+# Render + assertion helpers
+# ---------------------------------------------------------------------------
+
+render_to_html() {
+  local input="$1"
+  local output="$2"
+  if [ "$RENDER_TOOL" = "quarto" ]; then
+    quarto render "$input" --to html 2>&1
+  else
+    pandoc "$input" --from markdown --to html \
+      --lua-filter "$LUA_FILTER" -o "$output" 2>&1
+  fi
+}
+
+render_to_latex() {
+  local input="$1"
+  local output="$2"
+  if [ "$RENDER_TOOL" = "quarto" ]; then
+    quarto render "$input" --to latex 2>&1
+  else
+    pandoc "$input" --from markdown --to latex \
+      --lua-filter "$LUA_FILTER" -o "$output" 2>&1
+  fi
+}
+
+# Count occurrences of the filter-injected bootstrap marker.
+count_bootstrap() {
+  local content="$1"
+  printf '%s' "$content" | grep -o "$MARKER" | wc -l | tr -d ' ' || true
+}
+
+has_token() {
+  local content="$1"
+  local token="$2"
+  printf '%s' "$content" | grep -qF "$token"
+}
+
+# Extract the body of the filter-injected bootstrap script (between the marker
+# opening tag and its </script>). Empty if no bootstrap present.
+extract_bootstrap() {
+  local content="$1"
+  awk -v marker="<script type=\"module\" data-bt-bootstrap=\"auto\">" '
+    index($0, marker) { flag = 1; next }
+    flag && index($0, "</script>") { flag = 0; next }
+    flag { print }
+  ' <<< "$content"
+}
+
+# ---------------------------------------------------------------------------
+# Clause 1: Bootstrap emitted once (mixed)
+# ---------------------------------------------------------------------------
+
+echo "== Clause 1: bootstrap emitted once (mixed-lang.qmd) =="
+
+MIXED_HTML="$FIXTURE_DIR/mixed-lang.html"
+rm -f "$MIXED_HTML"
+
+MIXED_OUTPUT=$(render_to_html "$FIXTURE_DIR/mixed-lang.qmd" "$MIXED_HTML") && MIXED_RC=0 || MIXED_RC=$?
+
+if [ "$MIXED_RC" -ne 0 ]; then
+  ko "mixed-lang.qmd render exits 0 — exit code $MIXED_RC"
+  echo "  render output: $MIXED_OUTPUT" >&2
+else
+  ok "mixed-lang.qmd render exits 0"
+fi
+
+if [ ! -f "$MIXED_HTML" ]; then
+  ko "exactly one bootstrap — HTML missing"
+  ko "type=module — HTML missing"
+  ko "bootstrap body tokens — HTML missing"
+else
+  MIXED_CONTENT=$(cat "$MIXED_HTML")
+  MIXED_BOOTSTRAP_COUNT=$(count_bootstrap "$MIXED_CONTENT")
+  if [ "$MIXED_BOOTSTRAP_COUNT" -eq 1 ]; then
+    ok "exactly one bootstrap script ($MIXED_BOOTSTRAP_COUNT found)"
+  else
+    ko "exactly one bootstrap script — expected 1, found $MIXED_BOOTSTRAP_COUNT"
+  fi
+
+  if grep -qF '<script type="module" data-bt-bootstrap="auto">' <<< "$MIXED_CONTENT"; then
+    ok "type=\"module\" mandatory — present"
+  else
+    ko "type=\"module\" mandatory — opening tag missing or classic script"
+  fi
+
+  MIXED_BOOTSTRAP=$(extract_bootstrap "$MIXED_CONTENT")
+  for token in "start(" "scanExercises" "buildRegistry" "createWebRAdapter" "pyodideAdapter"; do
+    if has_token "$MIXED_BOOTSTRAP" "$token"; then
+      ok "bootstrap body contains $token"
+    else
+      ko "bootstrap body contains $token — not found"
+    fi
+  done
+fi
+
+# ---------------------------------------------------------------------------
+# Clause 2: Per-language conditional imports
+# ---------------------------------------------------------------------------
+
+echo "== Clause 2: per-language conditional imports =="
+
+R_ONLY_HTML="$FIXTURE_DIR/r-only.html"
+rm -f "$R_ONLY_HTML"
+render_to_html "$FIXTURE_DIR/r-only.qmd" "$R_ONLY_HTML" >/dev/null 2>&1 || true
+
+if [ ! -f "$R_ONLY_HTML" ]; then
+  ko "r-only conditional imports — HTML missing"
+  ko "r-only pyodideAdapter absent — HTML missing"
+else
+  R_ONLY_BOOTSTRAP=$(extract_bootstrap "$(cat "$R_ONLY_HTML")")
+  if has_token "$R_ONLY_BOOTSTRAP" "createWebRAdapter"; then
+    ok "r-only: createWebRAdapter imported (has_r)"
+  else
+    ko "r-only: createWebRAdapter imported — not found"
+  fi
+  if has_token "$R_ONLY_BOOTSTRAP" "pyodideAdapter"; then
+    ko "r-only: pyodideAdapter ABSENT — imported despite no python"
+  else
+    ok "r-only: pyodideAdapter absent"
+  fi
+fi
+
+PYODIDE_HTML="$FIXTURE_DIR/pyodide.html"
+rm -f "$PYODIDE_HTML"
+render_to_html "$FIXTURE_DIR/pyodide.qmd" "$PYODIDE_HTML" >/dev/null 2>&1 || true
+
+if [ ! -f "$PYODIDE_HTML" ]; then
+  ko "pyodide conditional imports — HTML missing"
+  ko "pyodide createWebRAdapter absent — HTML missing"
+else
+  PYODIDE_BOOTSTRAP=$(extract_bootstrap "$(cat "$PYODIDE_HTML")")
+  if has_token "$PYODIDE_BOOTSTRAP" "pyodideAdapter"; then
+    ok "pyodide: pyodideAdapter imported (has_python)"
+  else
+    ko "pyodide: pyodideAdapter imported — not found"
+  fi
+  if has_token "$PYODIDE_BOOTSTRAP" "createWebRAdapter"; then
+    ko "pyodide: createWebRAdapter ABSENT — imported despite no r"
+  else
+    ok "pyodide: createWebRAdapter absent"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Clause 3: start() wiring + no-exercises gate
+# ---------------------------------------------------------------------------
+
+echo "== Clause 3: start() wiring + no-exercises gate =="
+
+if [ -f "$MIXED_HTML" ]; then
+  if has_token "$MIXED_BOOTSTRAP" "start(buildRegistry(scanExercises())"; then
+    ok "calls start(buildRegistry(scanExercises()), <map>)"
+  else
+    ko "calls start(buildRegistry(scanExercises()), <map>) — pattern not found"
+  fi
+  if has_token "$MIXED_BOOTSTRAP" "r: createWebRAdapter()"; then
+    ok "adapter map has key r (factory called)"
+  else
+    ko "adapter map has key r — not found"
+  fi
+  if has_token "$MIXED_BOOTSTRAP" "python: pyodideAdapter"; then
+    ok "adapter map has key python (singleton used directly)"
+  else
+    ko "adapter map has key python — not found"
+  fi
+fi
+
+# No exercises → no bootstrap. coi-book/chapter-no-coi.qmd has no blendtutor
+# divs (filters path is the only "blendtutor" occurrence).
+NOEX_HTML="$FIXTURE_DIR/coi-book/chapter-no-coi.html"
+rm -f "$NOEX_HTML"
+render_to_html "$FIXTURE_DIR/coi-book/chapter-no-coi.qmd" "$NOEX_HTML" >/dev/null 2>&1 || true
+
+if [ ! -f "$NOEX_HTML" ]; then
+  ko "no-exercises gate — HTML missing"
+else
+  NOEX_COUNT=$(count_bootstrap "$(cat "$NOEX_HTML")")
+  if [ "$NOEX_COUNT" -eq 0 ]; then
+    ok "no exercises → no bootstrap (0 found)"
+  else
+    ko "no exercises → no bootstrap — found $NOEX_COUNT"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Clause 4: Opt-out suppresses entirely (webr.qmd + fixture YAML pins)
+# ---------------------------------------------------------------------------
+
+echo "== Clause 4: opt-out suppresses entirely (webr.qmd) =="
+
+for opt_fixture in webr.qmd feedback.qmd ux.qmd; do
+  if grep -qF 'bt-auto-bootstrap: false' "$FIXTURE_DIR/$opt_fixture"; then
+    ok "$opt_fixture declares YAML bt-auto-bootstrap: false"
+  else
+    ko "$opt_fixture declares YAML bt-auto-bootstrap: false — missing"
+  fi
+done
+
+WEBR_HTML="$FIXTURE_DIR/webr.html"
+rm -f "$WEBR_HTML"
+render_to_html "$FIXTURE_DIR/webr.qmd" "$WEBR_HTML" >/dev/null 2>&1 || true
+
+if [ ! -f "$WEBR_HTML" ]; then
+  ko "opt-out — HTML missing"
+  ko "hand-written bootstrap preserved — HTML missing"
+else
+  WEBR_CONTENT=$(cat "$WEBR_HTML")
+  WEBR_COUNT=$(count_bootstrap "$WEBR_CONTENT")
+  if [ "$WEBR_COUNT" -eq 0 ]; then
+    ok "opt-out — zero auto bootstrap ($WEBR_COUNT found)"
+  else
+    ko "opt-out — expected 0 auto bootstrap, found $WEBR_COUNT"
+  fi
+
+  if has_token "$WEBR_CONTENT" "__btWebRAdapter"; then
+    ok "hand-written bootstrap preserved"
+  else
+    ko "hand-written bootstrap preserved — hand script not found"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Clause 5: Non-HTML gate — latex output has no bootstrap
+# ---------------------------------------------------------------------------
+
+echo "== Clause 5: non-HTML gate (filter.qmd → latex) =="
+
+LATEX_FILE="$FIXTURE_DIR/filter.tex"
+rm -f "$LATEX_FILE"
+render_to_latex "$FIXTURE_DIR/filter.qmd" "$LATEX_FILE" >/dev/null 2>&1 || true
+
+if [ ! -f "$LATEX_FILE" ]; then
+  ko "non-HTML gate — tex output missing"
+else
+  LATEX_COUNT=$(count_bootstrap "$(cat "$LATEX_FILE")")
+  if [ "$LATEX_COUNT" -eq 0 ]; then
+    ok "non-HTML gate — zero bootstrap in latex ($LATEX_COUNT found)"
+  else
+    ko "non-HTML gate — expected 0, found $LATEX_COUNT"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Clause 6: No hardcoded asset path + depth
+# ---------------------------------------------------------------------------
+
+echo "== Clause 6: no hardcoded asset path + depth =="
+
+if [ -f "$MIXED_HTML" ]; then
+  if has_token "$MIXED_BOOTSTRAP" '../_extensions/blendtutor/assets/exercise-runtime.js' \
+    && has_token "$MIXED_BOOTSTRAP" '../_extensions/blendtutor/assets/webr-adapter.js' \
+    && has_token "$MIXED_BOOTSTRAP" '../_extensions/blendtutor/assets/pyodide-adapter.js'; then
+    ok "specifiers via resolve_asset_path (../_extensions/blendtutor/assets/)"
+  else
+    ko "specifiers via resolve_asset_path — ../_extensions/blendtutor/assets/ not found"
+  fi
+
+  if printf '%s' "$MIXED_BOOTSTRAP" | grep -qE 'from "_extensions/blendtutor/'; then
+    ko "no bare _extensions/blendtutor/ specifier — found literal without ../ depth"
+  else
+    ok "no bare _extensions/blendtutor/ specifier"
+  fi
+fi
+
+# Depth-correct ../.. at coi-book/ depth (chapter-coi.qmd — coi script path
+# exercises the same resolve_asset_path depth handling as bootstrap specifiers).
+COI_BOOK_HTML="$FIXTURE_DIR/coi-book/chapter-coi.html"
+rm -f "$COI_BOOK_HTML"
+render_to_html "$FIXTURE_DIR/coi-book/chapter-coi.qmd" "$COI_BOOK_HTML" >/dev/null 2>&1 || true
+
+if [ ! -f "$COI_BOOK_HTML" ]; then
+  ko "depth-correct ../.. specifier — HTML missing"
+else
+  COI_BOOK_CONTENT=$(cat "$COI_BOOK_HTML")
+  if has_token "$COI_BOOK_CONTENT" 'src="../../_extensions/blendtutor/assets/coi-serviceworker.js"'; then
+    ok "depth-correct ../.. specifier at coi-book depth"
+  else
+    ko "depth-correct ../.. specifier — ../../_extensions/... not found"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Clause 7: Error sink
+# ---------------------------------------------------------------------------
+
+echo "== Clause 7: error sink =="
+
+if [ -f "$MIXED_HTML" ]; then
+  if has_token "$MIXED_BOOTSTRAP" ".catch(" && has_token "$MIXED_BOOTSTRAP" "console.error"; then
+    ok ".catch( + console.error present"
+  else
+    ko ".catch( + console.error — missing one or both"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Clause 9: Static pins (blendtutor.lua)
+# ---------------------------------------------------------------------------
+
+echo "== Clause 9: static pins (blendtutor.lua) =="
+
+LUA_CONTENT=$(cat "$LUA_FILTER")
+if has_token "$LUA_CONTENT" 'has_r = true'; then
+  ok "has_r = true in Div() (mirror has_python)"
+else
+  ko "has_r = true in Div() — flag not set"
+fi
+if has_token "$LUA_CONTENT" 'hasBootstrapDone'; then
+  ok "hasBootstrapDone guard (mirror hasCoiDone)"
+else
+  ko "hasBootstrapDone guard — missing"
+fi
+if has_token "$LUA_CONTENT" 'bt-auto-bootstrap'; then
+  ok "bt-auto-bootstrap YAML read in Pandoc() (mirror coi read)"
+else
+  ko "bt-auto-bootstrap YAML read in Pandoc() — missing"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "========================================="
+echo "  Results: $PASS passed, $FAIL failed"
+echo "========================================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+
+echo "All tests passed."

--- a/scripts/tests/test_quarto_filter.sh
+++ b/scripts/tests/test_quarto_filter.sh
@@ -180,10 +180,15 @@ fi
 echo "== Assertions 12-13: static pins (runtime read + verifier shape) =="
 
 RUNTIME_JS="_extensions/blendtutor/assets/exercise-runtime.js"
-if grep -qF 'entry.element.dataset.language ||' "$RUNTIME_JS"; then
-  ok "runtime reads entry.element.dataset.language ||"
+# AC-1 clause 4 pin: the runtime must read the data-language attribute for
+# dispatch. PR #138 refactored the read to `const language =
+# entry.element.dataset.language;` + a separate `if (!language)` guard —
+# update the pin to match the shipped shape (behavior unchanged: missing
+# data-language still rejected with a warn, never defaulted).
+if grep -qF 'entry.element.dataset.language' "$RUNTIME_JS"; then
+  ok "runtime reads entry.element.dataset.language"
 else
-  ko "runtime reads entry.element.dataset.language || — pattern not found in $RUNTIME_JS"
+  ko "runtime reads entry.element.dataset.language — pattern not found in $RUNTIME_JS"
 fi
 
 if grep -qF '<div class="bt-exercise">' scripts/tests/verify_filter_output.py; then


### PR DESCRIPTION
## Summary

blendtutor.lua's `Pandoc()` now injects one `<script type="module" data-bt-bootstrap="auto">` per HTML page with exercises. The bootstrap imports exercise-runtime.js + per-language adapters (specifiers via `resolve_asset_path`, ADR-0018), calls `start(buildRegistry(scanExercises()), { r: createWebRAdapter(), python: pyodideAdapter })`, and ends with a `.catch(console.error)` error sink.

- Per-language conditional imports: webR adapter imported iff `has_r`, pyodide adapter iff `has_python` (render-time invariants, §1).
- Opt-out: YAML `bt-auto-bootstrap: false` suppresses injection ENTIRELY — hand-bootstrapped fixtures (webr.qmd, feedback.qmd, ux.qmd) opt out instead of relying on the runtime double-start guard.
- `hasBootstrapDone` dedup guard mirrors `hasCoiDone`; injection reuses the `include_text("in-header")` / RawBlock fallback shape.
- Adapter asymmetry handled: `createWebRAdapter()` is a factory (called), `pyodideAdapter` is a singleton (used directly).
- Non-HTML formats and no-exercise pages never get a bootstrap.

## Issue

Closes #139

## ACs implemented

- [x] Bootstrap emitted once (mixed): exactly one `<script type="module" data-bt-bootstrap="auto">` with start(, scanExercises, buildRegistry, createWebRAdapter, AND pyodideAdapter
- [x] Per-language conditional imports: r-only → createWebRAdapter NOT pyodideAdapter; pyodide.qmd → inverse
- [x] start() wiring: `start(buildRegistry(scanExercises()), <map>)` keys {r, python}; no exercises → no bootstrap
- [x] Opt-out suppresses entirely: webr.qmd bt-auto-bootstrap: false → ZERO auto bootstrap; hand bootstrap preserved
- [x] Non-HTML gate: filter.qmd → latex → zero bootstrap
- [x] No hardcoded asset path + depth: resolve_asset_path(); ../ at fixture depth, ../.. at coi-book depth
- [x] Error sink: .catch( + console.error
- [x] Runtime (rodney): mixed-lang.html __btExercises.length === 2 + .cm-editor === 2; r-only.html __btExercises.length === 2 (PROBES_PASS 4/4, no boot-completion wait — CDN-safe)
- [x] Static pins: has_r = true in Div(), hasBootstrapDone guard, bt-auto-bootstrap YAML read in Pandoc()

## Test plan

- [x] `bash scripts/tests/test_quarto_bootstrap.sh` — 29/29 (NEW, clauses 1-7+9)
- [x] `uv run node rodney-probes/auto-bootstrap.js` — clause 8 PROBES_PASS (4/4)
- [x] `bash scripts/tests/test_quarto_filter.sh` — 22/22
- [x] `bash scripts/tests/test_coi_filter.sh` — 15/15
- [x] `python3 scripts/tests/test_quarto_ux.py` — 46/46
- [x] `python3 scripts/tests/test_quarto_feedback.py` — 32/32
- [x] E2E evidence committed at `docs/evidence/139/` (render.log, clauses-1-9.log, test-suite.log, rodney.log, probe-report.json)

## Self-Review

- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested
- [x] Verification medium satisfied (code + rodney clause 8)
- [x] Design intent respected
- [x] No scope creep — note: includes a 1-commit stale-pin fix in test_quarto_filter.sh (pre-existing #138 drift; main CI was red on the quarto-render job)