### PR TITLE
[feature] Verify fixture hand-written bootstraps coexist with filter opt-out (no double-start)

### DIFF
--- a/.opencode/plans/filter-runtime-bootstrap/AC-6.md
+++ b/.opencode/plans/filter-runtime-bootstrap/AC-6.md
@@ -1,0 +1,81 @@
+---
+ac: 6
+depends_on: [3, 4]
+risk: medium
+status: in-progress
+---
+
+# AC-6: Verify fixture hand-written bootstraps coexist with filter opt-out — no double-start, no clobber
+
+## Executable Spec (resolver-merged, 9 clauses)
+- predicate: given quarto-fixture/ux.qmd (mock adapter), webr.qmd, feedback.qmd — all carrying bt-auto-bootstrap: false — rendered with the AC-3/AC-4 filter, then:
+  1. Zero auto-bootstrap on ALL THREE rendered pages: none of rendered ux.html/webr.html/feedback.html contains data-bt-bootstrap="auto". Closes load-bearing gap: test_quarto_bootstrap.sh:263-284 currently renders webr.qmd ONLY for zero-marker assert; ux/feedback verified YAML-side only.
+  2. Exactly-one scanExercises module script per page: each rendered page has exactly one <script type="module"> importing scanExercises — the hand-written bootstrap, never two.
+  3. Hand-written specifiers UNCHANGED — ../_extensions/blendtutor/assets/..., NOT libs-dir: AC-4 URL rewriting scoped to filter-injected bootstraps only; static HTML grep is authoritative (rodney is not — exercise-ux.js:158-188 ensureAssetSymlink masks specifier rewrites at runtime).
+  4. Per-fixture adapter tokens preserved: ux keeps mock-adapter import, webr keeps webr-adapter.js, feedback keeps exercise-feedback.js.
+  5. Real-page rodney population asserts — NO substitution: rodney navigates REAL rendered ux.html, webr.html, feedback.html and asserts window.__btExercises.length === 3 (ux), === 2 (webr), === 2 (feedback). CDN-safe: assert sync population (exercise-runtime.js:488, set before :491 boot await); never await boot completion. feedback-probe.js-style generateProbeHtml mock substitution (feedback-probe.js:188-216 — verified) is FORBIDDEN as evidence for this clause.
+  6. Double-start console.warn spy: spy on console.warn across the 3 fixture pages; assert ZERO "[blendtutor] start() called twice" warns (exercise-runtime.js:436). Defense-in-depth behind clause 1 — catches runtime-emitted duplicates invisible to static grep.
+  7. YAML static pin: all 3 fixture qmds grep-assert bt-auto-bootstrap: false (already at test_quarto_bootstrap.sh:255-261 — keep, extend loop unchanged).
+  8. Migration trigger semantics: any failure of clauses 1-5 IS the migration trigger (rewrite hand-written bootstrap or fix filter); green path performs NO fixture edits. No "speculative migration".
+  9. Regression suites green: test_quarto_ux.py, test_quarto_feedback.py, validate-webr-adapter.js, test_quarto_asset_deployment.sh, rodney-probes/exercise-ux.js all pass unmodified.
+- probe:
+  # EXTEND scripts/tests/test_quarto_bootstrap.sh clause 4 — generalize :263-284 render+assert block from webr-only to ux/webr/feedback: zero marker, exactly-one scanExercises, ../_extensions/ specifiers, per-fixture token
+  bash scripts/tests/test_quarto_bootstrap.sh   # clauses 1-4, 7 (ALREADY CI-wired at ci.yml:103)
+
+  # EXTEND rodney-probes/auto-bootstrap.js — add ux.html/webr.html/feedback.html real-page navigation (clauses 5-6); parameterize EVIDENCE_DIR (env, default docs/evidence/139 unchanged); AC-6 run overrides to docs/evidence/<AC-6-issue>/
+  EVIDENCE_DIR=docs/evidence/<AC-6-issue> uv run node rodney-probes/auto-bootstrap.js   # clauses 5-6
+
+  # Regression — unmodified
+  uv run node rodney-probes/exercise-ux.js
+  uv run python scripts/tests/test_quarto_ux.py
+  uv run python scripts/tests/test_quarto_feedback.py
+  uv run node scripts/tests/validate-webr-adapter.js
+  bash scripts/tests/test_quarto_asset_deployment.sh
+- negative:
+  1. webr-only render gap — clause 4 block stays webr-only; ux/feedback double-start or lose bootstrap undetected. Killed by clause 1 (generalized loop).
+  2. generateProbeHtml substitution — new rodney asserts reuse feedback-probe.js:188-216 mock-HTML pattern; mock DOM always passes while real page broken. Killed by clause 5 (real rendered pages only).
+  3. AC-4 rewrite leak — filter rewrites hand-written specifiers to libs-dir URLs; symlink (ensureAssetSymlink) masks it in dev, 404s in real installs. Killed by clause 3 (static grep authoritative).
+  4. Silent double-start — opt-out regresses; guard no-ops second start; population asserts still pass. Killed by clause 6 (warn spy) + clause 1.
+  5. Opt-out silently dropped in qmd edit — auto-bootstrap re-emitted. Killed by clause 7 (static YAML pin).
+  6. Boot-await flake — probe awaits WebR/Pyodide ready; CDN offline flakes CI. Killed by clause 5 (sync :488 population, never await :491).
+  7. EVIDENCE_DIR clobber — re-running auto-bootstrap.js overwrites docs/evidence/139 (AC-3 evidence, hardcoded at :31). Killed by env parameterization + AC-6 override in probe.
+  8. Render-noise commit — regenerated fixture HTML / *_files/ committed. Killed by fixture-status hygiene (rm before commit).
+- verification: code + rodney · code = clauses 1-4, 7-9 (extended test_quarto_bootstrap.sh + suite regressions, CI-wired); rodney = clauses 5-6 (extended auto-bootstrap.js, real-page boot)
+- fixture status: existing — quarto-fixture/ux.qmd, webr.qmd, feedback.qmd (opt-out present at line 4 of each, verified; NO edits unless clause 1-5 failure triggers migration per clause 8). MODIFY scripts/tests/test_quarto_bootstrap.sh (extend clause 4 render loop :263-284 → all 3 fixtures) and rodney-probes/auto-bootstrap.js (add 3 real-page asserts + warn spy + EVIDENCE_DIR env param). NO new files — scripts/tests/webr-probe.js exists but is vision-probe-only, NOT CI-wired; do NOT reuse or wire it. Regression-only: exercise-ux.js, test_quarto_ux.py, test_quarto_feedback.py, validate-webr-adapter.js, test_quarto_asset_deployment.sh.
+- rubric anchor: §1.1 (exactly-one-bootstrap invariant; YAML pin makes opt-out disappearance unrepresentable), §2 (sync :488 population = pure fact asserted without effectful boot await), §3.4 (hand-written ../_extensions/ vs filter-injected libs-dir seam = the opt-out), §5 (extend existing harnesses; no bespoke probe file; no substituted HTML)
+
+## Design Intent
+- §1: bt-auto-bootstrap: false is the type-level switch making dual-bootstrap unrepresentable; exactly-one scanExercises import + zero-marker are its DOM-level invariant probes; static YAML pin makes opt-out removal unrepresentable.
+- §2: pure = YAML pins, specifier strings, sync __btExercises set (:488); effectful = quarto render + rodney boot. CDN-safe strategy asserts the pure fact, never the effectful boot.
+- §3: seam = opt-out. Hand-written bootstraps keep source-tree specifiers (AC-6 scope); filter-injected keep libs-dir specifiers (AC-4 scope). Per-fixture adapter contracts cut at the fixture joint.
+- §4: fixture qmds document WHAT (hand-written bootstrap wins + opt-out), NOT (filter auto-start, libs rewriting). Extended bootstrap.sh clause 4 owns the coexistence contract; extended auto-bootstrap.js owns real-page runtime proof.
+- §5: extend two existing wired harnesses rather than create NEW unwired files; one warn-spy assertion; page-parametric probe loop; no HTML substitution path.
+
+## Technical Context
+- Files likely touched: MODIFY scripts/tests/test_quarto_bootstrap.sh (clause 4 loop generalization — already CI-wired ci.yml:103, no new wiring needed); MODIFY rodney-probes/auto-bootstrap.js (ux/webr/feedback real-page asserts, warn spy, EVIDENCE_DIR env param at :31); regression-read 5 files (see fixture status); qmds untouched on green path.
+- Traps: (a) ensureAssetSymlink (exercise-ux.js:158-188) masks specifier rewrites — static grep authoritative, rodney never verifies specifiers; (b) generateProbeHtml (feedback-probe.js:188-216) substitution — real pages only; (c) scripts/tests/webr-probe.js vision-only ambiguity — NOT the coverage vehicle; (d) EVIDENCE_DIR hardcode docs/evidence/139 (auto-bootstrap.js:31) — parameterize, AC-6 evidence → docs/evidence/<AC-6-issue>/; (e) render noise quarto-fixture/*_files/ — rm before commit; (f) rodney harness runs via uv run node; (g) exact count pins (=== 3/2/2) break intentionally on fixture exercise edits — loosen only via fixture-edit PR.
+- Regression surface: ~9 files (2 MODIFY + 5 regression + 0-2 qmd + ci.yml check-only).
+
+## Dependencies
+- Depends on: AC-3 (#139/PR #140 — opt-out + filter emission), AC-4 (#141/PR #142 — libs-dir specifiers, non-clobber), AC-2 (double-start guard exercise-runtime.js:436 — clause 6 target).
+- Blocks: none (AC-7 README documents pattern prose only).
+- Conflict set: test_quarto_bootstrap.sh, auto-bootstrap.js, 3 fixture qmds, 5 regression files — DISJOINT from AC-5 (demo-book/, test_quarto_distribution.sh) → Batch 4 parallel-safe.
+- Risk level: medium — no mechanism change; risk in probe quality (substitution/symlink masking), opt-out scoping regressions, render-noise hygiene.
+
+## Decision Log
+- resolver — opt-out key: both proposers wrote blendtutor-autostart: false — WRONG, corrected to bt-auto-bootstrap: false (matches AC-3); ux exercise count: A's ux===2 wrong, corrected to ===3 (verified fixture has 3 exercises); verification approach: EXTEND-over-NEW (test_quarto_bootstrap.sh + auto-bootstrap.js already CI-wired — AC-4 retro lesson: unwired tests escape); B's real-page + warn-spy adopted; feedback-probe generateProbeHtml substitution verified TRUE — real pages required; ensureAssetSymlink verified — static grep authoritative.
+- resolver — disagreement=minor; all divergences resolved by codebase verification; no user clarification needed.
+- builder — warn-spy injection mechanism: rodney 0.4.0 has NO addInitScript/console-capture (verified from bundled binary --help + uv cache source). Pre-load console.warn spy therefore cannot be installed via rodney post-navigation (module script runs during page load). Adopted serve-time injection: the harness's static server injects a passive observer <script> into the <head> of the REAL rendered ux/webr/feedback.html (spy records to window.__btWarnSpy, forwards to original warn). This is an OBSERVER, not generateProbeHtml-style bootstrap substitution (the real module script stays byte-identical; assertions run against real runtime). Documented in auto-bootstrap.js.
+- builder — evidence metadata: probe-report.json hardcodes issue/branch (139/139-filter-auto-bootstrap). Parameterized: issue = basename(EVIDENCE_DIR), branch = `git rev-parse --abbrev-ref HEAD` — correct metadata for both AC-3 (docs/evidence/139) and AC-6 (docs/evidence/144) runs.
+
+### Progress
+- [x] spec resolved (resolver) — pending implementation
+- [x] red: extend test_quarto_bootstrap.sh clause 4 to all 3 fixtures — 2026-08-03
+- [x] green: verify zero-marker + exactly-one + specifiers + tokens on rendered pages — 2026-08-03 (39/0 pass; negative control: removing ux opt-out → FAIL zero-marker + FAIL exactly-one, reverted)
+- [ ] rodney clauses 5-6 (real-page + warn spy) — pending
+- [ ] evidence docs/evidence/144/ — pending
+- [ ] regression suites green (exercise-ux.js, test_quarto_ux.py, test_quarto_feedback.py, validate-webr-adapter.js, test_quarto_asset_deployment.sh) — pending final run
+
+### Idempotence & Recovery
+- Safe retry: re-run renders + probes (regenerated at test time).
+- Rollback: git checkout -- scripts/tests/test_quarto_bootstrap.sh rodney-probes/auto-bootstrap.js

--- a/.opencode/plans/filter-runtime-bootstrap/AC-6.md
+++ b/.opencode/plans/filter-runtime-bootstrap/AC-6.md
@@ -2,7 +2,7 @@
 ac: 6
 depends_on: [3, 4]
 risk: medium
-status: in-progress
+status: complete
 ---
 
 # AC-6: Verify fixture hand-written bootstraps coexist with filter opt-out — no double-start, no clobber
@@ -72,9 +72,15 @@ status: in-progress
 - [x] spec resolved (resolver) — pending implementation
 - [x] red: extend test_quarto_bootstrap.sh clause 4 to all 3 fixtures — 2026-08-03
 - [x] green: verify zero-marker + exactly-one + specifiers + tokens on rendered pages — 2026-08-03 (39/0 pass; negative control: removing ux opt-out → FAIL zero-marker + FAIL exactly-one, reverted)
-- [ ] rodney clauses 5-6 (real-page + warn spy) — pending
-- [ ] evidence docs/evidence/144/ — pending
-- [ ] regression suites green (exercise-ux.js, test_quarto_ux.py, test_quarto_feedback.py, validate-webr-adapter.js, test_quarto_asset_deployment.sh) — pending final run
+- [x] rodney clauses 5-6 (real-page + warn spy) — 2026-08-03 (PROBES_PASS; negative control: fake double-start warn injection → clause-6 FAIL on all 3 pages, reverted)
+- [x] evidence docs/evidence/144/ — 2026-08-03 (probe-report.json, rodney.log, rendered-html-greps.txt, test-suite.log; docs/evidence/139 untouched)
+- [x] regression suites green (exercise-ux.js PROBES_PASS, test_quarto_ux.py 46/0, test_quarto_feedback.py 32/0, validate-webr-adapter.js 83/0, test_quarto_asset_deployment.sh 40/0) — 2026-08-03
+
+### Surprises & Discoveries
+- Serve-time spy injection was the ONLY way to install a console.warn spy before page boot: rodney 0.4.0 (uv cache verified) has no addInitScript or console-capture subcommand, and a real rendered page's deferred module script executes before any post-navigation rodney js can run. Injecting a passive observer <script> into <head> at serve time (real bootstrap byte-identical) is an observer, not the forbidden generateProbeHtml substitution.
+- First negative control attempt silently failed: perl -0pi pattern `apply(console, arguments);\n</script>` did not match because the actual file has `};\n</script>` between the two tokens — the fake warn was never injected and the probe still passed. Caught by grepping occurrence count (2 = doc comment + assert, not 3). Lesson: verify the injection actually landed before trusting a negative control.
+- probe-report.json metadata (issue/branch) was hardcoded to 139/139-filter-auto-bootstrap; parameterizing via EVIDENCE_DIR basename + git rev-parse fixes both AC-3 (139) and AC-6 (144) runs without a bespoke env var.
+- quarto-fixture/coi-book/*_files/ render noise is NOT gitignored (only top-level quarto-fixture/*_files/ is) — must rm -rf before each commit; CI does not see it (fresh checkout) but local runs leave it untracked.
 
 ### Idempotence & Recovery
 - Safe retry: re-run renders + probes (regenerated at test time).

--- a/docs/evidence/144/probe-report.json
+++ b/docs/evidence/144/probe-report.json
@@ -1,0 +1,59 @@
+{
+  "issue": 144,
+  "branch": "144-fixture-coexistence",
+  "worktree": "/Users/carbonite/Documents/coding/portfolio/worktree-issue-144",
+  "timestamp": "2026-08-03T18:30:45.598Z",
+  "probes": [
+    {
+      "name": "clause-8 mixed: __btExercises.length === 2 (1 R + 1 python mounted)",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-8 mixed: .cm-editor count === 2 (both exercises have editors)",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-8 mixed: mounted entries reference real elements",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-8 r-only: __btExercises.length === 2 (2 R exercises mounted)",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-5 ux: __btExercises.length === 3 (3 hand-written exercises mounted)",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-6 ux: zero double-start warns (no filter-injected duplicate start)",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-5 webr: __btExercises.length === 2 (2 hand-written exercises mounted)",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-6 webr: zero double-start warns (no filter-injected duplicate start)",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-5 feedback: __btExercises.length === 2 (2 hand-written exercises mounted)",
+      "status": "PASS",
+      "details": "assertion passed"
+    },
+    {
+      "name": "clause-6 feedback: zero double-start warns (no filter-injected duplicate start)",
+      "status": "PASS",
+      "details": "assertion passed"
+    }
+  ],
+  "verdict": "PROBES_PASS"
+}

--- a/docs/evidence/144/rendered-html-greps.txt
+++ b/docs/evidence/144/rendered-html-greps.txt
@@ -1,0 +1,39 @@
+# AC-6 coexistence evidence — issue #144
+## Rendered HTML static greps (clauses 1-4, static grep authoritative)
+
+Render: quarto render quarto-fixture/{ux,webr,feedback}.qmd --to html
+
+### ux.html
+- zero data-bt-bootstrap="auto" markers: 0
+- module script blocks: 1
+- scanExercises import lines: 1
+- exercises (bt-exercise class): 3
+- hand-written runtime specifiers:
+    from "../_extensions/blendtutor/assets/exercise-runtime.js"
+- libs-dir specifiers in hand-written module script: 0 (grep for _files/libs in module script)
+
+### webr.html
+- zero data-bt-bootstrap="auto" markers: 0
+- module script blocks: 1
+- scanExercises import lines: 1
+- exercises (bt-exercise class): 2
+- hand-written runtime specifiers:
+    from "../_extensions/blendtutor/assets/exercise-runtime.js"
+    from "../_extensions/blendtutor/assets/webr-adapter.js"
+- libs-dir specifiers in hand-written module script: 0 (grep for _files/libs in module script)
+
+### feedback.html
+- zero data-bt-bootstrap="auto" markers: 0
+- module script blocks: 1
+- scanExercises import lines: 1
+- exercises (bt-exercise class): 2
+- hand-written runtime specifiers:
+    from "../_extensions/blendtutor/assets/exercise-runtime.js"
+    from "../_extensions/blendtutor/assets/exercise-feedback.js"
+    from "../_extensions/blendtutor/assets/webr-adapter.js"
+- libs-dir specifiers in hand-written module script: 0 (grep for _files/libs in module script)
+
+## YAML static pins (clause 7)
+- ux.qmd: 1 occurrence(s)
+- webr.qmd: 1 occurrence(s)
+- feedback.qmd: 1 occurrence(s)

--- a/docs/evidence/144/rodney.log
+++ b/docs/evidence/144/rodney.log
@@ -1,0 +1,24 @@
+# Rodney probes for issue #144
+verdict: PROBES_PASS
+timestamp: 2026-08-03T18:30:45.598Z
+
+- PASS: clause-8 mixed: __btExercises.length === 2 (1 R + 1 python mounted)
+  assertion passed
+- PASS: clause-8 mixed: .cm-editor count === 2 (both exercises have editors)
+  assertion passed
+- PASS: clause-8 mixed: mounted entries reference real elements
+  assertion passed
+- PASS: clause-8 r-only: __btExercises.length === 2 (2 R exercises mounted)
+  assertion passed
+- PASS: clause-5 ux: __btExercises.length === 3 (3 hand-written exercises mounted)
+  assertion passed
+- PASS: clause-6 ux: zero double-start warns (no filter-injected duplicate start)
+  assertion passed
+- PASS: clause-5 webr: __btExercises.length === 2 (2 hand-written exercises mounted)
+  assertion passed
+- PASS: clause-6 webr: zero double-start warns (no filter-injected duplicate start)
+  assertion passed
+- PASS: clause-5 feedback: __btExercises.length === 2 (2 hand-written exercises mounted)
+  assertion passed
+- PASS: clause-6 feedback: zero double-start warns (no filter-injected duplicate start)
+  assertion passed

--- a/docs/evidence/144/test-suite.log
+++ b/docs/evidence/144/test-suite.log
@@ -1,0 +1,58 @@
+# Test suite log — issue #144 (AC-6 fixture coexistence verification)
+date: 2026-08-03T18:34:50Z
+
+## scripts/tests/test_quarto_bootstrap.sh (MODIFIED — clause 4 loop → ux/webr/feedback)
+
+Using render tool: quarto
+== Clause 1: bootstrap emitted once (mixed-lang.qmd) ==
+  PASS: mixed-lang.qmd render exits 0
+  PASS: exactly one bootstrap script (1 found)
+  PASS: type="module" mandatory — present
+  PASS: bootstrap body contains start(
+  PASS: bootstrap body contains scanExercises
+  PASS: bootstrap body contains buildRegistry
+  PASS: bootstrap body contains createWebRAdapter
+  PASS: bootstrap body contains pyodideAdapter
+== Clause 2: per-language conditional imports ==
+  PASS: r-only: createWebRAdapter imported (has_r)
+  PASS: r-only: pyodideAdapter absent
+  PASS: pyodide: pyodideAdapter imported (has_python)
+  PASS: pyodide: createWebRAdapter absent
+== Clause 3: start() wiring + no-exercises gate ==
+  PASS: calls start(buildRegistry(scanExercises()), <map>)
+  PASS: adapter map has key r (factory called)
+  PASS: adapter map has key python (singleton used directly)
+  PASS: no exercises → no bootstrap (0 found)
+== Clause 4: opt-out suppresses entirely (ux/webr/feedback) ==
+  PASS: ux.qmd declares YAML bt-auto-bootstrap: false
+  PASS: webr.qmd declares YAML bt-auto-bootstrap: false
+  PASS: feedback.qmd declares YAML bt-auto-bootstrap: false
+  PASS: ux opt-out — zero auto bootstrap (0 found)
+  PASS: ux exactly-one scanExercises module script (1 found)
+  PASS: ux hand-written specifiers preserved (../_extensions/, no libs-dir)
+  PASS: ux hand-written bootstrap preserved (__btTestAdapter)
+  PASS: webr opt-out — zero auto bootstrap (0 found)
+  PASS: webr exactly-one scanExercises module script (1 found)
+  PASS: webr hand-written specifiers preserved (../_extensions/, no libs-dir)
+  PASS: webr hand-written bootstrap preserved (__btWebRAdapter)
+  PASS: feedback opt-out — zero auto bootstrap (0 found)
+  PASS: feedback exactly-one scanExercises module script (1 found)
+  PASS: feedback hand-written specifiers preserved (../_extensions/, no libs-dir)
+  PASS: feedback hand-written bootstrap preserved (mountAllFeedback)
+== Clause 5: non-HTML gate (filter.qmd → latex) ==
+  PASS: non-HTML gate — zero bootstrap in latex (0 found)
+== Clause 6: libs-URL specifiers + coi depth ==
+  PASS: specifiers are libs URLs (mixed-lang_files/libs/quarto-contrib/blendtutor-0.1.0/)
+  PASS: no _extensions/ substring in bootstrap specifiers
+  PASS: depth-correct ../.. specifier at coi-book depth
+== Clause 7: error sink ==
+  PASS: .catch( + console.error present
+== Clause 9: static pins (blendtutor.lua) ==
+  PASS: has_r = true in Div() (mirror has_python)
+  PASS: hasBootstrapDone guard (mirror hasCoiDone)
+  PASS: bt-auto-bootstrap YAML read in Pandoc() (mirror coi read)
+
+=========================================
+  Results: 39 passed, 0 failed
+=========================================
+All tests passed.

--- a/rodney-probes/auto-bootstrap.js
+++ b/rodney-probes/auto-bootstrap.js
@@ -8,6 +8,16 @@
  *                     .cm-editor count === 2 (1 R + 1 python, both mounted)
  *   r-only.html     → window.__btExercises.length === 2 (2 R exercises)
  *
+ * Also verifies AC-6 (issue #144) clauses 5-6 against the REAL rendered
+ * opt-out fixture pages (ux.html mock adapter, webr.html, feedback.html):
+ *   ux.html/webr.html/feedback.html → __btExercises.length === 3/2/2 and
+ *   ZERO "[blendtutor] start() called twice" console warns (the AC-2
+ *   double-start guard at exercise-runtime.js:436). The warn spy is injected
+ *   serve-time into <head> of these three pages ONLY (passive observer; the
+ *   hand-written bootstrap module script stays byte-identical) — rodney 0.4.0
+ *   has no addInitScript, so this is the only way to spy before page boot.
+ *   generateProbeHtml-style bootstrap substitution is FORBIDDEN here.
+ *
  * The assertions NEVER wait for boot completion: webR/pyodide boot pulls CDN
  * assets that may be offline in the probe environment. start() sets
  * window.__btExercises synchronously BEFORE the awaited adapter boot
@@ -20,6 +30,9 @@
  *
  * Environment:
  *   STATIC_PORT - port for static fixture server (default: 8085)
+ *   EVIDENCE_DIR - evidence output dir relative to repo root (default:
+ *     docs/evidence/139 — AC-3; AC-6 run passes docs/evidence/144 so AC-3
+ *     evidence is never clobbered)
  */
 
 const { execFileSync, spawn } = require("child_process");
@@ -28,19 +41,69 @@ const path = require("path");
 const os = require("os");
 
 const WORKTREE = path.resolve(__dirname, "..");
-const EVIDENCE_DIR = path.join(WORKTREE, "docs", "evidence", "139");
+// EVIDENCE_DIR is parameterized (AC-6): default preserves the AC-3 evidence
+// path docs/evidence/139; the AC-6 run overrides EVIDENCE_DIR=docs/evidence/144.
+const EVIDENCE_DIR = path.resolve(
+  WORKTREE,
+  process.env.EVIDENCE_DIR || "docs/evidence/139",
+);
+const EVIDENCE_ISSUE = path.basename(EVIDENCE_DIR);
+const EVIDENCE_BRANCH = execFileSync(
+  "git",
+  ["-C", WORKTREE, "rev-parse", "--abbrev-ref", "HEAD"],
+  { encoding: "utf8" },
+).trim();
 const STATIC_PORT = parseInt(process.env.STATIC_PORT || "8085", 10);
 
 const BASE_URL = `http://localhost:${STATIC_PORT}`;
 const BLANK_URL = `${BASE_URL}/quarto-fixture/_probe-blank.html`;
 const MIXED_URL = `${BASE_URL}/quarto-fixture/mixed-lang.html`;
 const R_ONLY_URL = `${BASE_URL}/quarto-fixture/r-only.html`;
+// AC-6 (issue #144): real rendered opt-out fixture pages — ux (mock
+// adapter), webr, feedback. All three carry bt-auto-bootstrap: false.
+const UX_URL = `${BASE_URL}/quarto-fixture/ux.html`;
+const WEBR_URL = `${BASE_URL}/quarto-fixture/webr.html`;
+const FEEDBACK_URL = `${BASE_URL}/quarto-fixture/feedback.html`;
 
 const STATIC_SERVER_PY = `#!/usr/bin/env python3
 import http.server, socketserver, sys
 PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 8085
+# AC-6 (issue #144): the opt-out fixture pages are served as REAL rendered
+# HTML with one passive observer injected into <head> — a console.warn spy
+# that records into window.__btWarnSpy and forwards to the original warn.
+# This is an OBSERVER, not a generateProbeHtml-style substitution: the
+# hand-written bootstrap module script and the runtime stay byte-identical,
+# and the spy runs before the deferred module script (classic inline script
+# in head vs deferred module at end of body). rodney 0.4.0 has no
+# addInitScript/console-capture, so serve-time injection is the only way to
+# install the spy before the page's bootstrap executes.
+SPY_PATHS = {"/quarto-fixture/ux.html", "/quarto-fixture/webr.html", "/quarto-fixture/feedback.html"}
+SPY_SCRIPT = """<script>
+window.__btWarnSpy = [];
+var __btOrigWarn = console.warn.bind(console);
+console.warn = function () {
+  window.__btWarnSpy.push(Array.prototype.map.call(arguments, String).join(" "));
+  __btOrigWarn.apply(console, arguments);
+};
+</script>"""
 class Handler(http.server.SimpleHTTPRequestHandler):
     def log_message(self, fmt, *args): pass
+    def do_GET(self):
+        if self.path in SPY_PATHS:
+            import pathlib
+            html_path = pathlib.Path(self.path.lstrip("/"))
+            if html_path.exists():
+                body = html_path.read_text()
+                if "<head>" in body:
+                    body = body.replace("<head>", "<head>" + SPY_SCRIPT, 1)
+                data = body.encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html")
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+                return
+        return super().do_GET()
 socketserver.ThreadingTCPServer.allow_reuse_address = True
 with socketserver.ThreadingTCPServer(("", PORT), Handler) as httpd:
     print(f"static server on port {PORT}", flush=True)
@@ -208,6 +271,42 @@ function runProbes() {
     "clause-8 r-only: __btExercises.length === 2 (2 R exercises mounted)",
     "return window.__btExercises.length === 2",
   );
+
+  // ------------------------------------------------------------------
+  // AC-6 clauses 5-6 (issue #144): opt-out fixture pages — real-page
+  // population + zero double-start warns. These are the REAL rendered
+  // ux/webr/feedback.html (serve-time warn-spy injection only — the
+  // bootstrap module script is untouched). Counts pinned by fixture:
+  // ux === 3 (mock adapter), webr === 2, feedback === 2. CDN-safe:
+  // __btExercises is set synchronously before the awaited adapter boot
+  // (exercise-runtime.js:488 before :491) — never await boot completion.
+  // ------------------------------------------------------------------
+  const fixturePages = [
+    { url: UX_URL, name: "ux", count: 3 },
+    { url: WEBR_URL, name: "webr", count: 2 },
+    { url: FEEDBACK_URL, name: "feedback", count: 2 },
+  ];
+  for (const page of fixturePages) {
+    navigateToFixture(page.url);
+    if (
+      !waitForExpr(
+        "window.__btExercises !== undefined && window.__btWarnSpy !== undefined",
+      )
+    ) {
+      throw new Error(
+        `${page.name}.html: __btExercises not populated (hand-written bootstrap did not run)`,
+      );
+    }
+
+    rodneyAssert(
+      `clause-5 ${page.name}: __btExercises.length === ${page.count} (${page.count} hand-written exercises mounted)`,
+      `return window.__btExercises.length === ${page.count}`,
+    );
+    rodneyAssert(
+      `clause-6 ${page.name}: zero double-start warns (no filter-injected duplicate start)`,
+      `return window.__btWarnSpy.filter(w => w.indexOf('start() called twice') !== -1).length === 0`,
+    );
+  }
 }
 
 function writeReport() {
@@ -216,8 +315,8 @@ function writeReport() {
   const verdict = failed.length === 0 ? "PROBES_PASS" : "PROBES_FAIL";
 
   const report = {
-    issue: 139,
-    branch: "139-filter-auto-bootstrap",
+    issue: parseInt(EVIDENCE_ISSUE, 10) || EVIDENCE_ISSUE,
+    branch: EVIDENCE_BRANCH,
     worktree: WORKTREE,
     timestamp: new Date().toISOString(),
     probes: probeLog,
@@ -230,7 +329,7 @@ function writeReport() {
   );
 
   const lines = [
-    `# Rodney probes for issue #139`,
+    `# Rodney probes for issue #${EVIDENCE_ISSUE}`,
     `verdict: ${verdict}`,
     `timestamp: ${report.timestamp}`,
     "",
@@ -245,9 +344,12 @@ function writeReport() {
 
 function main() {
   try {
-    // Ensure the fixture pages exist (clause 8 targets rendered HTML).
+    // Ensure the fixture pages exist (clause 8 + AC-6 target rendered HTML).
     renderFixture("quarto-fixture/mixed-lang.qmd");
     renderFixture("quarto-fixture/r-only.qmd");
+    renderFixture("quarto-fixture/ux.qmd");
+    renderFixture("quarto-fixture/webr.qmd");
+    renderFixture("quarto-fixture/feedback.qmd");
     generateBlankPage();
     startServer();
     runProbes();

--- a/scripts/tests/test_quarto_bootstrap.sh
+++ b/scripts/tests/test_quarto_bootstrap.sh
@@ -110,6 +110,29 @@ extract_bootstrap() {
   ' <<< "$content"
 }
 
+# Extract the body of the page-owned hand-written bootstrap (the FIRST
+# <script type="module"> that has no filter marker). The hand-written script
+# is the one with the import of scanExercises; the filter-injected one always
+# carries data-bt-bootstrap="auto" and is excluded by the marker prefix.
+extract_hand_script() {
+  local content="$1"
+  awk '
+    /<script type="module"[^>]*>/ && !index($0, "data-bt-bootstrap=\"auto\"") {
+      flag = 1
+      sub(/^.*<script type="module"[^>]*>/, "")
+      print
+      next
+    }
+    flag && /<\/script>/ {
+      sub(/<\/script>.*$/, "")
+      print
+      flag = 0
+      next
+    }
+    flag { print }
+  ' <<< "$content"
+}
+
 # ---------------------------------------------------------------------------
 # Clause 1: Bootstrap emitted once (mixed)
 # ---------------------------------------------------------------------------
@@ -247,12 +270,23 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Clause 4: Opt-out suppresses entirely (webr.qmd + fixture YAML pins)
+# Clause 4: Opt-out suppresses entirely (ux/webr/feedback + fixture YAML pins)
+#
+# AC-6 (issue #144): generalizes the former webr-only render block to ALL
+# THREE hand-written-bootstrap fixtures — closes the webr-only render gap
+# (ux/feedback were YAML-side verified only). Per fixture:
+#   - zero filter-injected data-bt-bootstrap="auto" markers (clause 1)
+#   - exactly one scanExercises module script — the hand-written bootstrap
+#     (clause 2)
+#   - hand-written specifiers preserved as ../_extensions/... source-tree
+#     paths, NOT libs-dir URLs (clause 3) — static grep is authoritative
+#     (ensureAssetSymlink masks specifier rewrites at runtime)
+#   - per-fixture adapter token preserved (clause 4)
 # ---------------------------------------------------------------------------
 
-echo "== Clause 4: opt-out suppresses entirely (webr.qmd) =="
+echo "== Clause 4: opt-out suppresses entirely (ux/webr/feedback) =="
 
-for opt_fixture in webr.qmd feedback.qmd ux.qmd; do
+for opt_fixture in ux.qmd webr.qmd feedback.qmd; do
   if grep -qF 'bt-auto-bootstrap: false' "$FIXTURE_DIR/$opt_fixture"; then
     ok "$opt_fixture declares YAML bt-auto-bootstrap: false"
   else
@@ -260,28 +294,60 @@ for opt_fixture in webr.qmd feedback.qmd ux.qmd; do
   fi
 done
 
-WEBR_HTML="$FIXTURE_DIR/webr.html"
-rm -f "$WEBR_HTML"
-render_to_html "$FIXTURE_DIR/webr.qmd" "$WEBR_HTML" >/dev/null 2>&1 || true
+# fixture stem → expected hand-written bootstrap token (the adapter seam each
+# fixture owns: mock adapter, webr adapter, feedback mount).
+for opt_entry in "ux:__btTestAdapter" "webr:__btWebRAdapter" "feedback:mountAllFeedback"; do
+  opt_stem="${opt_entry%%:*}"
+  opt_token="${opt_entry##*:}"
 
-if [ ! -f "$WEBR_HTML" ]; then
-  ko "opt-out — HTML missing"
-  ko "hand-written bootstrap preserved — HTML missing"
-else
-  WEBR_CONTENT=$(cat "$WEBR_HTML")
-  WEBR_COUNT=$(count_bootstrap "$WEBR_CONTENT")
-  if [ "$WEBR_COUNT" -eq 0 ]; then
-    ok "opt-out — zero auto bootstrap ($WEBR_COUNT found)"
-  else
-    ko "opt-out — expected 0 auto bootstrap, found $WEBR_COUNT"
+  OPT_HTML="$FIXTURE_DIR/$opt_stem.html"
+  rm -f "$OPT_HTML"
+  render_to_html "$FIXTURE_DIR/$opt_stem.qmd" "$OPT_HTML" >/dev/null 2>&1 || true
+
+  if [ ! -f "$OPT_HTML" ]; then
+    ko "$opt_stem opt-out — HTML missing"
+    ko "$opt_stem hand-written bootstrap preserved — HTML missing"
+    ko "$opt_stem exactly-one scanExercises script — HTML missing"
+    ko "$opt_stem specifiers preserved — HTML missing"
+    continue
   fi
 
-  if has_token "$WEBR_CONTENT" "__btWebRAdapter"; then
-    ok "hand-written bootstrap preserved"
+  OPT_CONTENT=$(cat "$OPT_HTML")
+
+  # Clause 1: zero filter-injected auto-bootstrap.
+  OPT_COUNT=$(count_bootstrap "$OPT_CONTENT")
+  if [ "$OPT_COUNT" -eq 0 ]; then
+    ok "$opt_stem opt-out — zero auto bootstrap ($OPT_COUNT found)"
   else
-    ko "hand-written bootstrap preserved — hand script not found"
+    ko "$opt_stem opt-out — expected 0 auto bootstrap, found $OPT_COUNT"
   fi
-fi
+
+  # Clause 2: exactly one scanExercises module script (hand-written).
+  OPT_SCAN_COUNT=$(printf '%s' "$OPT_CONTENT" | grep -c 'import { scanExercises' || true)
+  if [ "$OPT_SCAN_COUNT" -eq 1 ]; then
+    ok "$opt_stem exactly-one scanExercises module script ($OPT_SCAN_COUNT found)"
+  else
+    ko "$opt_stem exactly-one scanExercises module script — expected 1, found $OPT_SCAN_COUNT"
+  fi
+
+  # Clause 3: hand-written specifiers preserved — ../_extensions/, NOT
+  # libs-dir URLs (static grep authoritative; ensureAssetSymlink masks at
+  # runtime).
+  OPT_SCRIPT=$(extract_hand_script "$OPT_CONTENT")
+  if has_token "$OPT_SCRIPT" 'from "../_extensions/blendtutor/assets/' \
+    && ! has_token "$OPT_SCRIPT" '_files/libs/'; then
+    ok "$opt_stem hand-written specifiers preserved (../_extensions/, no libs-dir)"
+  else
+    ko "$opt_stem hand-written specifiers preserved — libs rewrite leaked or source specifier missing"
+  fi
+
+  # Clause 4: per-fixture adapter token preserved in the hand-written script.
+  if has_token "$OPT_SCRIPT" "$opt_token"; then
+    ok "$opt_stem hand-written bootstrap preserved ($opt_token)"
+  else
+    ko "$opt_stem hand-written bootstrap preserved — $opt_token not found"
+  fi
+done
 
 # ---------------------------------------------------------------------------
 # Clause 5: Non-HTML gate — latex output has no bootstrap


### PR DESCRIPTION
## Summary

Verification-only AC (issue #144, AC-6 of filter-runtime-bootstrap): prove the three quarto-fixture pages with hand-written bootstraps (ux.qmd mock adapter, webr.qmd, feedback.qmd) coexist with the AC-3 `bt-auto-bootstrap: false` opt-out post-AC-4. **Zero filter/runtime source changes on the green path** — only test harnesses + evidence.

**What changed:**
- `scripts/tests/test_quarto_bootstrap.sh` — clause 4 generalized from webr-only render to a loop over ux/webr/feedback.qmd: zero `data-bt-bootstrap="auto"` markers, exactly-one `scanExercises` module script, `../_extensions/` source-tree specifiers preserved (no libs-dir rewrite — static grep authoritative, `ensureAssetSymlink` masks at runtime), per-fixture adapter tokens (`__btTestAdapter` / `__btWebRAdapter` / `mountAllFeedback`).
- `rodney-probes/auto-bootstrap.js` — navigates REAL rendered ux/webr/feedback.html (no `generateProbeHtml` substitution), asserts `window.__btExercises.length === 3/2/2` (sync population at exercise-runtime.js:488, never awaits boot — CDN-safe), and a serve-time `console.warn` spy asserts ZERO `"[blendtutor] start() called twice"` warns (exercise-runtime.js:436 guard). `EVIDENCE_DIR` env-parameterized (default `docs/evidence/139` unchanged; AC-6 run uses `docs/evidence/144`).
- Evidence committed to `docs/evidence/144/`.

**Negative controls (both reverted):**
- Removing `bt-auto-bootstrap: false` from ux.qmd → clause 4 FAILs (zero-marker + exactly-one) — the regression the old webr-only block could not see.
- Injecting a fake double-start warn into the spy → clause-6 FAILs on all three pages.

## Issue
Closes #144

## ACs implemented
- [x] Rendered ux.html/webr.html/feedback.html each contain zero data-bt-bootstrap="auto" markers, exactly one scanExercises module script (hand-written), unchanged ../_extensions/blendtutor/assets/ specifiers, per-fixture adapter tokens; rodney real-page asserts __btExercises.length === 3 (ux) / === 2 (webr) / === 2 (feedback); zero "start() called twice" console warns

## Test plan
- [x] `bash scripts/tests/test_quarto_bootstrap.sh` — 39/0 pass (clauses 1-7, 9)
- [x] `EVIDENCE_DIR=docs/evidence/144 uv run node rodney-probes/auto-bootstrap.js` — PROBES_PASS (clauses 5-6)
- [x] Regression (all unmodified): `uv run node rodney-probes/exercise-ux.js` PROBES_PASS · `uv run python scripts/tests/test_quarto_ux.py` 46/0 · `uv run python scripts/tests/test_quarto_feedback.py` 32/0 · `uv run node scripts/tests/validate-webr-adapter.js` 83/0 · `bash scripts/tests/test_quarto_asset_deployment.sh` 40/0
- [x] PR review findings resolved (pending review)

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested (opt-out removal + fake double-start warn, both reverted)
- [x] Verification medium satisfied (code clauses 1-4,7-9 · rodney clauses 5-6; not visual)
- [x] Design intent respected (opt-out seam, no fixture edits, CDN-safe sync asserts, extend-not-new harnesses)
- [x] No scope creep (3 files + plan + evidence; fixtures and docs/evidence/139 untouched)

## Evidence
- `docs/evidence/144/probe-report.json` + `rodney.log` (PROBES_PASS)
- `docs/evidence/144/rendered-html-greps.txt` (static greps)
- `docs/evidence/144/test-suite.log` (39/0)
