### PR TITLE
[feature] verify-live post-deploy alarm job in docs.yml (AC-3 probe vs live URL, rodney COI wrapper)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,17 @@ jobs:
       - name: Pages artifact assembly test
         run: bash scripts/tests/test_docs_pages_artifact.sh
 
+      # Issue #156 — Verify-live wiring test. Phase 1 pins the docs.yml
+      # verify-live job (needs: deploy, deploy outputs: page_url,
+      # DEPLOYED_URL = needs.deploy.outputs.page_url + /demo/, live probe,
+      # no continue-on-error / exit-swallow / if: always(), checkout +
+      # setup-uv + setup-node, deploy does NOT need verify-live) via awk
+      # job-block extraction. Phase 2 stubs Chrome via REAL_CHROME=/bin/echo
+      # and asserts rodney-chrome.sh strips the COI-breaking flags. Phase 3
+      # pins ROD_CHROME_BIN harness wiring + rodney==0.4.0.
+      - name: Verify-live wiring test
+        run: bash scripts/tests/test_verify_live_wiring.sh
+
   asset-parity:
     name: asset parity
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -122,6 +122,12 @@ jobs:
     name: deploy to Pages
     needs: build
     runs-on: ubuntu-latest
+    # Job-level outputs: the built site URL. deploy-pages publishes and emits
+    # the live URL via the step id; job-level outputs are the ONLY way to pass
+    # it across job boundaries (step outputs do NOT survive needs:), so the
+    # verify-live alarm job can build DEPLOYED_URL from it (AC-4).
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
     # Job-level permissions replace the workflow defaults: the Pages deploy needs
     # the OIDC token write + pages write, and nothing else (it consumes the
     # artifact the build job uploaded; it does not check out the repo).
@@ -135,3 +141,32 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+
+  # Post-deploy alarm — runs AC-3 probe against live URL; failure is NOT a gate
+  # (deploy already published).
+  verify-live:
+    name: verify live demo (AC-3 probe)
+    needs: deploy
+    runs-on: ubuntu-latest
+    # Probe wall-time ~4.5min (COI 30s + webR 120s + pyodide 60s); the alarm
+    # must outlive the probe so a slow-but-healthy site is not killed mid-run.
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      # uvx rodney (pinned rodney==0.4.0 in pages-live.js) requires uv.
+      - uses: astral-sh/setup-uv@v5
+
+      # Defensive node pin over the ubuntu-latest default.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      # AC-3 probe against the LIVE URL: DEPLOYED_URL = Pages site root
+      # (needs.deploy.outputs.page_url, trailing slash) + demo/ nest. The
+      # harness (pages-live.js) sets ROD_CHROME_BIN to scripts/rodney-chrome.sh
+      # itself, so the committed wrapper strips rodney 0.4.0's isolation-
+      # breaking Chrome flags. No continue-on-error / || true / if: always():
+      # a probe failure FAILS this job — that is the alarm.
+      - name: Verify live demo (rodney COI probe)
+        run: DEPLOYED_URL="${{ needs.deploy.outputs.page_url }}demo/" uv run node rodney-probes/pages-live.js live

--- a/.opencode/plans/github-pages-deploy/AC-4.md
+++ b/.opencode/plans/github-pages-deploy/AC-4.md
@@ -1,0 +1,102 @@
+---
+ac: 4
+depends_on: [2, 3]
+risk: high
+status: complete
+---
+
+# AC-4: verify-live post-deploy alarm job in docs.yml + rodney COI-flag workaround
+
+## Executable Spec (resolver-merged, 16 clauses)
+- predicate: given AC-2 merged (deploy job, step id `deployment`) and AC-3 merged (`rodney-probes/pages-live.js` with DEPLOYED_URL env + live arg + exit-code contract), when .github/workflows/docs.yml is structurally inspected (awk job-block extraction, per test_demo_standalone_render.sh:115 pattern — PR #151 cycle-2 lesson), then:
+  1. `^  verify-live:` exists as top-level job key in docs.yml, block start line > deploy block end line (job declared after deploy)
+  2. `needs: deploy` appears INSIDE the verify-live job block (awk-extracted, NOT file-wide grep)
+  3. deploy job block declares job-level `outputs:` with `page_url: ${{ steps.deployment.outputs.page_url }}` (step outputs do NOT cross job boundaries — without this needs.deploy.outputs.page_url is empty)
+  4. `DEPLOYED_URL` env in verify-live references `needs.deploy.outputs.page_url` (NOT steps.deployment.outputs) AND includes `demo` path suffix — page_url yields site ROOT with trailing slash; harness expects demo dir root
+  5. probe invocation contains `pages-live.js live` (live mode — NOT local)
+  6. NO `continue-on-error` key anywhere in verify-live job block
+  7. probe `run:` line contains NO exit-code swallow (`|| true`, `|| exit 0`, `|| :`, `; true`, `&& true`)
+  8. verify-live job does NOT declare `if: always()` (runs only when deploy succeeds)
+  9. `actions/checkout` appears in verify-live job block (deploy job does NOT checkout; probe file must exist on runner)
+  10. `astral-sh/setup-uv` step present in verify-live job block (`uvx rodney` requires uv)
+  11. node available: `actions/setup-node` step present (defensive pin over ubuntu-latest default)
+  12. deploy job block does NOT declare `needs: verify-live` (post-deploy alarm, NOT a gate — inversion check)
+  13. ALL assertions use awk job-block extraction — NOT file-wide `grep -q` on docs.yml (PR #151 cycle-1 regression guard)
+  14. runtime COI fix: `scripts/rodney-chrome.sh` committed + executable; wrapper strips `--single-process`, `--disable-site-isolation-trials`, and the whole `--disable-features=...` arg from argv, then execs real Chrome with resolution order `$REAL_CHROME` → macOS /Applications/Google Chrome.app/Contents/MacOS/Google Chrome → Linux /usr/bin/google-chrome → Chromium.orig fallback; preserves rodney-supplied --no-sandbox --disable-dev-shm-usage. (rodney 0.4.0 hardcodes poison flags unconditionally — rodney main.go:356, go-rod launcher.go:75,91; no upstream fix; without wrapper crossOriginIsolated never true → AC-3 P2 coi_failure → verify-live permanently red)
+  15. ROD_CHROME_BIN wired to the wrapper: EITHER verify-live job env sets `ROD_CHROME_BIN` → scripts/rodney-chrome.sh (belt-and-suspenders), OR the harness sets it itself. NOTE: post-AC-3-fix, pages-live.js sets ROD_CHROME_BIN to the wrapper unless caller overrides (verified at 9a50c01) — harness-level setting satisfies this clause; job-level explicit set optional. Test may grep either location.
+  16. rodney pinned: probe invocation in pages-live.js uses `execFileSync("uvx", ["--from", "rodney==0.4.0", "rodney", ...])` (prevents silent drift to a future rodney that changes flags/behavior; landed at 9a50c01)
+- probe:
+  bash scripts/tests/test_verify_live_wiring.sh
+  Test structure (NEW file, AC-1/AC-2 ok()/ko() counter pattern, exit 1 on fail):
+  - Phase 1 workflow structural: awk-extract verify-live: and deploy: blocks from docs.yml; per-clause grep assertions clauses 1-12 against correct block; line-number compare clause 1 ordering; awk-extract quarto-render: block from ci.yml → assert test_verify_live_wiring.sh step present (wiring, AC-2 clause 11 pattern)
+  - Phase 2 wrapper unit test (no browser): stub real Chrome via REAL_CHROME=/bin/echo; run bash scripts/rodney-chrome.sh --no-sandbox --single-process --disable-site-isolation-trials --disable-features=site-per-process --disable-dev-shm-usage about:blank; assert argv (a) no --single-process/--disable-site-isolation-trials/--disable-features, (b) keeps --no-sandbox --disable-dev-shm-usage + trailing about:blank (clause 14)
+  - Phase 3 env + pin static assertions: grep for ROD_CHROME_BIN wiring (clause 15 — either job env OR harness set; check pages-live.js for ROD_CHROME_BIN + wrapper path); grep rodney-probes/pages-live.js for literal `--from` + `rodney==0.4.0` (clause 16)
+  - Phase 4: none — live probe execution is the workflow's job at deploy time; first real push to main confirms end-to-end (manual, one-time)
+- negative (13):
+  1. verify-live job omitted → clause 1
+  2. probe wired into deploy job (no separate alarm job) → clauses 1 + 12
+  3. `needs: build` instead of `needs: deploy` → runs pre/concurrent with deploy, page_url empty, probe 404s → clause 2
+  4. deploy outputs: block missing → needs.deploy.outputs.page_url empty → DEPLOYED_URL = demo/ relative → probe curls wrong root → clause 3
+  5. DEPLOYED_URL = page_url verbatim (no /demo/) → harness navigates to site root (mdBook), no .cm-editor → verify-live ALWAYS red → clause 4
+  6. DEPLOYED_URL hardcoded instead of needs-output → breaks org rename / branch preview → clause 4
+  7. probe invoked as pages-live.js local → local static server, never touches live URL → silent-pass → clause 5
+  8. continue-on-error: true → alarm silenced (most dangerous sneaky-pass) → clause 6
+  9. `uv run node ... || true` → exit swallowed → clause 7
+  10. if: always() → runs on failed/skipped deploy → false alarm every time → clause 8
+  11. no actions/checkout → probe file absent → infra failure masks demo health → clause 9
+  12. file-wide grep -q verify-live in test → passes if job commented out or needs: deploy lands in wrong job → clause 13
+  13. runtime COI: wrapper missing/not executable, OR ROD_CHROME_BIN unwired → rodney 0.4.0 launches Chrome with poison flags → crossOriginIsolated never true → AC-3 P2 coi_failure → verify-live PERMANENTLY red from deploy #1 → clauses 14 + 15. Sub-case: wrapper strips only exact site-per-process → combined --disable-features arg partially survives → Phase 2 full-arg-strip assertion kills
+- verification: code · shell structural test (awk YAML + wrapper argv stub) + manual (one-time: first real push to main triggers verify-live green)
+- fixture status: EDIT .github/workflows/docs.yml (deploy job gains outputs: after header, keep needs: build; NEW verify-live job appended at EOF); NEW scripts/tests/test_verify_live_wiring.sh; NEW scripts/rodney-chrome.sh (landed at 9a50c01 on AC-3 branch — confirm present, EDIT if wrapper committed but executable bit or strip logic differs); EDIT .github/workflows/ci.yml (append one step in quarto-render job after AC-2's test step); rodney-probes/pages-live.js pin (landed at 9a50c01 — READ-ONLY unless pin regression)
+- rubric anchor: §4.1 (job-boundary responsibility — verify-live = run AC-3 probe against live URL, fail job on probe failure; NOT gate deploy, NOT implement probe logic), §5.1 (one job one concern, one ok/ko per clause), §3.1 (alarm-not-gate job seam), §1.1 (awk job-block extraction makes assertion-belongs-to-this-job unrepresentable-as-wrong)
+
+## Design Intent
+- Types / interfaces (§1): job-level outputs: page_url is the typed cross-job interface; clause 3 pins exact expression so contract cannot drift from environment-url reference at docs.yml:96. ROD_CHROME_BIN env is the typed interface between CI job and rodney launcher
+- Pure / effectful (§2): pure = awk extraction + grep assertions on YAML + wrapper argv stub test; effectful = actual probe run (browser, network, live site) — exercised only on real deploy, delegated to AC-3
+- Boundary cuts (§3): deploy (publishes) vs verify-live (post-deploy alarm) split at job seam; URL composition page_url + /demo/ marks site-root vs demo-nest boundary; wrapper script isolates rodney's Chrome-launch defect at the binary-swap seam (no rodney fork)
+- Module responsibility (§4): docs.yml deploy job owns publishing; verify-live owns post-deploy verification + runner environment; rodney-chrome.sh owns flag-sanitization only; test owns CI enforcement; probe harness stays AC-3-owned
+- Function discipline (§5): each verify-live step one thing (checkout, setup-uv, setup-node, single probe run line); wrapper does one thing (argv filter + exec); one ok/ko per clause
+
+## Technical Context
+- Files likely touched: .github/workflows/docs.yml:84-100 (deploy block + append verify-live); .github/workflows/ci.yml:54-119 (quarto-render test step); NEW scripts/tests/test_verify_live_wiring.sh; scripts/rodney-chrome.sh (EXISTS at 9a50c01 — verify, don't recreate); rodney-probes/pages-live.js (pin + ROD_CHROME_BIN landed at 9a50c01 — READ-ONLY unless regression)
+- Architecture notes:
+  - rodney 0.4.0 poison flags UNCONDITIONAL (main.go:356 + go-rod launcher.go:75,91); no flag override; only ROD_CHROME_BIN binary-swap or rodney connect escape. Binary-swap chosen (validated); rodney connect rejected (externally-managed Chrome lifecycle in CI, more moving parts)
+  - On ubuntu-latest, go-rod downloads own Chromium r1321438 (~120-150MB per run) — wrapper redirects to preinstalled /usr/bin/google-chrome, eliminating download AND poison flags
+  - Harness post-fix (9a50c01): pages-live.js sets ROD_CHROME_BIN → wrapper unless caller set — self-sufficient on any machine; verify-live job explicit set is optional belt-and-suspenders
+  - COI on Pages achieved via coi-serviceworker.js v0.1.7 shim (SW re-serves with COOP/COEP); shim works ONLY if Chrome doesn't cripple site isolation — clause 14 load-bearing
+  - COEP credentialless + CDN risk (webR cdn.r-wasm.org, pyodide cdn.jsdelivr.net): live-only; failure → AC-3 exec_failure (correct, distinct alarm)
+  - CDN propagation race post-deploy: AC-3 curl HEAD pre-check responsibility; optional sleep 5 (not a clause)
+  - Probe wall-time ~4.5min (COI 30s + webR 120s + pyodide 60s); recommend timeout-minutes: 15 (not a clause)
+  - Evidence: harness writes probe-report.json + rodney.log; optional upload-artifact step (not a clause)
+  - verify-live job header comment: "Post-deploy alarm — runs AC-3 probe against live URL; failure is NOT a gate (deploy already published)."
+- AC-3 dependency note: AC-3 (issue #153) branch 153-live-probe has the wrapper + pin at 9a50c01 — merge AC-3 BEFORE AC-4 (AC-4 depends on it; conflict set: rodney-probes/pages-live.js + scripts/rodney-chrome.sh serialized)
+
+## Dependencies
+- Depends on: AC-2 (docs.yml deploy job + step id deployment — MERGED #154); AC-3 (pages-live.js committed with wrapper + pin + DEPLOYED_URL/live/exit-code contract — branch 153-live-probe, must merge first)
+- Blocks: none (terminal alarm AC)
+- Conflict set: .github/workflows/docs.yml (AC-2 first — merged; AC-4 appends); .github/workflows/ci.yml (AC-2 first — merged; AC-4 appends); rodney-probes/pages-live.js + scripts/rodney-chrome.sh (AC-3 owns; AC-4 READ-ONLY after AC-3 merge)
+- Risk: high (raised from medium) — cross-job output mechanism new wiring AND runtime COI failure mode would make job permanently red from deploy #1; clauses 14-16 mitigation is fix-now. Residual live-only risks (COEP/CDN) are AC-3's domain and alarm-correct
+
+## Decision Log
+- resolver — naming: test_verify_live_wiring.sh over A's test_verify_live_job.sh (matches wiring-test vocabulary + test_demo_standalone_render.sh convention)
+- resolver — clause base: B's P1-P13 adopted wholesale (subsumes A's 7; B adds checkout/if:always/awk-mandate sneaky-passes). A's line-ordering merged INTO clause 1
+- resolver — NEW clauses 14-16 + negative 13: merged from runtime-COI research finding — NEITHER proposer had it; without it job permanently red. Risk medium → high
+- resolver — B's P11 documented-reliance → hardened to A's explicit setup-node requirement
+- resolver — rodney connect rejected (more moving parts than binary-swap)
+- resolver — disagreement=minor; all resolved w/o user input
+- Director — clause 15 adjusted post-resolver: AC-3 fix (9a50c01) makes harness set ROD_CHROME_BIN itself; job-level explicit set optional. Test may grep either.
+
+### Progress
+- [x] spec resolved (resolver) — done
+- [x] red: test_verify_live_wiring.sh — 2026-08-04: 10 pass / 9 fail (verify-live job absent on main), commit d264a36
+- [x] green: docs.yml verify-live job + deploy outputs — 2026-08-04: 19/19 pass, commit 8574764
+- [x] evidence docs/evidence/156/ — 2026-08-04: test-suite.log + verify-live-job-listing.txt + wrapper-argv-capture.txt, commit (evidence)
+
+### Surprises & Discoveries
+- Absence-grep false positives: the verify-live job header comment literally contains "No continue-on-error / || true / if: always()", so block-wide absence greps for clauses 6/8 matched the PROSE, not keys. Fixed by stripping comment-only lines (`grep -vE '^[[:space:]]*#'`) before the key greps and scoping clause 7 to the awk-extracted probe RUN LINE (spec pins the run line, not the block). The green run caught the false positives; red run couldn't (empty block → absent greps trivially passed). Lesson: absence clauses on YAML must match code (keys / run lines), never prose — comment-stripping is the cheap guard.
+- Evidence-capture zsh trap: the wrapper argv evidence script passed flags via an unquoted `$ARGV` variable; zsh does NOT word-split unquoted variables, so the wrapper received the whole flag list as ONE argument and stripped nothing (blob arg doesn't match any strip pattern). The wrapper itself is correct — the test (run under bash with literal args) proves 0 occurrences of each poison flag. Evidence capture must use literal args, not variable expansion, when run from a zsh shell tool.
+- Clause 3 deploy outputs placement: job-level `outputs:` inserted after `runs-on:` in the deploy header, before `permissions:` — keeps `needs: build` and step id `deployment` intact (AC-2 contract preserved; test_docs_pages_artifact.sh still 14/14).
+
+### Idempotence & Recovery
+- Safe retry: re-run test_verify_live_wiring.sh (structural, idempotent).
+- Rollback: git checkout -- .github/workflows/docs.yml .github/workflows/ci.yml; rm scripts/tests/test_verify_live_wiring.sh

--- a/docs/evidence/156/test-suite.log
+++ b/docs/evidence/156/test-suite.log
@@ -1,0 +1,28 @@
+== Phase 1: structural pins (docs.yml verify-live job) ==
+  PASS: verify-live top-level job declared after deploy block (line 147 > deploy end 146)
+  PASS: verify-live needs deploy (job-block pin)
+  PASS: deploy job declares outputs: page_url from steps.deployment.outputs (cross-job interface)
+  PASS: DEPLOYED_URL = needs.deploy.outputs.page_url + /demo/ suffix
+  PASS: probe runs pages-live.js in live mode
+  PASS: no continue-on-error in verify-live job
+  PASS: probe run line swallows no exit codes (no || true / || exit 0 / || : / ; true / && true)
+  PASS: no if: always() on verify-live job
+  PASS: actions/checkout in verify-live job (probe file must exist on runner)
+  PASS: astral-sh/setup-uv in verify-live job (uvx rodney requires uv)
+  PASS: actions/setup-node in verify-live job (node for probe)
+  PASS: deploy does NOT need verify-live (post-deploy alarm, not a gate)
+== Phase 1: structural pins (ci.yml quarto-render job) ==
+  PASS: CI quarto-render job runs test_verify_live_wiring.sh
+== Phase 2: rodney COI wrapper (clause 14) ==
+  PASS: scripts/rodney-chrome.sh committed and executable
+  PASS: wrapper resolution order: $REAL_CHROME → macOS Chrome → /usr/bin/google-chrome → Chromium.orig (4/4)
+  PASS: wrapper strips --single-process / --disable-site-isolation-trials / whole --disable-features=* arg (argv: --no-sandbox --disable-dev-shm-usage about:blank)
+  PASS: wrapper keeps --no-sandbox --disable-dev-shm-usage + trailing about:blank (argv: --no-sandbox --disable-dev-shm-usage about:blank)
+== Phase 3: ROD_CHROME_BIN wiring + rodney pin (clauses 15-16) ==
+  PASS: ROD_CHROME_BIN wired to wrapper (harness sets it: pages-live.js → scripts/rodney-chrome.sh)
+  PASS: rodney pinned uvx --from rodney==0.4.0
+
+=========================================
+  Results: 19 passed, 0 failed
+=========================================
+All tests passed.

--- a/docs/evidence/156/verify-live-job-listing.txt
+++ b/docs/evidence/156/verify-live-job-listing.txt
@@ -1,0 +1,63 @@
+# docs.yml — deploy job outputs (clause 3) + verify-live job listing (clause 1-12)
+# awk-extracted via job_block pattern (per test_demo_standalone_render.sh:115 / clause 13)
+
+## deploy job block (awk extraction) — outputs: page_url present
+    name: deploy to Pages
+    needs: build
+    runs-on: ubuntu-latest
+    # Job-level outputs: the built site URL. deploy-pages publishes and emits
+    # the live URL via the step id; job-level outputs are the ONLY way to pass
+    # it across job boundaries (step outputs do NOT survive needs:), so the
+    # verify-live alarm job can build DEPLOYED_URL from it (AC-4).
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
+    # Job-level permissions replace the workflow defaults: the Pages deploy needs
+    # the OIDC token write + pages write, and nothing else (it consumes the
+    # artifact the build job uploaded; it does not check out the repo).
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5
+
+  # Post-deploy alarm — runs AC-3 probe against live URL; failure is NOT a gate
+  # (deploy already published).
+
+## verify-live job block (awk extraction) — declared AFTER deploy block end
+    name: verify live demo (AC-3 probe)
+    needs: deploy
+    runs-on: ubuntu-latest
+    # Probe wall-time ~4.5min (COI 30s + webR 120s + pyodide 60s); the alarm
+    # must outlive the probe so a slow-but-healthy site is not killed mid-run.
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      # uvx rodney (pinned rodney==0.4.0 in pages-live.js) requires uv.
+      - uses: astral-sh/setup-uv@v5
+
+      # Defensive node pin over the ubuntu-latest default.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      # AC-3 probe against the LIVE URL: DEPLOYED_URL = Pages site root
+      # (needs.deploy.outputs.page_url, trailing slash) + demo/ nest. The
+      # harness (pages-live.js) sets ROD_CHROME_BIN to scripts/rodney-chrome.sh
+      # itself, so the committed wrapper strips rodney 0.4.0's isolation-
+      # breaking Chrome flags. No continue-on-error / || true / if: always():
+      # a probe failure FAILS this job — that is the alarm.
+      - name: Verify live demo (rodney COI probe)
+        run: DEPLOYED_URL="${{ needs.deploy.outputs.page_url }}demo/" uv run node rodney-probes/pages-live.js live
+
+## Job header line numbers (clause 1: verify-live start > deploy end)
+deploy: line 121
+verify-live: line 147
+
+## DEPLOYED_URL run line (clauses 4-5, 7):
+172:        run: DEPLOYED_URL="${{ needs.deploy.outputs.page_url }}demo/" uv run node rodney-probes/pages-live.js live

--- a/docs/evidence/156/wrapper-argv-capture.txt
+++ b/docs/evidence/156/wrapper-argv-capture.txt
@@ -1,0 +1,30 @@
+# rodney-chrome.sh argv capture (Phase 2, clause 14) — Chrome stubbed via REAL_CHROME=/bin/echo
+# No browser launched; the wrapper's argv filter + exec is what AC-4 wires.
+
+## Invocation (same literal args as test Phase 2):
+REAL_CHROME=/bin/echo bash scripts/rodney-chrome.sh --no-sandbox --single-process \
+  --disable-site-isolation-trials --disable-features=site-per-process \
+  --disable-dev-shm-usage about:blank
+
+## Actual argv passed to Chrome (wrapper output):
+    --no-sandbox --disable-dev-shm-usage about:blank
+
+## Per-flag occurrence counts in wrapper output (0 = stripped, 1+ = kept):
+  --single-process:                    0 occurrence(s)
+  --disable-site-isolation-trials:     0 occurrence(s)
+  --disable-features:                  0 occurrence(s)
+  --no-sandbox:                        1 occurrence(s)
+  --disable-dev-shm-usage:             1 occurrence(s)
+  about:blank:                         1 occurrence(s)
+  (about:blank must be the TRAILING arg — output ends with it: yes)
+
+## Wrapper static facts (clause 14):
+  -rwxr-xr-x@ 1 carbonite  staff  3533 Aug  4 13:35 scripts/rodney-chrome.sh
+  resolution order strings present:
+    34:  if [[ -n "${REAL_CHROME:-}" && -x "${REAL_CHROME}" ]]; then
+    35:    printf '%s\n' "${REAL_CHROME}"
+    39:  local mac_chrome="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    45:  local linux_chrome="/usr/bin/google-chrome"
+    56:      if [[ -x "${dir}/Chromium.orig" ]]; then
+    57:        printf '%s\n' "${dir}/Chromium.orig"
+    71:  echo "rodney-chrome.sh: no real Chrome found. Set REAL_CHROME to a Chrome/Chromium binary path (e.g. REAL_CHROME=/path/to/chrome). Checked: \$REAL_CHROME, /Applications/Google Chrome.app/Contents/MacOS/Google Chrome, /usr/bin/google-chrome, ~/.cache/rod/browser/chromium-*/*.orig" >&2

--- a/scripts/tests/test_verify_live_wiring.sh
+++ b/scripts/tests/test_verify_live_wiring.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# Executable spec for issue #156 — verify-live post-deploy alarm job in
+# docs.yml (AC-3 probe vs live URL, rodney COI wrapper).
+#
+# Verifies the 16-clause compound predicate from AC-4:
+#   Phase 1 — workflow structural pins (clauses 1-13): docs.yml gains a
+#     verify-live job AFTER the deploy block (line-order pin, clause 1) that
+#     needs deploy (2); deploy declares job-level outputs: page_url from
+#     steps.deployment.outputs (3 — step outputs do NOT cross job boundaries);
+#     DEPLOYED_URL = needs.deploy.outputs.page_url + /demo/ suffix (4);
+#     probe runs pages-live.js in LIVE mode (5); no continue-on-error (6);
+#     no exit-code swallow on the run line (7); no if: always() (8);
+#     actions/checkout present (9); astral-sh/setup-uv present (10);
+#     actions/setup-node present (11); deploy does NOT need verify-live
+#     (12 — alarm, not gate, inversion check). ALL docs.yml assertions use
+#     awk job-block extraction, NEVER file-wide grep (13). ci.yml
+#     quarto-render job runs this test (wiring, AC-2 clause-11 pattern).
+#   Phase 2 — wrapper unit test (clause 14): scripts/rodney-chrome.sh exists +
+#     executable, resolution order $REAL_CHROME → macOS Chrome →
+#     /usr/bin/google-chrome → Chromium.orig; stub Chrome via
+#     REAL_CHROME=/bin/echo and assert the wrapper strips
+#     --single-process / --disable-site-isolation-trials / the whole
+#     --disable-features=... arg while keeping --no-sandbox +
+#     --disable-dev-shm-usage and the trailing about:blank.
+#   Phase 3 — env + pin (clauses 15-16): pages-live.js wires ROD_CHROME_BIN
+#     to the wrapper itself (harness-level setting satisfies clause 15 —
+#     post-AC-3-fix at 9a50c01; job-level explicit set is optional
+#     belt-and-suspenders); rodney pinned via uvx --from rodney==0.4.0.
+#   Phase 4: none — live probe execution is the workflow's job at deploy
+#     time; the first real push to main confirms it (manual, one-time).
+#
+# Negative cases (from the spec):
+#   - verify-live job omitted → clause 1
+#   - probe wired into deploy job (no separate alarm job) → clauses 1 + 12
+#   - needs: build instead of needs: deploy → runs pre/concurrent with deploy,
+#     page_url empty, probe 404s → clause 2
+#   - deploy outputs: block missing → needs.deploy.outputs.page_url empty →
+#     DEPLOYED_URL = demo/ relative → wrong root → clause 3
+#   - DEPLOYED_URL = page_url verbatim (no /demo/) → mdBook root, no
+#     .cm-editor → verify-live ALWAYS red → clause 4
+#   - DEPLOYED_URL hardcoded instead of needs-output → breaks org rename /
+#     branch preview → clause 4
+#   - probe invoked as pages-live.js local → local static server, never
+#     touches live URL → silent-pass → clause 5
+#   - continue-on-error: true → alarm silenced (most dangerous sneaky-pass)
+#     → clause 6
+#   - uv run node ... || true → exit swallowed → clause 7
+#   - if: always() → runs on failed/skipped deploy → false alarm every time
+#     → clause 8
+#   - no actions/checkout → probe file absent → infra failure masks demo
+#     health → clause 9
+#   - file-wide grep -q verify-live → passes if job commented out or needs:
+#     deploy lands in the wrong job → clause 13 (this test uses awk
+#     extraction everywhere)
+#   - wrapper missing/not executable, OR ROD_CHROME_BIN unwired → rodney
+#     0.4.0 launches Chrome with poison flags → crossOriginIsolated never
+#     true → verify-live PERMANENTLY red from deploy #1 → clauses 14 + 15.
+#     Sub-case: wrapper strips only the exact site-per-process value → the
+#     combined --disable-features=... arg partially survives → Phase 2
+#     full-arg-strip assertion kills it.
+#
+# Usage: bash scripts/tests/test_verify_live_wiring.sh
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+PASS=0
+FAIL=0
+
+ok() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+ko() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+DOCS_FILE=".github/workflows/docs.yml"
+CI_FILE=".github/workflows/ci.yml"
+WRAPPER="scripts/rodney-chrome.sh"
+PROBE="rodney-probes/pages-live.js"
+
+# ---------------------------------------------------------------------------
+# Helpers — job-block extraction + job header line numbers
+# ---------------------------------------------------------------------------
+
+# Extract one job block from a workflow: starts at the 2-space-indented job
+# header (the header line itself is skipped so the range cannot self-close),
+# ends at the next 2-space-indented job header. Mirrors the AC-1 cycle-2
+# pattern — a file-wide grep is insufficient because a step that regressed to
+# the wrong job (e.g. deploy) would still pass it (clause 13).
+job_block() {
+  local file="$1" job="$2"
+  awk -v job="^  $job:" '$0 ~ job {f=1;next} f&&/^  [a-z][a-z-]*:$/{f=0} f' "$file"
+}
+
+# File line number of a 2-space-indented job header (empty if absent).
+job_line() {
+  local file="$1" job="$2"
+  awk -v job="^  $job:" '$0 ~ job {print NR; exit}' "$file"
+}
+
+# ---------------------------------------------------------------------------
+# Phase 1 — workflow structural pins (clauses 1-13)
+# ---------------------------------------------------------------------------
+
+echo "== Phase 1: structural pins (docs.yml verify-live job) =="
+
+DEPLOY_BLOCK="$(job_block "$DOCS_FILE" deploy || true)"
+VERIFY_BLOCK="$(job_block "$DOCS_FILE" verify-live || true)"
+DEPLOY_LINE="$(job_line "$DOCS_FILE" deploy || true)"
+VERIFY_LINE="$(job_line "$DOCS_FILE" verify-live || true)"
+
+# Clause 1 — verify-live is a top-level job key declared AFTER the deploy
+# block ends (block start line > deploy block end line).
+NEXT_AFTER_DEPLOY="$(awk -v dl="${DEPLOY_LINE:-0}" 'NR>dl && /^  [a-z][a-z-]*:$/{print NR; exit}' "$DOCS_FILE" || true)"
+if [ -n "$NEXT_AFTER_DEPLOY" ]; then
+  DEPLOY_END=$((NEXT_AFTER_DEPLOY - 1))
+else
+  DEPLOY_END="$(wc -l < "$DOCS_FILE" | tr -d ' ')"
+fi
+if [ -n "$VERIFY_LINE" ] && [ -n "$DEPLOY_LINE" ] && [ "$VERIFY_LINE" -gt "$DEPLOY_END" ]; then
+  ok "verify-live top-level job declared after deploy block (line $VERIFY_LINE > deploy end $DEPLOY_END)"
+else
+  ko "verify-live top-level job declared after deploy block (verify_line=$VERIFY_LINE deploy_line=$DEPLOY_LINE deploy_end=$DEPLOY_END)"
+fi
+
+# Clause 2 — needs: deploy INSIDE the verify-live block (awk-extracted, not
+# file-wide grep).
+if grep -qF 'needs: deploy' <<< "$VERIFY_BLOCK"; then
+  ok "verify-live needs deploy (job-block pin)"
+else
+  ko "verify-live needs deploy (job-block pin) — missing"
+fi
+
+# Clause 3 — deploy job declares job-level outputs: page_url from
+# steps.deployment.outputs (step outputs do NOT cross job boundaries).
+if grep -qF 'outputs:' <<< "$DEPLOY_BLOCK" \
+    && grep -qF 'page_url: ${{ steps.deployment.outputs.page_url }}' <<< "$DEPLOY_BLOCK"; then
+  ok "deploy job declares outputs: page_url from steps.deployment.outputs (cross-job interface)"
+else
+  ko "deploy job declares outputs: page_url from steps.deployment.outputs — missing"
+fi
+
+# Clause 4 — DEPLOYED_URL references needs.deploy.outputs.page_url AND
+# includes the demo path suffix (page_url yields site ROOT; harness expects
+# demo dir root).
+if grep -qF 'needs.deploy.outputs.page_url' <<< "$VERIFY_BLOCK" \
+    && grep -qF 'demo/' <<< "$VERIFY_BLOCK"; then
+  ok "DEPLOYED_URL = needs.deploy.outputs.page_url + /demo/ suffix"
+else
+  ko "DEPLOYED_URL = needs.deploy.outputs.page_url + /demo/ suffix — missing needs.deploy output ref or demo/ suffix"
+fi
+
+# Clause 5 — probe invocation in LIVE mode (NOT local).
+if grep -qF 'pages-live.js live' <<< "$VERIFY_BLOCK"; then
+  ok "probe runs pages-live.js in live mode"
+else
+  ko "probe runs pages-live.js in live mode — missing"
+fi
+
+# Clause 6 — no continue-on-error anywhere in the verify-live job block
+# (a true value would silence the alarm).
+if grep -qF 'continue-on-error' <<< "$VERIFY_BLOCK"; then
+  ko "no continue-on-error in verify-live job (silent-alarm trap)"
+else
+  ok "no continue-on-error in verify-live job"
+fi
+
+# Clause 7 — probe run line swallows no exit codes.
+SWALLOW=""
+for pat in '|| true' '|| exit 0' '|| :' '; true' '&& true'; do
+  if grep -qF "$pat" <<< "$VERIFY_BLOCK"; then
+    SWALLOW="$SWALLOW '$pat'"
+  fi
+done
+if [ -z "$SWALLOW" ]; then
+  ok "probe run line swallows no exit codes (no || true / || exit 0 / || : / ; true / && true)"
+else
+  ko "probe run line swallows no exit codes — found:$SWALLOW"
+fi
+
+# Clause 8 — no if: always() (runs only when deploy succeeds; always() would
+# false-alarm on failed/skipped deploys).
+if grep -qF 'if: always()' <<< "$VERIFY_BLOCK"; then
+  ko "no if: always() on verify-live job (runs only when deploy succeeds)"
+else
+  ok "no if: always() on verify-live job"
+fi
+
+# Clause 9 — actions/checkout present (deploy does NOT checkout; the probe
+# file must exist on the runner).
+if grep -qF 'actions/checkout' <<< "$VERIFY_BLOCK"; then
+  ok "actions/checkout in verify-live job (probe file must exist on runner)"
+else
+  ko "actions/checkout in verify-live job — missing"
+fi
+
+# Clause 10 — astral-sh/setup-uv present (uvx rodney requires uv).
+if grep -qF 'astral-sh/setup-uv' <<< "$VERIFY_BLOCK"; then
+  ok "astral-sh/setup-uv in verify-live job (uvx rodney requires uv)"
+else
+  ko "astral-sh/setup-uv in verify-live job — missing"
+fi
+
+# Clause 11 — actions/setup-node present (defensive pin over the
+# ubuntu-latest default node).
+if grep -qF 'actions/setup-node' <<< "$VERIFY_BLOCK"; then
+  ok "actions/setup-node in verify-live job (node for probe)"
+else
+  ko "actions/setup-node in verify-live job — missing"
+fi
+
+# Clause 12 — deploy job block does NOT declare needs: verify-live
+# (post-deploy alarm, NOT a gate — inversion check).
+if grep -qF 'needs: verify-live' <<< "$DEPLOY_BLOCK"; then
+  ko "deploy does NOT need verify-live (post-deploy alarm, not a gate)"
+else
+  ok "deploy does NOT need verify-live (post-deploy alarm, not a gate)"
+fi
+
+# Clause 13 — all docs.yml assertions above use awk job-block extraction
+# (this file), NOT file-wide grep. Satisfied by construction of this test.
+
+echo "== Phase 1: structural pins (ci.yml quarto-render job) =="
+
+QR_BLOCK="$(job_block "$CI_FILE" quarto-render || true)"
+if grep -qF 'scripts/tests/test_verify_live_wiring.sh' <<< "$QR_BLOCK"; then
+  ok "CI quarto-render job runs test_verify_live_wiring.sh"
+else
+  ko "CI quarto-render job runs test_verify_live_wiring.sh — not found in quarto-render job block"
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 2 — rodney COI wrapper (clause 14)
+# ---------------------------------------------------------------------------
+
+echo "== Phase 2: rodney COI wrapper (clause 14) =="
+
+# Static: wrapper committed + executable.
+if [ -f "$WRAPPER" ] && [ -x "$WRAPPER" ]; then
+  ok "scripts/rodney-chrome.sh committed and executable"
+else
+  ko "scripts/rodney-chrome.sh committed and executable — missing or not executable"
+fi
+
+# Static: resolution order $REAL_CHROME → macOS Chrome →
+# /usr/bin/google-chrome → Chromium.orig fallback.
+RESOLVE_OK=0
+for needle in 'REAL_CHROME' '/Applications/Google Chrome.app' '/usr/bin/google-chrome' 'Chromium.orig'; do
+  grep -qF "$needle" "$WRAPPER" && RESOLVE_OK=$((RESOLVE_OK + 1))
+done
+if [ "$RESOLVE_OK" -eq 4 ]; then
+  ok "wrapper resolution order: \$REAL_CHROME → macOS Chrome → /usr/bin/google-chrome → Chromium.orig (4/4)"
+else
+  ko "wrapper resolution order — only $RESOLVE_OK/4 resolution strings found in $WRAPPER"
+fi
+
+# Behavioral (no browser): stub Chrome via REAL_CHROME=/bin/echo; the wrapper
+# must strip the 3 COI-breaking flag classes and exec echo with the rest.
+WRAPPER_OUT="$(REAL_CHROME=/bin/echo bash "$WRAPPER" \
+  --no-sandbox --single-process --disable-site-isolation-trials \
+  --disable-features=site-per-process --disable-dev-shm-usage about:blank 2>&1)"
+
+LEAKED=""
+for flag in '--single-process' '--disable-site-isolation-trials' '--disable-features'; do
+  if grep -qF -- "$flag" <<< "$WRAPPER_OUT"; then
+    LEAKED="$LEAKED '$flag'"
+  fi
+done
+if [ -z "$LEAKED" ]; then
+  ok "wrapper strips --single-process / --disable-site-isolation-trials / whole --disable-features=* arg (argv: $WRAPPER_OUT)"
+else
+  ko "wrapper strips the 3 COI-breaking flag classes — leaked:$LEAKED (argv: $WRAPPER_OUT)"
+fi
+
+KEPT_OK=1
+for needle in '--no-sandbox' '--disable-dev-shm-usage'; do
+  grep -qF -- "$needle" <<< "$WRAPPER_OUT" || KEPT_OK=0
+done
+if [ "$KEPT_OK" -eq 1 ] && [[ "$WRAPPER_OUT" == *"about:blank" ]] \
+    && [[ "${WRAPPER_OUT##* }" == "about:blank" ]]; then
+  ok "wrapper keeps --no-sandbox --disable-dev-shm-usage + trailing about:blank (argv: $WRAPPER_OUT)"
+else
+  ko "wrapper keeps --no-sandbox --disable-dev-shm-usage + trailing about:blank (argv: $WRAPPER_OUT)"
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 3 — ROD_CHROME_BIN wiring + rodney pin (clauses 15-16)
+# ---------------------------------------------------------------------------
+
+echo "== Phase 3: ROD_CHROME_BIN wiring + rodney pin (clauses 15-16) =="
+
+# Clause 15 — ROD_CHROME_BIN wired to the wrapper. The harness sets it
+# itself (post-AC-3-fix at 9a50c01: pages-live.js sets ROD_CHROME_BIN to
+# scripts/rodney-chrome.sh unless the caller overrode it) — harness-level
+# setting satisfies this clause; job-level explicit set is optional
+# belt-and-suspenders. Documented: grep of the HARNESS, not the job env.
+if grep -qF 'ROD_CHROME_BIN' "$PROBE" \
+    && grep -qF 'rodney-chrome.sh' "$PROBE"; then
+  ok "ROD_CHROME_BIN wired to wrapper (harness sets it: pages-live.js → scripts/rodney-chrome.sh)"
+else
+  ko "ROD_CHROME_BIN wired to wrapper — pages-live.js must set ROD_CHROME_BIN to the wrapper"
+fi
+
+# Clause 16 — rodney pinned: uvx --from rodney==0.4.0 (prevents silent drift
+# to a future rodney that changes flags/behavior).
+if grep -qF -e '--from' "$PROBE" && grep -qF 'rodney==0.4.0' "$PROBE"; then
+  ok "rodney pinned uvx --from rodney==0.4.0"
+else
+  ko "rodney pinned uvx --from rodney==0.4.0 — --from or rodney==0.4.0 missing in pages-live.js"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "========================================="
+echo "  Results: $PASS passed, $FAIL failed"
+echo "========================================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+
+echo "All tests passed."

--- a/scripts/tests/test_verify_live_wiring.sh
+++ b/scripts/tests/test_verify_live_wiring.sh
@@ -106,6 +106,12 @@ VERIFY_BLOCK="$(job_block "$DOCS_FILE" verify-live || true)"
 DEPLOY_LINE="$(job_line "$DOCS_FILE" deploy || true)"
 VERIFY_LINE="$(job_line "$DOCS_FILE" verify-live || true)"
 
+# Comment-only lines (e.g. the job header's "No continue-on-error / || true"
+# prose) must not trip the absence greps — the clauses pin KEYS and the RUN
+# LINE, not documentation prose. Strip comment lines for key greps; clause 7
+# greps the extracted run line directly.
+VERIFY_BLOCK_CODE="$(grep -vE '^[[:space:]]*#' <<< "$VERIFY_BLOCK" || true)"
+
 # Clause 1 — verify-live is a top-level job key declared AFTER the deploy
 # block ends (block start line > deploy block end line).
 NEXT_AFTER_DEPLOY="$(awk -v dl="${DEPLOY_LINE:-0}" 'NR>dl && /^  [a-z][a-z-]*:$/{print NR; exit}' "$DOCS_FILE" || true)"
@@ -154,30 +160,32 @@ else
   ko "probe runs pages-live.js in live mode — missing"
 fi
 
-# Clause 6 — no continue-on-error anywhere in the verify-live job block
+# Clause 6 — no continue-on-error key anywhere in the verify-live job block
 # (a true value would silence the alarm).
-if grep -qF 'continue-on-error' <<< "$VERIFY_BLOCK"; then
+if grep -qF 'continue-on-error' <<< "$VERIFY_BLOCK_CODE"; then
   ko "no continue-on-error in verify-live job (silent-alarm trap)"
 else
   ok "no continue-on-error in verify-live job"
 fi
 
-# Clause 7 — probe run line swallows no exit codes.
+# Clause 7 — the probe RUN LINE swallows no exit codes (spec pins the run
+# line, not prose).
+RUN_LINE="$(grep -F 'pages-live.js live' <<< "$VERIFY_BLOCK" | head -1 || true)"
 SWALLOW=""
 for pat in '|| true' '|| exit 0' '|| :' '; true' '&& true'; do
-  if grep -qF "$pat" <<< "$VERIFY_BLOCK"; then
+  if grep -qF "$pat" <<< "$RUN_LINE"; then
     SWALLOW="$SWALLOW '$pat'"
   fi
 done
 if [ -z "$SWALLOW" ]; then
   ok "probe run line swallows no exit codes (no || true / || exit 0 / || : / ; true / && true)"
 else
-  ko "probe run line swallows no exit codes — found:$SWALLOW"
+  ko "probe run line swallows no exit codes — found:$SWALLOW (run line: $RUN_LINE)"
 fi
 
-# Clause 8 — no if: always() (runs only when deploy succeeds; always() would
-# false-alarm on failed/skipped deploys).
-if grep -qF 'if: always()' <<< "$VERIFY_BLOCK"; then
+# Clause 8 — no if: always() declared on the verify-live job (runs only when
+# deploy succeeds; always() would false-alarm on failed/skipped deploys).
+if grep -qF 'if: always()' <<< "$VERIFY_BLOCK_CODE"; then
   ko "no if: always() on verify-live job (runs only when deploy succeeds)"
 else
   ok "no if: always() on verify-live job"


### PR DESCRIPTION
## Summary

Adds a **verify-live** post-deploy alarm job to `docs.yml` (github-pages-deploy AC-4). After `deploy` publishes the site, verify-live runs the AC-3 rodney probe (`rodney-probes/pages-live.js`) against the **live** URL and fails the job if the probe fails — an alarm, NOT a gate: deploy does not depend on verify-live.

- **deploy job** gains job-level `outputs: page_url: ${{ steps.deployment.outputs.page_url }}` — step outputs do not cross job boundaries; this is the typed cross-job interface verify-live consumes.
- **verify-live job** (appended after the deploy block): `needs: deploy`; runs `DEPLOYED_URL="${{ needs.deploy.outputs.page_url }}demo/" uv run node rodney-probes/pages-live.js live` — page_url yields the site root, `/demo/` suffix targets the demo nest. checkout + setup-uv + setup-node (node 22) present; `timeout-minutes: 15` covers the ~4.5 min probe wall time. No `continue-on-error`, no exit-code swallow, no `if: always()` — a probe failure fails the job, which is the alarm.
- **rodney COI wrapper**: `scripts/rodney-chrome.sh` (AC-3-owned, READ-ONLY here) strips rodney 0.4.0's isolation-breaking Chrome flags; wired via the harness — `pages-live.js` sets `ROD_CHROME_BIN` to the wrapper itself. rodney pinned `uvx --from rodney==0.4.0`.
- **ci.yml** quarto-render job runs `scripts/tests/test_verify_live_wiring.sh` after AC-2's artifact test.

## Issue

Closes #156

## ACs implemented

- [x] docs.yml gains verify-live job (needs: deploy, after deploy block) + deploy job outputs: page_url; DEPLOYED_URL = needs.deploy.outputs.page_url + /demo/; probe runs pages-live.js live; no continue-on-error / no exit-swallow / no if: always; checkout + setup-uv + setup-node present; deploy does NOT depend on verify-live
- [x] rodney COI wrapper (scripts/rodney-chrome.sh, AC-3 9a50c01) strips --single-process/--disable-site-isolation-trials/--disable-features and execs real Chrome; ROD_CHROME_BIN wired (harness sets it); rodney pinned rodney==0.4.0
- [x] scripts/tests/test_verify_live_wiring.sh: Phase 1 awk job-block pins (16 clauses), Phase 2 wrapper argv stub test (REAL_CHROME=/bin/echo), Phase 3 env+pin assertions; runs in ci.yml quarto-render job

## Test plan

- [x] **RED confirmed**: `test_verify_live_wiring.sh` 9 FAIL pre-edit (verify-live job absent on main) → **GREEN 19/19** after implementation
- [x] Phase 1: awk job-block extraction pins clauses 1-13 (verify-live after deploy, needs: deploy, deploy outputs page_url, DEPLOYED_URL + /demo/, live mode, no continue-on-error/exit-swallow/if: always, checkout + setup-uv + setup-node, deploy does not need verify-live, ci.yml wiring) — clause 13 awk-extraction-by-construction, no file-wide grep
- [x] Phase 2: wrapper argv stub `REAL_CHROME=/bin/echo` — 3 poison flag classes stripped (0 occurrences), --no-sandbox + --disable-dev-shm-usage + trailing about:blank kept; wrapper executable + resolution order present
- [x] Phase 3: ROD_CHROME_BIN harness wiring (pages-live.js → scripts/rodney-chrome.sh) + rodney==0.4.0 pin
- [x] AC-2 regression gate: `test_docs_pages_artifact.sh` 14/14 pass (deploy outputs addition did not break the artifact contract)
- [x] Both workflow YAMLs parse (YAML.safe_load: jobs build/deploy/verify-live)

## Self-Review

- [x] All ACs exercised by tests
- [x] Predicates match spec (16 clauses from .opencode/plans/github-pages-deploy/AC-4.md)
- [x] Negative case tested (absent-job red; absence-grep refusal arms; wrapper strip assertions)
- [x] Verification medium satisfied (code — shell structural + wrapper argv stub)
- [x] Design intent respected — alarm-not-gate preserved (deploy does NOT need verify-live); job-boundary responsibility: deploy publishes, verify-live verifies, wrapper sanitizes flags, harness stays AC-3-owned
- [x] No scope creep — rodney-probes/pages-live.js + scripts/rodney-chrome.sh READ-ONLY verified, not modified

## Evidence

- `docs/evidence/156/test-suite.log` — full run, 19 passed / 0 failed
- `docs/evidence/156/verify-live-job-listing.txt` — awk-extracted deploy outputs + verify-live block, clause-1 line-order (verify-live line 147 > deploy end 146)
- `docs/evidence/156/wrapper-argv-capture.txt` — stub capture: poison flags 0 occurrences, kept flags + trailing about:blank

**NOTE:** the first real push to main after merge triggers the verify-live live probe end-to-end (browser + network + live URL) — manual one-time confirmation per spec Phase 4.