### PR TITLE
[feature] Deploy demo-book + demo-standalone to Pages artifact (/demo-book/ + /demo/) with .nojekyll

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,16 @@ jobs:
       - name: Standalone demo render test
         run: bash scripts/tests/test_demo_standalone_render.sh
 
+      # Issue #152 — Pages artifact assembly test. Phase 1 pins the docs.yml
+      # build-job steps (quarto setup, both demo renders, COI post-process
+      # ordering, dot-copy demo-book, selective demo copy, root .nojekyll,
+      # all-before-upload, no refusal arms) via awk job-block extraction, plus
+      # the check-docs.sh mirror contract. Phase 2 runs check-docs.sh
+      # end-to-end (render + assemble + assert) and SKIPs when quarto/mdbook/
+      # cargo are absent — this job has only quarto, so Phase 1 is enforced here.
+      - name: Pages artifact assembly test
+        run: bash scripts/tests/test_docs_pages_artifact.sh
+
   asset-parity:
     name: asset parity
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -76,6 +76,43 @@ jobs:
       - name: Build Python example site (Pyodide)
         run: cargo run --release -p blendtutor-cli -- build examples/write-less-code-python --target pyodide -o docs/book/book/examples/python
 
+      # AC-2 (#152) — deploy demo-book + demo-standalone into the Pages
+      # artifact at /demo-book/ + /demo/, mirroring the /api + /examples nesting.
+      # Quarto is not installed on this runner until setup@v2 runs, and the
+      # demo-book renders into demo-book/_output/ (demo-book/_quarto.yml pins
+      # output-dir: _output), so the copy must DOT-COPY (trailing /.): a bare
+      # cp -R demo-book/_output dst would add a demo-book/_output/ layer and
+      # /demo-book/ would 404. demo-standalone renders beside its source, so the
+      # copy is SELECTIVE (index.html + index_files/ + coi-serviceworker.js) to
+      # keep .qmd sources/_quarto.yml/_extensions/ out of the public artifact.
+      # The COI scope post-process runs after render, before copy, so the page
+      # serves ./coi-serviceworker.js at page root (SW scope covers the page).
+      - uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Render demo-book (Quarto)
+        run: quarto render demo-book --to html
+
+      - name: Render demo-standalone (Quarto)
+        run: quarto render demo-standalone --to html
+
+      - name: Fix COI service-worker scope (demo-standalone)
+        run: bash scripts/fix-demo-coi-scope.sh demo-standalone
+
+      - name: Assemble demo-book into artifact (/demo-book/)
+        run: |
+          mkdir -p docs/book/book/demo-book
+          cp -R demo-book/_output/. docs/book/book/demo-book/
+
+      - name: Assemble demo-standalone into artifact (/demo/)
+        run: |
+          mkdir -p docs/book/book/demo
+          cp demo-standalone/index.html docs/book/book/demo/
+          cp -R demo-standalone/index_files docs/book/book/demo/
+          cp demo-standalone/coi-serviceworker.js docs/book/book/demo/
+
+      - name: Add .nojekyll at artifact root
+        run: touch docs/book/book/.nojekyll
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5
         with:

--- a/docs/agent-notes/quarto-extension-lua.md
+++ b/docs/agent-notes/quarto-extension-lua.md
@@ -25,3 +25,5 @@ slices: [129]
 - 2026-08-02 (#129): **`quarto render` can mutate sibling files.** Rendering
   `demo-book` added `**/*.quarto_ipynb` to `demo-book/.gitignore` — an
   unrelated side effect that must be reverted, not committed.
+- 2026-08-04 (#152): **quarto render auto-creates `<dir>/.gitignore`** (contents: `/.quarto/` + `**/*.quarto_ipynb`) in every directory it renders — not just demo-book. demo-standalone/ got one on render. It shows as untracked `?? <dir>/.gitignore` and must be rm'd before commit (root .gitignore already covers `.quarto/`).
+- 2026-08-04 (#152): **root `.gitignore` line `/quarto-fixture/*_files/` only matches depth-1.** test_coi_filter.sh renders into `quarto-fixture/coi-book/*_files/` (nested), which escapes the ignore and shows untracked. Cleanup before commit: `rm -rf quarto-fixture/coi-book/*_files/` (or generalize the ignore line).

--- a/docs/evidence/152/assembled-artifact-layout.txt
+++ b/docs/evidence/152/assembled-artifact-layout.txt
@@ -1,0 +1,57 @@
+# Assembled Pages artifact layout (local check-docs.sh run, issue #152)
+
+## docs/book/book/ root
+404.html
+api
+api-reference.html
+architecture.html
+ayu-highlight-3fdfc3ac.css
+book-c22b7243.js
+clipboard-1626706a.min.js
+creating-lessons.html
+css
+demo
+demo-book
+elasticlunr-ef4e11c1.min.js
+examples
+examples.html
+favicon-8114d1fc.png
+favicon-de23e50b.svg
+fonts
+highlight-493f70e1.css
+highlight-abc7f01d.js
+index.html
+introduction.html
+mark-09e88c2c.min.js
+print.html
+searcher-09f2665d.js
+searchindex-1f289877.js
+toc-7137a1ba.js
+toc.html
+tomorrow-night-4c0ae647.css
+
+## demo-book/ (flattened _output — no _output/ layer)
+index.html
+python-exercises.html
+r-exercises.html
+search.json
+site_libs
+
+## demo/ (selective copy)
+coi-serviceworker.js
+index_files
+index.html
+
+## coi src in assembled demo/index.html
+src="./coi-serviceworker.js"
+
+## shim cksum (assembled vs vendored)
+150961642 5407
+150961642 5407
+
+## survivors
+OK  docs/book/book/index.html
+OK  docs/book/book/api/blendtutor_core/index.html
+OK  docs/book/book/examples/r/index.html
+OK  docs/book/book/examples/python/index.html
+OK  docs/book/book/.nojekyll

--- a/docs/evidence/152/check-docs-run.log
+++ b/docs/evidence/152/check-docs-run.log
@@ -1,0 +1,44 @@
+docs: building API reference (rustdoc, -D warnings) …
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.44s
+   Generated /Users/carbonite/Documents/coding/portfolio/worktree-issue-152/target/doc/blendtutor/index.html and 1 other file
+docs: building narrative site (mdBook) …
+ INFO Book building has started
+ INFO Running the html backend
+ INFO HTML book written to `/Users/carbonite/Documents/coding/portfolio/worktree-issue-152/docs/book/book`
+docs: assembling merged site (docs/book/book + /api) …
+docs: building example sites (webr + pyodide) …
+    Finished `release` profile [optimized] target(s) in 0.25s
+     Running `target/release/blendtutor build examples/write-less-code-r --target webr -o docs/book/book/examples/r`
+built 5 lesson(s) for webr into docs/book/book/examples/r
+    Finished `release` profile [optimized] target(s) in 0.17s
+     Running `target/release/blendtutor build examples/write-less-code-python --target pyodide -o docs/book/book/examples/python`
+built 5 lesson(s) for pyodide into docs/book/book/examples/python
+docs: rendering demos (quarto) and assembling /demo-book/ + /demo/ …
+[1m[34m[1/3] index.qmd[39m[22m
+[1m[34m[2/3] r-exercises.qmd[39m[22m
+[1m[34m[3/3] python-exercises.qmd[39m[22m
+
+Output created: _output/index.html
+
+[1mpandoc [22m
+  to: html
+  output-file: index.html
+  standalone: true
+  section-divs: true
+  html-math-method: mathjax
+  wrap: none
+  default-image-extension: png
+  
+[1mmetadata[22m
+  document-css: false
+  link-citations: true
+  date-format: long
+  lang: en
+  title: Blendtutor Interactive Demo
+  coi: true
+  
+Output created: index.html
+
+fixed COI scope for demo-standalone: src -> ./coi-serviceworker.js, shim -> demo-standalone/coi-serviceworker.js
+docs: verifying failure propagation (missing course path) …
+docs: OK — merged site at docs/book/book (book at /, API at /api, examples at /examples/{r,python}, demos at /demo-book/ + /demo/)

--- a/docs/evidence/152/docs-yml-steps.txt
+++ b/docs/evidence/152/docs-yml-steps.txt
@@ -1,0 +1,34 @@
+# docs.yml build job steps (issue #152)
+
+41:      - uses: actions/checkout@v5
+45:      - name: Install pinned toolchain
+46:        run: rustup show active-toolchain || rustup toolchain install
+48:      - uses: Swatinem/rust-cache@v2
+50:      - uses: taiki-e/install-action@v2
+56:      - name: Build API docs (rustdoc)
+57:        run: cargo doc --no-deps
+60:      - name: Build narrative docs (mdBook)
+61:        run: mdbook build docs/book
+65:      - name: Assemble merged site
+66:        run: |
+73:      - name: Build R example site (webR)
+74:        run: cargo run --release -p blendtutor-cli -- build examples/write-less-code-r --target webr -o docs/book/book/examples/r
+76:      - name: Build Python example site (Pyodide)
+77:        run: cargo run --release -p blendtutor-cli -- build examples/write-less-code-python --target pyodide -o docs/book/book/examples/python
+90:      - uses: quarto-dev/quarto-actions/setup@v2
+92:      - name: Render demo-book (Quarto)
+93:        run: quarto render demo-book --to html
+95:      - name: Render demo-standalone (Quarto)
+96:        run: quarto render demo-standalone --to html
+98:      - name: Fix COI service-worker scope (demo-standalone)
+99:        run: bash scripts/fix-demo-coi-scope.sh demo-standalone
+101:      - name: Assemble demo-book into artifact (/demo-book/)
+102:        run: |
+106:      - name: Assemble demo-standalone into artifact (/demo/)
+107:        run: |
+113:      - name: Add .nojekyll at artifact root
+114:        run: touch docs/book/book/.nojekyll
+116:      - name: Upload Pages artifact
+117:        uses: actions/upload-pages-artifact@v5
+135:      - name: Deploy to GitHub Pages
+137:        uses: actions/deploy-pages@v5

--- a/docs/evidence/152/test-suite.log
+++ b/docs/evidence/152/test-suite.log
@@ -1,0 +1,67 @@
+== Phase 1: structural pins (docs.yml build job) ==
+  PASS: quarto setup in build job (quarto-dev/quarto-actions/setup@v2)
+  PASS: build job renders demo-book (quarto render demo-book --to html)
+  PASS: build job renders demo-standalone (quarto render demo-standalone --to html)
+  PASS: COI post-process present (scripts/fix-demo-coi-scope.sh demo-standalone)
+  PASS: demo-book DOT-COPY literal (cp -R demo-book/_output/. — no _output/ layer)
+  PASS: selective demo copy (index.html + index_files/ + coi-serviceworker.js → /demo/)
+  PASS: .nojekyll step at artifact root (touch docs/book/book/.nojekyll)
+  PASS: ordering: setup → renders → fix-coi → copies → .nojekyll all BEFORE upload (clauses 4, 8)
+  PASS: no '|| true' on build steps
+  PASS: no 'continue-on-error: true' on build steps
+  PASS: no render/copy steps in deploy job block
+== Phase 1: structural pins (ci.yml quarto-render job) ==
+  PASS: CI quarto-render job runs test_docs_pages_artifact.sh
+== Phase 1: structural pins (check-docs.sh mirror contract) ==
+  PASS: check-docs.sh mirrors the new build steps (8/8 commands found)
+== Phase 2: local render + assemble + assert (check-docs.sh) ==
+docs: building API reference (rustdoc, -D warnings) …
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.28s
+   Generated /Users/carbonite/Documents/coding/portfolio/worktree-issue-152/target/doc/blendtutor/index.html and 1 other file
+docs: building narrative site (mdBook) …
+ INFO Book building has started
+ INFO Running the html backend
+ INFO HTML book written to `/Users/carbonite/Documents/coding/portfolio/worktree-issue-152/docs/book/book`
+docs: assembling merged site (docs/book/book + /api) …
+docs: building example sites (webr + pyodide) …
+    Finished `release` profile [optimized] target(s) in 0.15s
+     Running `target/release/blendtutor build examples/write-less-code-r --target webr -o docs/book/book/examples/r`
+built 5 lesson(s) for webr into docs/book/book/examples/r
+    Finished `release` profile [optimized] target(s) in 0.09s
+     Running `target/release/blendtutor build examples/write-less-code-python --target pyodide -o docs/book/book/examples/python`
+built 5 lesson(s) for pyodide into docs/book/book/examples/python
+docs: rendering demos (quarto) and assembling /demo-book/ + /demo/ …
+[1m[34m[1/3] index.qmd[39m[22m
+[1m[34m[2/3] r-exercises.qmd[39m[22m
+[1m[34m[3/3] python-exercises.qmd[39m[22m
+
+Output created: _output/index.html
+
+[1mpandoc [22m
+  to: html
+  output-file: index.html
+  standalone: true
+  section-divs: true
+  html-math-method: mathjax
+  wrap: none
+  default-image-extension: png
+  
+[1mmetadata[22m
+  document-css: false
+  link-citations: true
+  date-format: long
+  lang: en
+  title: Blendtutor Interactive Demo
+  coi: true
+  
+Output created: index.html
+
+fixed COI scope for demo-standalone: src -> ./coi-serviceworker.js, shim -> demo-standalone/coi-serviceworker.js
+docs: verifying failure propagation (missing course path) …
+docs: OK — merged site at docs/book/book (book at /, API at /api, examples at /examples/{r,python}, demos at /demo-book/ + /demo/)
+  PASS: check-docs.sh renders + assembles + asserts the artifact layout (clauses 9-10)
+
+=========================================
+  Results: 14 passed, 0 failed
+=========================================
+All tests passed.

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -62,6 +62,74 @@ cargo run --release -p blendtutor-cli -- build examples/write-less-code-r \
 cargo run --release -p blendtutor-cli -- build examples/write-less-code-python \
   --target pyodide -o "$book_out/examples/python"
 
+# AC-2 (#152) — render demo-book + demo-standalone into the Pages artifact at
+# /demo-book/ + /demo/, mirroring the /api + /examples/{r,python} nesting.
+# Mirrors the docs.yml build steps (module-responsibility contract): demo-book
+# renders into demo-book/_output/ (its _quarto.yml pins output-dir: _output),
+# so the copy DOT-COPIES (trailing /.) to avoid a demo-book/_output/ layer;
+# demo-standalone renders beside its source, so the copy is SELECTIVE
+# (index.html + index_files/ + coi-serviceworker.js only — no .qmd sources,
+# _quarto.yml, or _extensions/ leak). The COI post-process runs after render,
+# before copy, so the assembled page serves ./coi-serviceworker.js at page root
+# (SW scope covers the page, else R exercises are silent-dead on Pages).
+echo "docs: rendering demos (quarto) and assembling /demo-book/ + /demo/ …"
+quarto render demo-book --to html
+quarto render demo-standalone --to html
+bash scripts/fix-demo-coi-scope.sh demo-standalone
+mkdir -p "$book_out/demo-book"
+cp -R demo-book/_output/. "$book_out/demo-book/"
+mkdir -p "$book_out/demo"
+cp demo-standalone/index.html "$book_out/demo/"
+cp -R demo-standalone/index_files "$book_out/demo/"
+cp demo-standalone/coi-serviceworker.js "$book_out/demo/"
+touch "$book_out/.nojekyll"
+
+# AC-2 — assert the assembled layout (clause 9):
+#   * demo-book/index.html exists at /demo-book/ root, NOT under an _output/
+#     layer (dot-copy flattened the render output)
+#   * demo/index.html exists with coi src EXACTLY ./coi-serviceworker.js and no
+#     _extensions/ substring in the coi script tag (post-process applied AFTER
+#     copy would keep the subdir src → SW scope = assets dir → webR dead)
+#   * demo/coi-serviceworker.js exists, non-empty, byte-identical to the
+#     vendored shim
+#   * .nojekyll at artifact ROOT
+test -f "$book_out/demo-book/index.html" \
+  || { echo "docs: demo-book/index.html missing ($book_out/demo-book/)" >&2; exit 1; }
+if [ -e "$book_out/demo-book/_output" ]; then
+  echo "docs: demo-book assembled under an _output/ layer (bare cp, not dot-copy)" >&2
+  exit 1
+fi
+test -f "$book_out/demo/index.html" \
+  || { echo "docs: demo/index.html missing ($book_out/demo/)" >&2; exit 1; }
+grep -qF 'src="./coi-serviceworker.js"' "$book_out/demo/index.html" \
+  || { echo "docs: demo/index.html coi src is not exactly ./coi-serviceworker.js (SW scope trap)" >&2; exit 1; }
+COI_TAG=$(grep -oE '<script[^>]*coi-serviceworker\.js[^>]*>' "$book_out/demo/index.html")
+if grep -qF '_extensions/' <<< "$COI_TAG"; then
+  echo "docs: demo/index.html coi script tag leaks _extensions/ (source-tree path in artifact)" >&2
+  exit 1
+fi
+test -f "$book_out/demo/coi-serviceworker.js" \
+  || { echo "docs: demo/coi-serviceworker.js missing" >&2; exit 1; }
+test -s "$book_out/demo/coi-serviceworker.js" \
+  || { echo "docs: demo/coi-serviceworker.js is empty" >&2; exit 1; }
+DEMO_SHIM_SUM=$(cksum "$book_out/demo/coi-serviceworker.js" | cut -d' ' -f1)
+DEMO_SHIM_SRC_SUM=$(cksum "_extensions/blendtutor/assets/coi-serviceworker.js" | cut -d' ' -f1)
+if [ "$DEMO_SHIM_SUM" != "$DEMO_SHIM_SRC_SUM" ]; then
+  echo "docs: demo/coi-serviceworker.js not byte-identical to vendored shim" >&2
+  exit 1
+fi
+test -f "$book_out/.nojekyll" \
+  || { echo "docs: .nojekyll missing at artifact root ($book_out/)" >&2; exit 1; }
+
+# AC-2 — clause 10: the existing artifact survives assembly (no rm -rf clobber).
+for fname in "$book_out/index.html" \
+             "$book_out/api/blendtutor_core/index.html" \
+             "$book_out/examples/r/index.html" \
+             "$book_out/examples/python/index.html"; do
+  test -f "$fname" \
+    || { echo "docs: existing artifact clobbered by demo assembly — missing $fname" >&2; exit 1; }
+done
+
 # AC-6 — assert each example site has the required files: index.html,
 # lesson-runner.js, lessons/0.json (at least one lesson built), eval-results.html.
 for target_dir in "$book_out/examples/r" "$book_out/examples/python"; do
@@ -115,6 +183,21 @@ for needle in \
     || { echo "docs: $workflow missing build command: $needle" >&2; exit 1; }
 done
 
+# AC-2 (#152) — docs.yml contains the demo deploy steps (quarto setup, both
+# renders, COI post-process, dot-copy demo-book, root .nojekyll) so the local
+# mirror cannot silently diverge from CI.
+for needle in \
+  'quarto-dev/quarto-actions/setup@v2' \
+  'quarto render demo-book' \
+  'quarto render demo-standalone' \
+  'scripts/fix-demo-coi-scope.sh demo-standalone' \
+  'demo-book/_output/.' \
+  'docs/book/book/demo' \
+  'docs/book/book/.nojekyll'; do
+  grep -q "$needle" "$workflow" \
+    || { echo "docs: $workflow missing demo deploy step: $needle" >&2; exit 1; }
+done
+
 # AC-6 — README.md links to both example sites.
 for needle in 'examples/r/' 'examples/python/'; do
   grep -q "$needle" README.md \
@@ -135,4 +218,4 @@ grep -q 'examples/r/' "$book_out/examples.html" \
 grep -q 'examples/python/' "$book_out/examples.html" \
   || { echo "docs: built mdBook examples.html missing rendered link to examples/python/" >&2; exit 1; }
 
-echo "docs: OK — merged site at $book_out (book at /, API at /api, examples at /examples/{r,python})"
+echo "docs: OK — merged site at $book_out (book at /, API at /api, examples at /examples/{r,python}, demos at /demo-book/ + /demo/)"

--- a/scripts/tests/test_docs_pages_artifact.sh
+++ b/scripts/tests/test_docs_pages_artifact.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# Executable spec for issue #152 — deploy demo-book + demo-standalone to the
+# GitHub Pages artifact (/demo-book/ + /demo/) with a root .nojekyll.
+#
+# Verifies the 11-clause compound predicate from AC-2:
+#   1. build job block has quarto setup (quarto-dev/quarto-actions/setup@v2)
+#      — docs.yml has no quarto setup today, so a clean runner render fails
+#   2. build job renders demo-book (quarto render demo-book --to html)
+#   3. build job renders demo-standalone (quarto render demo-standalone --to html)
+#   4. scripts/fix-demo-coi-scope.sh demo-standalone runs AFTER the standalone
+#      render step and BEFORE the artifact-copy steps + upload (line-order pin)
+#   5. demo-book assembled via DOT-COPY: cp -R demo-book/_output/. — a bare cp
+#      would create a demo-book/_output/ layer (demo-book/_quarto.yml:3 pins
+#      output-dir: _output) and /demo-book/ would 404
+#   6. demo-standalone assembled SELECTIVELY into /demo/: index.html +
+#      index_files/ + coi-serviceworker.js only — no .qmd / _quarto.yml /
+#      _extensions/ leak into the public artifact
+#   7. explicit workflow step creates docs/book/book/.nojekyll at artifact ROOT
+#      (must not rely on the local untracked file)
+#   8. ALL new steps appear BEFORE actions/upload-pages-artifact@v5; NO || true,
+#      NO continue-on-error: true; render/copy steps in the build job block
+#      only, NOT the deploy job block (deploy has no checkout/quarto)
+#   9. scripts/check-docs.sh mirrors the new steps (mirror contract) and its
+#      render/assemble/assert section enforces the assembled-layout predicates
+#      (clauses 9-10 asserted by Phase 2's end-to-end check-docs.sh run; the
+#      structural greps here pin the mirror contract)
+#  10. existing artifact survives (mdBook index.html, api/, examples/) — no
+#      rm -rf docs/book/book/* clobber (asserted by check-docs.sh Phase 2)
+#  11. ci.yml quarto-render job runs this test (awk job-block pin, not file-wide)
+#
+# Negative cases (from the spec):
+#   - quarto setup step missing → render fails on clean runner → clause 1
+#   - || true / continue-on-error: true → silent-failure deploy of a broken
+#     artifact → clause 8 refusal-arm pin
+#   - cp -R demo-book/_output dst (no trailing /.) → extra _output/ layer →
+#     /demo-book/ 404 → clause 5 + check-docs demo-book/index.html existence
+#   - COI post-process skipped or run after copy → SW subdir scope → webR dead
+#     despite a green "coi present" grep → clause 4 order pin + check-docs
+#     exact ./coi-serviceworker.js src on the ASSEMBLED artifact
+#   - .nojekyll omitted from workflow (relying on local untracked file) or
+#     nested path → Quarto *_files/ dirs Jekyll-filtered in branch mode →
+#     clause 7 step pin + check-docs root-existence assert
+#   - new steps placed AFTER upload → artifact uploaded without demos →
+#     clause 8 line-order pin
+#   - render/copy steps in deploy job (no checkout, no quarto) → clause 8
+#     build-job-block scoping + deploy-block absence assert
+#   - rm -rf docs/book/book/* during assembly → mdBook/rustdoc/examples
+#     clobbered → clause 10 survival asserts in check-docs.sh
+#   - demo-standalone copied wholesale → .qmd/_quarto.yml/_extensions/ leak →
+#     clause 6 selective-copy pin + check-docs no-_extensions/ assert
+#   - check-docs.sh not updated → mirror contract silently broken → clause 9
+#     structural grep in Phase 1
+#
+# Usage: bash scripts/tests/test_docs_pages_artifact.sh
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+PASS=0
+FAIL=0
+
+ok() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+ko() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+DOCS_FILE=".github/workflows/docs.yml"
+CI_FILE=".github/workflows/ci.yml"
+CHECK_DOCS="scripts/check-docs.sh"
+
+# ---------------------------------------------------------------------------
+# Helpers — job-block extraction + relative line numbers
+# ---------------------------------------------------------------------------
+
+# Extract one job block from a workflow: starts at the 2-space-indented job
+# header (the header line itself is skipped so the range cannot self-close),
+# ends at the next 2-space-indented job header. Mirrors the AC-1 cycle-2
+# pattern — a file-wide grep is insufficient because a step that regressed to
+# the wrong job (e.g. deploy) would still pass it.
+job_block() {
+  local file="$1" job="$2"
+  awk -v job="^  $job:" '$0 ~ job {f=1;next} f&&/^  [a-z][a-z-]*:$/{f=0} f' "$file"
+}
+
+# Relative line number of the first occurrence of $2 in block $1 (empty if
+# none). Used for the clause-4/8 ordering pins within the build job block.
+block_line() {
+  grep -nF "$2" <<< "$1" | head -1 | cut -d: -f1 || true
+}
+
+# ---------------------------------------------------------------------------
+# Phase 1 — structural pins on docs.yml / ci.yml / check-docs.sh
+# ---------------------------------------------------------------------------
+
+echo "== Phase 1: structural pins (docs.yml build job) =="
+
+BUILD_BLOCK="$(job_block "$DOCS_FILE" build || true)"
+DEPLOY_BLOCK="$(job_block "$DOCS_FILE" deploy || true)"
+
+L_SETUP="$(block_line "$BUILD_BLOCK" 'quarto-dev/quarto-actions/setup@v2')"
+L_RENDER_BOOK="$(block_line "$BUILD_BLOCK" 'quarto render demo-book')"
+L_RENDER_SA="$(block_line "$BUILD_BLOCK" 'quarto render demo-standalone')"
+L_FIX="$(block_line "$BUILD_BLOCK" 'scripts/fix-demo-coi-scope.sh demo-standalone')"
+L_COPY_BOOK="$(block_line "$BUILD_BLOCK" 'demo-book/_output/.')"
+L_COPY_DEMO="$(block_line "$BUILD_BLOCK" 'cp demo-standalone/index.html')"
+L_NOJEKYLL="$(block_line "$BUILD_BLOCK" 'docs/book/book/.nojekyll')"
+L_UPLOAD="$(block_line "$BUILD_BLOCK" 'actions/upload-pages-artifact@v5')"
+
+# Clause 1 — quarto setup in the build job block (absent today: a clean
+# runner has no quarto and the render steps would fail).
+if [ -n "$L_SETUP" ]; then
+  ok "quarto setup in build job (quarto-dev/quarto-actions/setup@v2)"
+else
+  ko "quarto setup in build job (quarto-dev/quarto-actions/setup@v2) — missing"
+fi
+
+# Clause 2 — build job renders demo-book.
+if [ -n "$L_RENDER_BOOK" ]; then
+  ok "build job renders demo-book (quarto render demo-book --to html)"
+else
+  ko "build job renders demo-book (quarto render demo-book --to html) — missing"
+fi
+
+# Clause 3 — build job renders demo-standalone.
+if [ -n "$L_RENDER_SA" ]; then
+  ok "build job renders demo-standalone (quarto render demo-standalone --to html)"
+else
+  ko "build job renders demo-standalone (quarto render demo-standalone --to html) — missing"
+fi
+
+# Clause 4 — COI post-process present, after the standalone render, before copy.
+if [ -n "$L_FIX" ]; then
+  ok "COI post-process present (scripts/fix-demo-coi-scope.sh demo-standalone)"
+else
+  ko "COI post-process present (scripts/fix-demo-coi-scope.sh demo-standalone) — missing"
+fi
+
+# Clause 5 — dot-copy literal (trailing /.) for demo-book/_output.
+if [ -n "$L_COPY_BOOK" ]; then
+  ok "demo-book DOT-COPY literal (cp -R demo-book/_output/. — no _output/ layer)"
+else
+  ko "demo-book DOT-COPY literal (cp -R demo-book/_output/. — no _output/ layer) — missing"
+fi
+
+# Clause 6 — selective demo copy: index.html + index_files/ + coi-serviceworker.js.
+SELECTIVE_OK=0
+for needle in \
+  'cp demo-standalone/index.html' \
+  'cp -R demo-standalone/index_files' \
+  'cp demo-standalone/coi-serviceworker.js' \
+  'docs/book/book/demo'; do
+  grep -qF "$needle" <<< "$BUILD_BLOCK" && SELECTIVE_OK=$((SELECTIVE_OK + 1))
+done
+if [ "$SELECTIVE_OK" -eq 4 ]; then
+  ok "selective demo copy (index.html + index_files/ + coi-serviceworker.js → /demo/)"
+else
+  ko "selective demo copy — only $SELECTIVE_OK/4 selective-copy commands found in build job"
+fi
+
+# Clause 7 — explicit .nojekyll step at artifact ROOT.
+if [ -n "$L_NOJEKYLL" ]; then
+  ok ".nojekyll step at artifact root (touch docs/book/book/.nojekyll)"
+else
+  ko ".nojekyll step at artifact root (touch docs/book/book/.nojekyll) — missing"
+fi
+
+# Clause 8 — ordering: setup → demo-book render → demo-standalone render →
+# fix-coi → dot-copy demo-book → selective demo copy → .nojekyll → upload.
+ORDER_OK=1
+for ln in "$L_SETUP" "$L_RENDER_BOOK" "$L_RENDER_SA" "$L_FIX" "$L_COPY_BOOK" \
+          "$L_COPY_DEMO" "$L_NOJEKYLL" "$L_UPLOAD"; do
+  [ -n "$ln" ] || ORDER_OK=0
+done
+if [ "$ORDER_OK" -eq 1 ] \
+    && [ "$L_SETUP" -lt "$L_RENDER_BOOK" ] \
+    && [ "$L_RENDER_BOOK" -lt "$L_RENDER_SA" ] \
+    && [ "$L_RENDER_SA" -lt "$L_FIX" ] \
+    && [ "$L_FIX" -lt "$L_COPY_BOOK" ] \
+    && [ "$L_COPY_BOOK" -lt "$L_COPY_DEMO" ] \
+    && [ "$L_COPY_DEMO" -lt "$L_NOJEKYLL" ] \
+    && [ "$L_NOJEKYLL" -lt "$L_UPLOAD" ]; then
+  ok "ordering: setup → renders → fix-coi → copies → .nojekyll all BEFORE upload (clauses 4, 8)"
+else
+  ko "ordering: all new steps BEFORE upload with fix-coi after render, before copy — setup=$L_SETUP render_book=$L_RENDER_BOOK render_sa=$L_RENDER_SA fix=$L_FIX copy_book=$L_COPY_BOOK copy_demo=$L_COPY_DEMO nojekyll=$L_NOJEKYLL upload=$L_UPLOAD"
+fi
+
+# Clause 8 — refusal arms: no || true, no continue-on-error on any step.
+if grep -qE '\|\|\s*true' <<< "$BUILD_BLOCK"; then
+  ko "no '|| true' on build steps (silent-failure trap)"
+else
+  ok "no '|| true' on build steps"
+fi
+
+if grep -qF 'continue-on-error: true' <<< "$BUILD_BLOCK"; then
+  ko "no 'continue-on-error: true' on build steps (silent-failure trap)"
+else
+  ok "no 'continue-on-error: true' on build steps"
+fi
+
+# Clause 8 — build-job-block scoping: no render/copy steps leak into deploy.
+DEPLOY_LEAK=""
+for needle in 'quarto render' 'fix-demo-coi-scope' 'demo-book' 'demo-standalone' '.nojekyll'; do
+  if grep -qF "$needle" <<< "$DEPLOY_BLOCK"; then
+    DEPLOY_LEAK="$DEPLOY_LEAK $needle"
+  fi
+done
+if [ -z "$DEPLOY_LEAK" ]; then
+  ok "no render/copy steps in deploy job block"
+else
+  ko "no render/copy steps in deploy job block — leaked:$DEPLOY_LEAK"
+fi
+
+echo "== Phase 1: structural pins (ci.yml quarto-render job) =="
+
+# Clause 11 — ci.yml quarto-render job runs this test (awk job-block pin).
+QR_BLOCK="$(job_block "$CI_FILE" quarto-render || true)"
+if grep -qF 'scripts/tests/test_docs_pages_artifact.sh' <<< "$QR_BLOCK"; then
+  ok "CI quarto-render job runs test_docs_pages_artifact.sh"
+else
+  ko "CI quarto-render job runs test_docs_pages_artifact.sh — not found in quarto-render job block"
+fi
+
+echo "== Phase 1: structural pins (check-docs.sh mirror contract) =="
+
+# Clause 9 (structural half) — check-docs.sh mirrors the new build steps so
+# the local mirror cannot silently diverge from CI.
+MIRROR_OK=0
+for needle in \
+  'quarto render demo-book' \
+  'quarto render demo-standalone' \
+  'scripts/fix-demo-coi-scope.sh demo-standalone' \
+  'demo-book/_output/.' \
+  'cp demo-standalone/index.html' \
+  'cp -R demo-standalone/index_files' \
+  'cp demo-standalone/coi-serviceworker.js' \
+  '.nojekyll'; do
+  grep -qF "$needle" "$CHECK_DOCS" && MIRROR_OK=$((MIRROR_OK + 1))
+done
+if [ "$MIRROR_OK" -eq 8 ]; then
+  ok "check-docs.sh mirrors the new build steps (8/8 commands found)"
+else
+  ko "check-docs.sh mirrors the new build steps — only $MIRROR_OK/8 commands found"
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 2 — local render + assemble + assert (check-docs.sh end-to-end)
+# ---------------------------------------------------------------------------
+
+echo "== Phase 2: local render + assemble + assert (check-docs.sh) =="
+
+# Clause 9-10 (assert half) live in check-docs.sh's render/assemble/assert
+# section: full local build (mdBook + rustdoc + examples + demo renders) then
+# assembled-layout asserts (demo-book/index.html not under _output/,
+# demo/index.html coi src exactly ./coi-serviceworker.js with no _extensions/,
+# shim byte-identical to vendored, root .nojekyll, existing artifact survives).
+# SKIP (exit 0) when any required tool is absent — CI's quarto-render job only
+# has quarto, so this phase is exercised locally and on dev machines.
+if ! command -v quarto &>/dev/null || ! command -v mdbook &>/dev/null \
+    || ! command -v cargo &>/dev/null; then
+  echo "  SKIP: quarto/mdbook/cargo not all installed — Phase 2 skipped"
+  echo "  (Phase 1 structural assertions are the CI-enforced half)"
+else
+  if bash "$CHECK_DOCS"; then
+    ok "check-docs.sh renders + assembles + asserts the artifact layout (clauses 9-10)"
+  else
+    ko "check-docs.sh renders + assembles + asserts the artifact layout (clauses 9-10)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "========================================="
+echo "  Results: $PASS passed, $FAIL failed"
+echo "========================================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+
+echo "All tests passed."


### PR DESCRIPTION
## Summary

Extends the docs.yml build job to render **demo-book** + **demo-standalone** into the Pages artifact at `/demo-book/` + `/demo/` (mirroring the existing `/api` + `/examples/{r,python}` nesting), runs the COI scope post-process before copy/upload, and adds a root `.nojekyll`.

**Copy-semantics findings (resolver-verified, confirmed by local render):**
- `demo-book/_quarto.yml:3` pins `output-dir: _output` → a bare `cp -R demo-book/_output dst` would create a `demo-book/_output/` layer and `/demo-book/` would 404. The workflow uses **dot-copy** (`cp -R demo-book/_output/.`), verified by the assembled-layout assert (`docs/book/book/demo-book/index.html` exists, no `_output/` dir).
- `demo-standalone` renders beside its source → **selective copy** (index.html + index_files/ + coi-serviceworker.js only) so `.qmd` sources / `_quarto.yml` / `_extensions/` never leak into the public artifact.
- COI post-process (`scripts/fix-demo-coi-scope.sh demo-standalone`, AC-1) runs **after** render, **before** copy, so the assembled page serves `./coi-serviceworker.js` at page root — SW scope covers the page or R exercises are silent-dead on Pages.

**Quarto setup finding:** docs.yml had no quarto installation at all — added `quarto-dev/quarto-actions/setup@v2` (the render steps would fail on a clean runner otherwise).

## Issue

Closes #152

## ACs implemented

- [x] docs.yml build job: quarto setup@v2, render demo-book, render demo-standalone, fix-demo-coi-scope.sh AFTER render BEFORE copy/upload (line-order pinned), dot-copy demo-book → /demo-book/, selective demo copy → /demo/, touch root .nojekyll — all BEFORE upload-pages-artifact; no `|| true`/`continue-on-error`; nothing in deploy job
- [x] check-docs.sh mirrors the steps and asserts the assembled layout (demo/index.html coi src exactly `./coi-serviceworker.js`, no `_extensions/` in coi tag, shim byte-identical cksum, demo-book not under `_output/`, root `.nojekyll`, mdBook/api/examples survive)
- [x] ci.yml quarto-render job runs `scripts/tests/test_docs_pages_artifact.sh` (awk job-block pin)

## Test plan

- [x] `bash scripts/tests/test_docs_pages_artifact.sh` — 14/14 passed (Phase 1 structural pins + Phase 2 full local render/assemble/assert via check-docs.sh, exit 0)
- [x] Local end-to-end: `bash scripts/check-docs.sh` exit 0 — assembled artifact verified (evidence at `docs/evidence/152/`)
- [x] Regression: test_demo_standalone_render.sh, test_quarto_filter.sh, test_quarto_bootstrap.sh, test_quarto_asset_deployment.sh, test_quarto_distribution.sh, test_coi_filter.sh, test_quarto_install_render.sh, test_quarto_ux.py (46), test_quarto_feedback.py (32), sync-quarto-assets.sh + `git diff --exit-code`, verify_asset_scoping.py — all green
- [x] PR review findings resolved (n/a — first cycle)

## Self-Review

- [x] All ACs exercised by tests
- [x] Predicates match spec (11 clauses)
- [x] Negative case tested
- [x] Verification medium satisfied (code — structural + local render/assemble/assert; no browser, live = AC-3/AC-4)
- [x] Design intent respected
- [x] No scope creep (fix-demo-coi-scope.sh untouched; only docs.yml/check-docs.sh/ci.yml + new test)

## Evidence

- `docs/evidence/152/assembled-artifact-layout.txt` — assembled layout listing + coi src + shim cksum + survivors
- `docs/evidence/152/docs-yml-steps.txt` — build-job step list
- `docs/evidence/152/test-suite.log` — 14/14
