### PR TITLE
[docs] README quick-start: zero-bootstrap flow + feedback opt-in + COI caveat

### DIFF
--- a/.opencode/plans/filter-runtime-bootstrap/AC-7.md
+++ b/.opencode/plans/filter-runtime-bootstrap/AC-7.md
@@ -1,0 +1,61 @@
+---
+ac: 7
+depends_on: [4, 5]
+risk: low
+status: complete
+---
+
+# AC-7: README quick-start — zero-bootstrap flow + feedback opt-in + COI caveat (with test lockstep)
+
+## Executable Spec (resolver-merged, 11 clauses)
+- predicate:
+  1. Quick-start zero-bootstrap flow — `quarto add mcmullarkey/blendtutor` + `filters:` by-name + explicit no-hand-written-bootstrap prose.
+  2. Zero-bootstrap example integrity — quick-start fence contains NO script/module/scanExercises/start(/buildRegistry tokens.
+  3. Opt-out documented — `bt-auto-bootstrap: false` literal + prose.
+  4. Feedback opt-in — `exercise-feedback.js` + `mountAllFeedback`, manual, BYOK, NOT auto-mounted.
+  5. COI book-mode caveat — does NOT function in `type: book`; SW scope can't cover `_output/`.
+  6. Demo book COI honesty — :254 "COI configuration" overclaim removed.
+  7. Stale mechanism removed — :174-176 "locates its assets relative to the filter script" dropped; keep install-path-independent OUTCOME, drop MECHANISM.
+  8. No stale runtime bootstrap instructions.
+  9. Command/version consistency — matches ci.yml:148 (full org/repo, no short-form), _extension.yml:3 version 0.1.0.
+  10. Existing Group 1 clauses preserved (install cmd, both-lang syntax, BYOK, min Quarto, demo link, org/repo path, ADR annotation).
+  11. Clause 6d lockstep — drops `relative to.*filter|PANDOC_SCRIPT_FILE` alternation, asserts new mechanism or outcome.
+- probe: `bash scripts/tests/test_quarto_distribution.sh` (primary, CI-wired); greps: quarto add mcmullarkey/blendtutor present + no short form; bt-auto-bootstrap: false present; exercise-feedback.js|mountAllFeedback present; book mode|type: book present; no "locates its assets relative to the filter script"; no import .*exercise-runtime.js; no unqualified COI configuration; manual: quick-start fence has no script tag.
+- negative: auto-bootstrap invisible (reader hand-writes); quick-start ships a bootstrap (double-start); opt-out undocumented; feedback mechanism invisible (key set, no UI); COI overclaim in demo book; stale mechanism survives (wrong debug path); test encodes stale claim (false-fail or docs lie); command drift (short-name install fails).
+- verification: code + manual (prose tone, caveat clarity).
+- fixture status: README.md (MODIFY) + scripts/tests/test_quarto_distribution.sh (MODIFY: extend Group 1, update clause 6d); NO new files.
+- rubric anchor: §4.1, §5, §1, §3.
+
+## Design Intent
+- §1: full org/repo mcmullarkey/blendtutor + bt-auto-bootstrap: false literal pinned; stale mechanism removed.
+- §2: pure = README text + grep assertions; effectful = quarto render (already in distribution test).
+- §3: docs cut at verified-flow joints — quick-start / opt-out / feedback / COI caveat.
+- §4: README names WHAT (verified end-state), NOT internal mechanism names.
+- §5: extend ONE existing CI-wired test, update ONE stale clause.
+
+## Technical Context
+- README.md :153-254 → Installation :164 (zero-bootstrap quick-start + filters snippet, replaces stale mechanism :174-176), Authoring syntax, BYOK :217 (feedback opt-in subsection per quarto-fixture/feedback.qmd pattern), COI :228 (book-mode limitation), Demo book :243 (fix COI overclaim).
+- scripts/tests/test_quarto_distribution.sh Group 1 — extended with clauses 7-12; clause 6d updated to outcome-level only.
+- Verified anchors: ci.yml:148 `quarto add mcmullarkey/blendtutor --no-prompt`; demo-book/_quarto.yml:15; version 0.1.0 = _extension.yml:3 = BT_DEP_VERSION blendtutor.lua:137.
+- COI wording mirrors AC-5 surprise #2 (Quarto rewrites coi src to own site_libs copy; SW scope can't cover _output/).
+
+## Dependencies
+- Depends on: #143 (AC-5, merged), #139 (AC-3 auto-bootstrap), #142 (AC-4 asset deployment), #145 (AC-6 fixture coexistence).
+- Conflict set: README.md, test_quarto_distribution.sh.
+
+## Progress
+- [x] RED: extended test_quarto_distribution.sh Group 1 (clauses 7-12 + 6d lockstep) — confirmed fail (README lacked quick-start/opt-out/feedback/COI caveat; stale mechanism present) (2026-08-03)
+- [x] GREEN: README.md Quarto Extension section — quick-start (by-name filter + zero-hand-written-bootstrap prose, fence token-clean), opt-out (bt-auto-bootstrap: false), feedback opt-in (exercise-feedback.js + mountAllFeedback, manual, BYOK), COI book-mode limitation (COI + Demo book sections), demo book COI honesty (:254 overclaim removed), stale mechanism replaced with outcome-level install-path independence, version 0.1.0 stated (2026-08-03)
+- [x] Verify: test_quarto_distribution.sh 73 passed / 0 failed; regression suite green (test_quarto_filter.sh, test_coi_filter.sh, test_quarto_ux.py, test_quarto_feedback.py, test_quarto_bootstrap.sh, test_quarto_asset_deployment.sh, test_quarto_install_render.sh, test_quarto_render.sh, test_sync_assets.sh, verify_asset_scoping.py, sync-quarto-assets.sh drift check) (2026-08-03)
+- [x] Manual review: prose tone natural, COI book-vs-standalone caveat clear, no internal API names (libs_url/add_html_dependency/PANDOC_SCRIPT_FILE) leak (2026-08-03)
+- [x] Evidence: docs/evidence/147/ (grep new-present/old-absent + distribution + test-suite logs) (2026-08-03)
+
+## Decision Log
+- Quick-start fence extracted via awk region (`#### Quick start` → `#### Auto-bootstrap opt-out`) so clause 8 token-integrity greps scope to the quick-start example only, not the whole README.
+- Feedback opt-in snippet imports ONLY exercise-feedback.js (never exercise-runtime.js) — keeps the `no import .*exercise-runtime.js` probe negative satisfiable while documenting the manual opt-in per feedback.qmd pattern.
+- Clause 11 covers BOTH COI book-mode caveat AND demo book honesty in one clause (caveat appears in both sections per trap list).
+- Version 0.1.0 pinned in installation prose to satisfy command/version consistency clause (matches _extension.yml:3).
+
+## Surprises & Discoveries
+- README's existing Authoring syntax section already uses nested 3-backtick fences (outer ``` containing ```r) — mirrored that style in the quick-start example; GFM treats ```r as a code-fence *info string*, not a closing fence, so the block renders literally.
+- The opt-out subsection prose ("leaves bootstrapping to you") stays outside the awk-extracted quick-start region, so clause 8's token-integrity check cannot be tripped by it — region scoping is load-bearing, not the fence itself.

--- a/README.md
+++ b/README.md
@@ -163,17 +163,62 @@ hints — all rendered as static HTML.
 
 ### Installation
 
+Install the extension (currently version 0.1.0) from the
+[`mcmullarkey/blendtutor`](https://github.com/mcmullarkey/blendtutor) GitHub
+repository into your project's `_extensions/mcmullarkey/blendtutor/` directory:
+
 ```bash
 quarto add mcmullarkey/blendtutor
 ```
 
-This installs the extension from the
-[`mcmullarkey/blendtutor`](https://github.com/mcmullarkey/blendtutor) GitHub
-repository into your project's `_extensions/mcmullarkey/blendtutor/` directory.
+Asset resolution is install-path-independent: the extension's assets are
+deployed alongside the rendered HTML, so the extension works regardless of
+where `quarto add` installs it.
 
-Asset resolution is install-path-independent — the extension locates its
-assets relative to the filter script, so it works regardless of where `quarto
-add` installs it.
+#### Quick start (zero hand-written bootstrap)
+
+Author an exercise with the `.blendtutor` div, enable the filter by name, and
+render — the extension bootstraps the editor, checks, and solution UI
+automatically. No hand-written bootstrap is needed:
+
+```yaml
+---
+title: "My exercises"
+filters: [mcmullarkey/blendtutor]
+---
+```
+
+```markdown
+::: {.blendtutor language="r"}
+Write a function `add(a, b)` that returns the sum.
+
+```r
+add <- function(a, b) { ___ }
+```
+
+```{.r .checks}
+stopifnot(add(1, 2) == 3)
+```
+:::
+```
+
+Render the document and open the output in a browser — the exercises are
+interactive immediately.
+
+#### Auto-bootstrap opt-out
+
+The filter auto-bootstraps by default. To disable it and wire up the runtime
+yourself, set `bt-auto-bootstrap: false` in the YAML header:
+
+```yaml
+---
+title: "My exercises"
+bt-auto-bootstrap: false
+---
+```
+
+With the opt-out set, the filter leaves bootstrapping to you — for example to
+mount per-exercise feedback (see below).
 
 ### Authoring syntax
 
@@ -225,6 +270,21 @@ Set one in the browser when prompted:
 The key is stored in the browser's `sessionStorage` and never sent to a server
 other than the LLM provider.
 
+#### Feedback opt-in (manual)
+
+Per-exercise AI feedback is not auto-mounted. To enable it, import
+`exercise-feedback.js` and call `mountAllFeedback` after the runtime has
+started — each exercise then gets its own feedback button and container:
+
+```js
+import { mountAllFeedback } from "./_extensions/mcmullarkey/blendtutor/assets/exercise-feedback.js";
+
+// After the runtime has started (registry = your exercise registry):
+mountAllFeedback(registry);
+```
+
+The API key is entered once and shared across exercises via `sessionStorage`.
+
 ### Cross-origin isolation (COI)
 
 webR requires `SharedArrayBuffer`, which needs cross-origin isolation
@@ -240,6 +300,11 @@ coi: true
 The filter injects a vendored `coi-serviceworker.js` shim that re-serves the
 page with the required headers. Pyodide-only pages do not need COI.
 
+> **Book-mode limitation:** COI does not function in Quarto `type: book`
+> projects. The shim re-serves the page's own scope, which cannot cover the
+> book's `_output/` directory where rendered pages are written. For
+> COI-enabled exercises, use a standalone document rather than a book.
+
 ### Demo book
 
 A complete demo book with R and Python exercises lives in
@@ -251,7 +316,10 @@ quarto render
 ```
 
 This produces a multi-page HTML book in `demo-book/_output/` with interactive
-exercises, checks, solutions, and COI configuration.
+exercises, checks, and solutions. The demo book's exercise pages set
+`coi: true`, but because it is a Quarto `type: book` project, COI does not
+take effect in the book render (see the COI book-mode limitation above) — use
+a standalone document for COI-enabled exercises.
 
 ## License
 

--- a/docs/evidence/147/distribution-test.log
+++ b/docs/evidence/147/distribution-test.log
@@ -1,0 +1,118 @@
+== Group 1: README ==
+== Clause 1: install command ==
+  PASS: install command present (quarto add mcmullarkey/blendtutor)
+== Clause 2: syntax both languages ==
+  PASS: R exercise syntax shown in README
+  PASS: Python exercise syntax shown in README
+== Clause 3: BYOK ==
+  PASS: BYOK mentioned in README
+== Clause 4: minimum Quarto version ==
+  PASS: minimum Quarto version stated in README
+== Clause 5: demo book link ==
+  PASS: demo book link present in README
+== Clause 6: install path contract ==
+  PASS: install command present (quarto add mcmullarkey/blendtutor)
+  PASS: install path stated (_extensions/mcmullarkey/blendtutor/)
+  PASS: old wrong install path claim removed
+  PASS: install-path independence stated in README
+  PASS: ADR-0017 annotated with org/repo install path (CI actually + _extensions/mcmullarkey/blendtutor/)
+== Clause 7: zero-bootstrap quick-start ==
+  PASS: quick-start uses by-name filter (filters: [mcmullarkey/blendtutor])
+  PASS: quick-start prose states zero hand-written bootstrap
+  PASS: quick-start shows .blendtutor exercise div
+== Clause 8: quick-start example integrity ==
+  PASS: quick-start example has no script/module/scanExercises/start(/buildRegistry tokens
+== Clause 9: auto-bootstrap opt-out ==
+  PASS: opt-out literal present (bt-auto-bootstrap: false)
+  PASS: opt-out prose present
+== Clause 10: feedback opt-in ==
+  PASS: feedback opt-in names exercise-feedback.js
+  PASS: feedback opt-in calls mountAllFeedback
+  PASS: feedback opt-in marked manual (not auto-mounted)
+  PASS: feedback opt-in BYOK key present (ANTHROPIC_API_KEY)
+== Clause 11: COI book-mode caveat ==
+  PASS: COI caveat names Quarto type: book
+  PASS: COI caveat states book-mode does not function
+  PASS: COI caveat explains _output/ scope
+  PASS: demo book no longer overclaims 'COI configuration'
+== Clause 12: no stale mechanism, command/version consistency ==
+  PASS: stale mechanism claim removed (relative to filter script / PANDOC_SCRIPT_FILE)
+  PASS: no stale runtime bootstrap import (import .*exercise-runtime.js)
+  PASS: no short-form install command (full org/repo required, matches ci.yml:148)
+  PASS: version stated matches _extension.yml (0.1.0)
+
+== Group 2: Demo book ==
+== AC-5 Clause 1: by-name install committed ==
+  PASS: .gitignore no longer ignores /_extensions/
+  PASS: /_output/ added to .gitignore (render artifacts excluded)
+  PASS: vendored install present at demo-book/_extensions/mcmullarkey/blendtutor/ (extension.yml + lua + assets)
+== AC-5 Clause 2: vendored extension current (markers) ==
+  PASS: vendored lua current (add_html_dependency + BT_DEP_VERSION + libs URL markers)
+== AC-5 Clause 3: by-name filter reference ==
+  PASS: filters reference mcmullarkey/blendtutor (full org/repo form)
+  PASS: no ../_extensions filter path in _quarto.yml
+== Clause 7: render exits 0 ==
+  PASS: quarto render demo-book exits 0
+  PASS: asset href target exists: site_libs/quarto-contrib/blendtutor-0.1.0/styles.css
+== AC-5 Clause 5: book libs URLs (site_libs) + no _extensions/ in bootstrap ==
+  PASS: r-exercises references site_libs exercise-runtime.js URL
+  PASS: r-exercises references site_libs webr-adapter.js URL (conditional import)
+  PASS: r-exercises does not import pyodide-adapter.js (conditional per-language import)
+  PASS: r-exercises references site_libs styles.css URL
+  PASS: r-exercises bootstrap specifiers contain no _extensions/ substring
+  PASS: python-exercises references site_libs exercise-runtime.js URL
+  PASS: python-exercises references site_libs pyodide-adapter.js URL (conditional import)
+  PASS: python-exercises does not import webr-adapter.js (conditional per-language import)
+  PASS: python-exercises references site_libs styles.css URL
+  PASS: python-exercises bootstrap specifiers contain no _extensions/ substring
+== AC-5 Clause 6: files on disk at _output/site_libs/... ==
+  PASS: book site_libs contains exercise-runtime.js
+  PASS: book site_libs contains styles.css
+  PASS: book site_libs contains codemirror.js
+  PASS: book site_libs contains webr-adapter.js (book has R exercises)
+  PASS: book site_libs contains pyodide-adapter.js (book has python exercises)
+== AC-5 Clause 7: COI stays out of blendtutor libs dir (Quarto-managed src) ==
+  PASS: r-exercises loads coi-serviceworker.js via include_text (src present)
+  PASS: coi shim src does not point into blendtutor-0.1.0 libs dir
+  PASS: coi-serviceworker.js not in blendtutor libs dir
+== Clause 8: ≥2 exercises per language ==
+  PASS: ≥2 R exercises (2 found)
+  PASS: ≥2 Python exercises (2 found)
+== Clause 9: non-empty content ==
+  PASS: non-empty content (no empty exercise divs)
+  PASS: non-empty content (code blocks present: 4)
+== Clause 10: mixed-language ==
+  PASS: mixed-language (R: 2, Python: 2)
+== Clause 11: no llm_evaluation_prompt ==
+  PASS: no llm_evaluation_prompt (0 occurrences)
+== Clause 12: COI config ==
+  PASS: COI config present (coi="true" or coi: true)
+
+== P9: demo-book side-effect free (org/repo-aware, issue #143) ==
+  PASS: demo-book side-effect free — no bare extension-dir residue (non-org path absent)
+  PASS: org/repo by-name install present (allowed by P9)
+
+== Group 3: CI ==
+== Clause 13: quarto add in temp dir ==
+  PASS: quarto add mcmullarkey/blendtutor present in CI
+  PASS: temp dir creation in CI
+  PASS: test -f paths use _extensions/mcmullarkey/blendtutor/ (actual install path)
+== Clause 14: setup@v2 ==
+  PASS: quarto-dev/quarto-actions/setup@v2 present in CI
+== Clause 15: no continue-on-error ==
+  PASS: no continue-on-error in quarto-distribution job
+
+== Negative cases ==
+== Negative 1: correct org/repo ==
+  PASS: correct org/repo (mcmullarkey/blendtutor)
+== Negative 2: no empty JSON (exercises have content) ==
+  PASS: no empty JSON (all exercises have content)
+== Negative 3: CI does not use _extensions: copy ==
+  PASS: CI does not use _extensions: copy (uses quarto add instead)
+== Negative 4: README mentions BYOK ==
+  PASS: README mentions BYOK
+
+=========================================
+  Results: 73 passed, 0 failed
+=========================================
+All tests passed.

--- a/docs/evidence/147/grep-new-content.log
+++ b/docs/evidence/147/grep-new-content.log
@@ -1,0 +1,18 @@
+=== Issue #147 AC-7 README quick-start — NEW content PRESENT ===
+171:quarto add mcmullarkey/blendtutor
+187:filters: [mcmullarkey/blendtutor]
+182:automatically. No hand-written bootstrap is needed:
+211:yourself, set `bt-auto-bootstrap: false` in the YAML header:
+216:bt-auto-bootstrap: false
+276:`exercise-feedback.js` and call `mountAllFeedback` after the runtime has
+280:import { mountAllFeedback } from "./_extensions/mcmullarkey/blendtutor/assets/exercise-feedback.js";
+276:`exercise-feedback.js` and call `mountAllFeedback` after the runtime has
+280:import { mountAllFeedback } from "./_extensions/mcmullarkey/blendtutor/assets/exercise-feedback.js";
+283:mountAllFeedback(registry);
+43:- `ANTHROPIC_API_KEY` — [Anthropic](https://www.anthropic.com) (used by built
+267:- `ANTHROPIC_API_KEY` — [Anthropic](https://www.anthropic.com) (browser BYOK is
+303:> **Book-mode limitation:** COI does not function in Quarto `type: book`
+320:`coi: true`, but because it is a Quarto `type: book` project, COI does not
+305:> book's `_output/` directory where rendered pages are written. For
+318:This produces a multi-page HTML book in `demo-book/_output/` with interactive
+166:Install the extension (currently version 0.1.0) from the

--- a/docs/evidence/147/grep-old-absent.log
+++ b/docs/evidence/147/grep-old-absent.log
@@ -1,0 +1,15 @@
+=== Issue #147 AC-7 — OLD content ABSENT (expect exit 1 per grep) ===
+-- 'locates its assets relative to the filter script' --
+ABSENT ✓
+-- 'relative to.*filter' --
+ABSENT ✓
+-- 'PANDOC_SCRIPT_FILE' --
+ABSENT ✓
+-- 'COI configuration' --
+ABSENT ✓
+-- 'import .*exercise-runtime.js' --
+ABSENT ✓
+-- short-form 'quarto add blendtutor' --
+ABSENT ✓
+-- quick-start fence bootstrap tokens (script/module/scanExercises/start(/buildRegistry) --
+ABSENT ✓

--- a/docs/evidence/147/test-suite.log
+++ b/docs/evidence/147/test-suite.log
@@ -1,0 +1,12 @@
+=== Issue #147 AC-7 regression suite (full) ===
+test_quarto_filter.sh                    PASS
+test_coi_filter.sh                       PASS
+test_quarto_bootstrap.sh                 PASS
+test_quarto_asset_deployment.sh          PASS
+test_quarto_install_render.sh            PASS
+test_quarto_render.sh                    PASS
+test_sync_assets.sh                      PASS
+test_quarto_ux.py                        PASS
+test_quarto_feedback.py                  PASS
+verify_asset_scoping.py                  PASS
+sync-quarto-assets.sh (drift)            PASS (no drift)

--- a/scripts/tests/test_quarto_distribution.sh
+++ b/scripts/tests/test_quarto_distribution.sh
@@ -3,15 +3,22 @@
 #
 # Verifies the 15-clause predicate from AC-10 in 3 groups (extended by issue
 # #143 AC-5: by-name install clauses 1-3, book-aware site_libs libs clauses
-# 5-7, org/repo-aware P9):
+# 5-7, org/repo-aware P9; extended by issue #147 AC-7: README quick-start /
+# opt-out / feedback opt-in / COI caveat clauses 7-12):
 #
-#   Group 1 — README (6 clauses):
+#   Group 1 — README (12 clauses):
 #     1. Install command present (quarto add mcmullarkey/blendtutor)
 #     2. Syntax shown for both languages (R and Python)
 #     3. BYOK (bring your own key) mentioned
 #     4. Minimum Quarto version stated
 #     5. Demo book link present
 #     6. Install path contract (org/repo path, per AC-3)
+#     7. Zero-bootstrap quick-start (by-name filter + no hand-written bootstrap prose)
+#     8. Quick-start example integrity (no script/module/bootstrap tokens)
+#     9. Auto-bootstrap opt-out documented (bt-auto-bootstrap: false)
+#    10. Feedback opt-in (exercise-feedback.js + mountAllFeedback, manual, BYOK)
+#    11. COI book-mode caveat + demo book COI honesty
+#    12. No stale mechanism/bootstrap instructions + command/version consistency
 #
 #   Group 2 — Demo book (6 clauses):
 #     7. quarto render demo-book exits 0 + asset href targets file-checked
@@ -154,8 +161,10 @@ else
     ko "old wrong install path claim removed — found 'your project's \`_extensions/blendtutor/\`'"
   fi
 
-  # 6d: Install-path independence stated
-  if grep -qiE 'install-path-independent|independent of.{0,40}install|regardless install|relative to.*filter|PANDOC_SCRIPT_FILE' "$README"; then
+  # 6d: Install-path independence stated (outcome-level only — assets deploy
+  # alongside the rendered HTML; NOT the stale 'relative to the filter
+  # script' mechanism, which issue #147 removed in lockstep with the README).
+  if grep -qiE 'install-path-independent|independent of.{0,40}install|regardless install' "$README"; then
     ok "install-path independence stated in README"
   else
     ko "install-path independence stated in README — no independence mention found"
@@ -174,6 +183,130 @@ else
   else
     ko "ADR-0017 annotated with org/repo install path — annotation missing ('CI actually' + '_extensions/mcmullarkey/blendtutor/' not both found)"
   fi
+fi
+
+# Clause 7: zero-bootstrap quick-start (quarto add → by-name filter → render,
+# no hand-written bootstrap). Issue #147 — the verified quick-start flow.
+echo "== Clause 7: zero-bootstrap quick-start =="
+QUICK_START=""
+if [ -f "$README" ]; then
+  QUICK_START=$(awk '/^#### Quick start/{flag=1;next} /^#### Auto-bootstrap opt-out/{flag=0;next} flag' "$README")
+fi
+if [ -z "$QUICK_START" ]; then
+  ko "quick-start — no '#### Quick start' subsection found in README"
+else
+  if grep -qF 'filters: [mcmullarkey/blendtutor]' <<< "$QUICK_START"; then
+    ok "quick-start uses by-name filter (filters: [mcmullarkey/blendtutor])"
+  else
+    ko "quick-start by-name filter — 'filters: [mcmullarkey/blendtutor]' not found in quick-start"
+  fi
+  if grep -qiE 'no hand-written bootstrap|hand-written bootstrap' <<< "$QUICK_START"; then
+    ok "quick-start prose states zero hand-written bootstrap"
+  else
+    ko "quick-start prose — no 'hand-written bootstrap' statement found"
+  fi
+  if grep -qF '.blendtutor' <<< "$QUICK_START"; then
+    ok "quick-start shows .blendtutor exercise div"
+  else
+    ko "quick-start .blendtutor exercise div not shown"
+  fi
+fi
+
+# Clause 8: quick-start example integrity — the quick-start fence must NOT
+# ship a bootstrap (zero script/module/scanExercises/start(/buildRegistry
+# tokens) while the prose claims zero-bootstrap (double-start trap).
+echo "== Clause 8: quick-start example integrity =="
+if [ -n "$QUICK_START" ] && ! grep -qE 'script|module|scanExercises|start\(|buildRegistry' <<< "$QUICK_START"; then
+  ok "quick-start example has no script/module/scanExercises/start(/buildRegistry tokens"
+else
+  ko "quick-start example contains bootstrap tokens (script|module|scanExercises|start(|buildRegistry)"
+fi
+
+# Clause 9: auto-bootstrap opt-out documented (literal + prose).
+echo "== Clause 9: auto-bootstrap opt-out =="
+if [ -f "$README" ] && grep -qF 'bt-auto-bootstrap: false' "$README"; then
+  ok "opt-out literal present (bt-auto-bootstrap: false)"
+else
+  ko "opt-out literal — 'bt-auto-bootstrap: false' not found"
+fi
+if [ -f "$README" ] && grep -qiE 'opt-out' "$README"; then
+  ok "opt-out prose present"
+else
+  ko "opt-out prose — no 'opt-out' mention found"
+fi
+
+# Clause 10: feedback opt-in (exercise-feedback.js + mountAllFeedback,
+# manual — NOT auto-mounted — BYOK ANTHROPIC_API_KEY).
+echo "== Clause 10: feedback opt-in =="
+if [ -f "$README" ] && grep -qF 'exercise-feedback.js' "$README"; then
+  ok "feedback opt-in names exercise-feedback.js"
+else
+  ko "feedback opt-in — 'exercise-feedback.js' not found"
+fi
+if [ -f "$README" ] && grep -qF 'mountAllFeedback' "$README"; then
+  ok "feedback opt-in calls mountAllFeedback"
+else
+  ko "feedback opt-in — 'mountAllFeedback' not found"
+fi
+if [ -f "$README" ] && grep -qiE 'not auto-mounted|manual' "$README"; then
+  ok "feedback opt-in marked manual (not auto-mounted)"
+else
+  ko "feedback opt-in — no 'not auto-mounted'/'manual' statement found"
+fi
+if [ -f "$README" ] && grep -qF 'ANTHROPIC_API_KEY' "$README"; then
+  ok "feedback opt-in BYOK key present (ANTHROPIC_API_KEY)"
+else
+  ko "feedback opt-in — 'ANTHROPIC_API_KEY' not found"
+fi
+
+# Clause 11: COI book-mode caveat + demo book COI honesty. The service-worker
+# shim's scope cannot cover a book's _output/ — caveat must appear in BOTH the
+# COI section AND the Demo book section (no unqualified 'COI configuration').
+echo "== Clause 11: COI book-mode caveat =="
+if [ -f "$README" ] && grep -qF 'type: book' "$README"; then
+  ok "COI caveat names Quarto type: book"
+else
+  ko "COI caveat — 'type: book' not found"
+fi
+if [ -f "$README" ] && grep -qiE 'does not function|does not take effect|cannot cover' "$README"; then
+  ok "COI caveat states book-mode does not function"
+else
+  ko "COI caveat — no book-mode limitation statement found"
+fi
+if [ -f "$README" ] && grep -qF '_output/' "$README"; then
+  ok "COI caveat explains _output/ scope"
+else
+  ko "COI caveat — '_output/' not mentioned"
+fi
+if [ -f "$README" ] && ! grep -qF 'COI configuration' "$README"; then
+  ok "demo book no longer overclaims 'COI configuration'"
+else
+  ko "demo book overclaim — 'COI configuration' still present"
+fi
+
+# Clause 12: no stale mechanism/bootstrap instructions + command/version
+# consistency (matches ci.yml:148 full org/repo command, _extension.yml:3
+# version 0.1.0, no short-form install).
+echo "== Clause 12: no stale mechanism, command/version consistency =="
+if [ -f "$README" ] && ! grep -qiE 'relative to.*filter|PANDOC_SCRIPT_FILE|locates its assets' "$README"; then
+  ok "stale mechanism claim removed (relative to filter script / PANDOC_SCRIPT_FILE)"
+else
+  ko "stale mechanism claim still present (relative to.*filter|PANDOC_SCRIPT_FILE|locates its assets)"
+fi
+if [ -f "$README" ] && ! grep -qE 'import .*exercise-runtime\.js' "$README"; then
+  ok "no stale runtime bootstrap import (import .*exercise-runtime.js)"
+else
+  ko "stale runtime bootstrap import found (import .*exercise-runtime.js)"
+fi
+if [ -f "$README" ] && ! grep -qE 'quarto add[[:space:]]+blendtutor([^/]|$)' "$README"; then
+  ok "no short-form install command (full org/repo required, matches ci.yml:148)"
+else
+  ko "short-form install command found ('quarto add blendtutor')"
+fi
+if [ -f "$README" ] && grep -qF '0.1.0' "$README"; then
+  ok "version stated matches _extension.yml (0.1.0)"
+else
+  ko "version consistency — '0.1.0' not stated in README"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Documents the verified zero-hand-written-bootstrap quick-start for the Quarto extension (issue #147, AC-7). The auto-bootstrap flow shipped in #140/#142/#145 is now the documented happy path; the opt-out, manual feedback opt-in, and COI book-mode limitation are documented honestly; the stale asset-resolution mechanism claim is removed.

**README.md Quarto Extension section:**
- **Quick start (zero hand-written bootstrap)** — `quarto add mcmullarkey/blendtutor` → by-name filter (`filters: [mcmullarkey/blendtutor]`) → `.blendtutor` div → `quarto render` → working exercises. Example fence ships **zero** bootstrap tokens (no script/module/scanExercises/start(/buildRegistry).
- **Auto-bootstrap opt-out** — `bt-auto-bootstrap: false` literal + prose.
- **Feedback opt-in (manual)** — `exercise-feedback.js` + `mountAllFeedback` after runtime boot, BYOK, not auto-mounted (per `quarto-fixture/feedback.qmd` pattern).
- **COI book-mode limitation** — shim scope cannot cover `type: book` `_output/`; documented in both COI and Demo book sections.
- **Demo book honesty** — removed "COI configuration" overclaim; `coi: true` in exercise pages qualified as ineffective in book render.
- **Stale mechanism removed** — "locates its assets relative to the filter script" replaced with outcome-level install-path independence; version 0.1.0 stated.

**scripts/tests/test_quarto_distribution.sh (lockstep):**
- Group 1 extended 6 → 12 clauses (quick-start flow, example integrity, opt-out, feedback opt-in, COI caveat + demo honesty, no stale mechanism/bootstrap/short-form + version consistency).
- Clause 6d updated in lockstep — drops `relative to.*filter|PANDOC_SCRIPT_FILE`, asserts install-path independence outcome only.

## Issue

Closes #147

## ACs implemented
- [x] README quick-start shows quarto add → .blendtutor div → render → working exercises, explicit no-hand-written-bootstrap prose; quick-start example block contains zero script/module/bootstrap tokens
- [x] bt-auto-bootstrap: false opt-out documented
- [x] Feedback opt-in documented (manual, BYOK ANTHROPIC_API_KEY)
- [x] COI book-mode caveat documented (COI + Demo book sections)
- [x] Demo book section no longer overclaims "COI configuration"
- [x] Stale "locates its assets relative to the filter script" mechanism claim removed
- [x] test_quarto_distribution.sh Group 1 extended + clause 6d updated in lockstep
- [x] All existing README clauses preserved

## Test plan
- [x] `bash scripts/tests/test_quarto_distribution.sh` — 73 passed, 0 failed
- [x] Regression: test_quarto_filter.sh, test_coi_filter.sh, test_quarto_bootstrap.sh, test_quarto_asset_deployment.sh, test_quarto_install_render.sh, test_quarto_render.sh, test_sync_assets.sh, test_quarto_ux.py, test_quarto_feedback.py, verify_asset_scoping.py — all PASS
- [x] sync-quarto-assets.sh drift check — no drift

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested (quick-start double-start, opt-out undocumented, feedback invisible, COI overclaim, stale mechanism, command drift — all pinned as negative greps)
- [x] Verification medium satisfied (code + manual)
- [x] Design intent respected (WHAT not internal mechanism names; no libs_url/add_html_dependency leak)
- [x] No scope creep

Evidence: `docs/evidence/147/` (grep-new-content.log, grep-old-absent.log, distribution-test.log, test-suite.log)