### PR TITLE
[feature] Switch BYOK key storage to localStorage with clearKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Set one in the browser when prompted:
 - `ANTHROPIC_API_KEY` — [Anthropic](https://www.anthropic.com) (browser BYOK is
   Anthropic-only).
 
-The key is stored in the browser's `sessionStorage` and never sent to a server
+The key is stored in the browser's `localStorage` and never sent to a server
 other than the LLM provider.
 
 #### Feedback opt-in (manual)
@@ -283,7 +283,7 @@ import { mountAllFeedback } from "./_extensions/mcmullarkey/blendtutor/assets/ex
 mountAllFeedback(registry);
 ```
 
-The API key is entered once and shared across exercises via `sessionStorage`.
+The API key is entered once and shared across exercises via `localStorage`.
 
 ### Cross-origin isolation (COI)
 

--- a/_extensions/blendtutor/assets/exercise-feedback.js
+++ b/_extensions/blendtutor/assets/exercise-feedback.js
@@ -1,6 +1,6 @@
 // exercise-feedback.js — per-exercise BYOK LLM feedback (AC-7).
 //
-// WHAT:  Per-exercise feedback UI + shared sessionStorage key + ?provider= override.
+// WHAT:  Per-exercise feedback UI + shared localStorage key + ?provider= override.
 // WHERE: _extensions/blendtutor/assets/exercise-feedback.js
 // NOT:   NOT execution (exercise-runtime.js), NOT filter (blendtutor.lua),
 //        NOT CodeMirror editor, NOT prompt construction beyond the pure builder.
@@ -18,7 +18,7 @@
 //   toVerdict, fireworksRequest, fireworksToVerdict, providerBaseUrl.
 //   These are byte-identical to the Rust core::llm prompt constants (ADR-0006).
 //
-// Shared sessionStorage (key entered once, reused across exercises):
+// Shared localStorage (key entered once, reused across exercises):
 //   readKey/storeKey use provider-scoped slots (fireworks_api_key,
 //   anthropic_api_key) — NOT exercise-scoped. The key entered for exercise 1
 //   is reused for exercise 2 without re-prompting (clause 1 + clause 3).
@@ -51,12 +51,12 @@ export const OUTPUT_LABEL = "<<<CAPTURED_OUTPUT>>>";
 export const CHECKS_LABEL = "<<<CHECK_RESULTS>>>";
 const NEUTRALIZED = "[neutralized-delimiter]";
 
-// --- provider map + key handling (sessionStorage, tab-scoped) -------------------
+// --- provider map + key handling (localStorage, persistent) ----------------------
 
-// The closed set of providers. Each entry carries the tab-scoped
-// sessionStorage slot for the learner's key (provider-scoped, NOT
-// exercise-scoped — the key is entered once and reused across exercises),
-// the base URL, the fallback model, and the FeedbackBackend factory.
+// The closed set of providers. Each entry carries the persistent localStorage
+// slot for the learner's key (provider-scoped, NOT exercise-scoped — the key is
+// entered once and reused across exercises), the base URL, the fallback model,
+// and the FeedbackBackend factory.
 export const PROVIDERS = {
   fireworks: {
     label: "Fireworks",
@@ -79,12 +79,12 @@ export const DEFAULT_PROVIDER = "fireworks";
 // verify BOTH are present. Each matches the dynamic disclosure renderKeyPrompt
 // builds from PROVIDERS[id].label so the disclosure is never stale.
 const PROVIDER_DISCLOSURES = {
-  fireworks: "Your Fireworks API key is stored only in this tab (this browser " +
-    "tab's sessionStorage) and sent only to Fireworks to fetch feedback — never " +
-    "to this site's server or any third party.",
-  anthropic: "Your Anthropic API key is stored only in this tab (this browser " +
-    "tab's sessionStorage) and sent only to Anthropic to fetch feedback — never " +
-    "to this site's server or any third party.",
+  fireworks: "Your Fireworks API key is stored in this browser (localStorage) " +
+    "and sent only to Fireworks to fetch feedback — never to this site's " +
+    "server or any third party.",
+  anthropic: "Your Anthropic API key is stored in this browser (localStorage) " +
+    "and sent only to Anthropic to fetch feedback — never to this site's " +
+    "server or any third party.",
 };
 
 const TOOL_NAME = "respond_with_feedback";
@@ -128,7 +128,7 @@ export function buildPrompt({ task, code, output, checks }) {
   ].join("\n");
 }
 
-// --- key handling (sessionStorage, tab-scoped, SHARED across exercises) -----------
+// --- key handling (localStorage, persistent, SHARED across exercises) -------------
 //
 // The key slot is provider-scoped (fireworks_api_key / anthropic_api_key), NOT
 // exercise-scoped. This is the contract that makes "key entered once, reused
@@ -136,20 +136,35 @@ export function buildPrompt({ task, code, output, checks }) {
 // the same slot without re-prompting (clause 1 + clause 3).
 
 export function readKey(providerId) {
-  return window.sessionStorage.getItem(PROVIDERS[providerId].keySlot);
+  try {
+    return window.localStorage.getItem(PROVIDERS[providerId].keySlot);
+  } catch (_error) {
+    // localStorage unavailable (private mode / file://) → degrade to "no key"
+    // so the submit flow renders the key prompt instead of crashing.
+    return null;
+  }
 }
 
 export function storeKey(key, providerId) {
-  window.sessionStorage.setItem(PROVIDERS[providerId].keySlot, key);
+  window.localStorage.setItem(PROVIDERS[providerId].keySlot, key);
+}
+
+// Scoped removal: the provider's key AND the feedback counter. Deliberately NOT
+// localStorage.clear() — unrelated app state (byok_provider, anthropic_api_key,
+// quarto-reader-mode, quarto-persistent-tabsets-data) survives. Removing the
+// counter is what un-locks a rate-capped learner (the counter is persistent now).
+export function clearKey(providerId) {
+  window.localStorage.removeItem(PROVIDERS[providerId].keySlot);
+  window.localStorage.removeItem(FEEDBACK_COUNT_KEY);
 }
 
 export function readProvider() {
-  const stored = window.sessionStorage.getItem("byok_provider");
+  const stored = window.localStorage.getItem("byok_provider");
   return stored && Object.hasOwn(PROVIDERS, stored) ? stored : DEFAULT_PROVIDER;
 }
 
 export function storeProvider(providerId) {
-  window.sessionStorage.setItem("byok_provider", providerId);
+  window.localStorage.setItem("byok_provider", providerId);
 }
 
 // The provider base URL. A `?provider=` override is the test seam (point rodney
@@ -359,7 +374,7 @@ function byokFireworks({ baseUrl, apiKey }) {
   };
 }
 
-// --- rate limiting (sessionStorage counter, ported from feedback.js) ------------
+// --- rate limiting (localStorage counter, ported from feedback.js) ---------------
 
 const FEEDBACK_COUNT_KEY = "bt_feedback_count";
 
@@ -367,20 +382,23 @@ const FEEDBACK_COUNT_KEY = "bt_feedback_count";
 // non-integer. The parseInt + || 0 guard ensures a corrupt value never yields
 // NaN (which would silently disable limiting — the negative case from the spec).
 export function feedbackCount() {
-  return parseInt(sessionStorage.getItem(FEEDBACK_COUNT_KEY)) || 0;
+  return parseInt(localStorage.getItem(FEEDBACK_COUNT_KEY)) || 0;
 }
 
-// Whether the learner has reached the per-session feedback request limit.
+// Whether the learner has reached the per-browser feedback request limit. The
+// counter lives in localStorage, so the cap is persistent across tabs and
+// reloads; clearKey() resets it. The maxFeedbackPerSession config key keeps its
+// name (smallest correct move) but now caps PER-BROWSER, not per-session.
 export function rateLimitReached() {
   const max =
     (window.__btConfig && window.__btConfig.maxFeedbackPerSession) || 0;
   return feedbackCount() >= max;
 }
 
-// Increment the per-session feedback request counter. Called AFTER the try/catch
+// Increment the per-browser feedback request counter. Called AFTER the try/catch
 // in handleSubmitForExercise — both successful and failed requests count.
 export function incrementFeedbackCount() {
-  sessionStorage.setItem(FEEDBACK_COUNT_KEY, String(feedbackCount() + 1));
+  localStorage.setItem(FEEDBACK_COUNT_KEY, String(feedbackCount() + 1));
 }
 
 // --- the per-exercise submit flow (effectful shell, REWRITTEN) -------------------
@@ -388,7 +406,7 @@ export function incrementFeedbackCount() {
 // The old feedback.js used a singleton #feedback container and window.__bt.
 // This module uses per-exercise containers (created in mountFeedback) and the
 // AC-4 registry entry's getSubmission(). The key handling is shared
-// (sessionStorage), so the key entered for exercise 1 is reused for exercise 2.
+// (localStorage), so the key entered for exercise 1 is reused for exercise 2.
 
 // Read the current lesson + the learner's code from the per-exercise registry
 // entry — no reach into runner internals (§3.4). The code comes from
@@ -409,7 +427,7 @@ function currentSubmissionForExercise(entry) {
 
 // Prompt the learner for a provider + key, with per-provider disclosure. The
 // provider chooser renders a <select data-byok="provider">. The key is stored
-// in the selected provider's sessionStorage slot (shared across exercises).
+// in the selected provider's localStorage slot (shared across exercises).
 function renderKeyPrompt(container) {
   const form = document.createElement("form");
   form.dataset.byok = "key-prompt";
@@ -503,7 +521,7 @@ function renderLimitReached(container) {
   const note = document.createElement("p");
   note.dataset.byok = "limit-reached";
   note.textContent =
-    "Feedback request limit reached for this session. Reload the page to reset.";
+    "Feedback request limit reached for this browser. Clear your saved API key to reset.";
   container.replaceChildren(note);
 }
 
@@ -558,7 +576,7 @@ function selectedModel(container, providerId) {
 //   picker shown     → build the prompt and send feedback through the chosen
 //                      provider's backend, using the chosen model.
 //
-// The provider + key are read from SHARED sessionStorage (entered once, reused).
+// The provider + key are read from SHARED localStorage (entered once, reused).
 // The submission is read from the per-exercise registry entry. The verdict
 // renders into the per-exercise container (no cross-exercise bleed).
 //
@@ -618,7 +636,7 @@ async function handleSubmitForExercise(entry) {
 // --- embedded key (build-time --embed-key, ported) ------------------------------
 //
 // Apply an embedded API key (if present). The decrypt shell sets
-// window.__btEmbeddedKey; applyEmbeddedKey stores it in sessionStorage and
+// window.__btEmbeddedKey; applyEmbeddedKey stores it in localStorage and
 // clears the global, so handleSubmitForExercise's key-entry phase is skipped
 // naturally. Exported, NOT called at module load — the caller invokes it before
 // mountAllFeedback (§2.1: no module-level effectful code).
@@ -637,7 +655,7 @@ export function applyEmbeddedKey() {
 // div.bt-exercise. Each exercise gets its own UI — no singleton #feedback.
 // The button triggers handleSubmitForExercise(entry), which reads the
 // submission from entry.getSubmission() (the per-exercise editor) and the key
-// from shared sessionStorage (entered once, reused).
+// from shared localStorage (entered once, reused).
 export function mountFeedback(entry) {
   // Create the feedback container inside the exercise div.
   const feedbackContainer = document.createElement("div");
@@ -669,7 +687,7 @@ export function mountFeedback(entry) {
 // Mount feedback UI for every exercise in the registry. Called by the page
 // AFTER start(registry, adapters) boots the runtime — each exercise already has
 // its editor + Run button wired by exercise-runtime.js. This adds the feedback
-// button + container per-exercise, using the shared sessionStorage key.
+// button + container per-exercise, using the shared localStorage key.
 export function mountAllFeedback(registry) {
   applyEmbeddedKey();
   for (const entry of registry) {

--- a/demo-book/_extensions/mcmullarkey/blendtutor/assets/exercise-feedback.js
+++ b/demo-book/_extensions/mcmullarkey/blendtutor/assets/exercise-feedback.js
@@ -1,6 +1,6 @@
 // exercise-feedback.js — per-exercise BYOK LLM feedback (AC-7).
 //
-// WHAT:  Per-exercise feedback UI + shared sessionStorage key + ?provider= override.
+// WHAT:  Per-exercise feedback UI + shared localStorage key + ?provider= override.
 // WHERE: _extensions/blendtutor/assets/exercise-feedback.js
 // NOT:   NOT execution (exercise-runtime.js), NOT filter (blendtutor.lua),
 //        NOT CodeMirror editor, NOT prompt construction beyond the pure builder.
@@ -18,7 +18,7 @@
 //   toVerdict, fireworksRequest, fireworksToVerdict, providerBaseUrl.
 //   These are byte-identical to the Rust core::llm prompt constants (ADR-0006).
 //
-// Shared sessionStorage (key entered once, reused across exercises):
+// Shared localStorage (key entered once, reused across exercises):
 //   readKey/storeKey use provider-scoped slots (fireworks_api_key,
 //   anthropic_api_key) — NOT exercise-scoped. The key entered for exercise 1
 //   is reused for exercise 2 without re-prompting (clause 1 + clause 3).
@@ -51,12 +51,12 @@ export const OUTPUT_LABEL = "<<<CAPTURED_OUTPUT>>>";
 export const CHECKS_LABEL = "<<<CHECK_RESULTS>>>";
 const NEUTRALIZED = "[neutralized-delimiter]";
 
-// --- provider map + key handling (sessionStorage, tab-scoped) -------------------
+// --- provider map + key handling (localStorage, persistent) ----------------------
 
-// The closed set of providers. Each entry carries the tab-scoped
-// sessionStorage slot for the learner's key (provider-scoped, NOT
-// exercise-scoped — the key is entered once and reused across exercises),
-// the base URL, the fallback model, and the FeedbackBackend factory.
+// The closed set of providers. Each entry carries the persistent localStorage
+// slot for the learner's key (provider-scoped, NOT exercise-scoped — the key is
+// entered once and reused across exercises), the base URL, the fallback model,
+// and the FeedbackBackend factory.
 export const PROVIDERS = {
   fireworks: {
     label: "Fireworks",
@@ -79,12 +79,12 @@ export const DEFAULT_PROVIDER = "fireworks";
 // verify BOTH are present. Each matches the dynamic disclosure renderKeyPrompt
 // builds from PROVIDERS[id].label so the disclosure is never stale.
 const PROVIDER_DISCLOSURES = {
-  fireworks: "Your Fireworks API key is stored only in this tab (this browser " +
-    "tab's sessionStorage) and sent only to Fireworks to fetch feedback — never " +
-    "to this site's server or any third party.",
-  anthropic: "Your Anthropic API key is stored only in this tab (this browser " +
-    "tab's sessionStorage) and sent only to Anthropic to fetch feedback — never " +
-    "to this site's server or any third party.",
+  fireworks: "Your Fireworks API key is stored in this browser (localStorage) " +
+    "and sent only to Fireworks to fetch feedback — never to this site's " +
+    "server or any third party.",
+  anthropic: "Your Anthropic API key is stored in this browser (localStorage) " +
+    "and sent only to Anthropic to fetch feedback — never to this site's " +
+    "server or any third party.",
 };
 
 const TOOL_NAME = "respond_with_feedback";
@@ -128,7 +128,7 @@ export function buildPrompt({ task, code, output, checks }) {
   ].join("\n");
 }
 
-// --- key handling (sessionStorage, tab-scoped, SHARED across exercises) -----------
+// --- key handling (localStorage, persistent, SHARED across exercises) -------------
 //
 // The key slot is provider-scoped (fireworks_api_key / anthropic_api_key), NOT
 // exercise-scoped. This is the contract that makes "key entered once, reused
@@ -136,20 +136,35 @@ export function buildPrompt({ task, code, output, checks }) {
 // the same slot without re-prompting (clause 1 + clause 3).
 
 export function readKey(providerId) {
-  return window.sessionStorage.getItem(PROVIDERS[providerId].keySlot);
+  try {
+    return window.localStorage.getItem(PROVIDERS[providerId].keySlot);
+  } catch (_error) {
+    // localStorage unavailable (private mode / file://) → degrade to "no key"
+    // so the submit flow renders the key prompt instead of crashing.
+    return null;
+  }
 }
 
 export function storeKey(key, providerId) {
-  window.sessionStorage.setItem(PROVIDERS[providerId].keySlot, key);
+  window.localStorage.setItem(PROVIDERS[providerId].keySlot, key);
+}
+
+// Scoped removal: the provider's key AND the feedback counter. Deliberately NOT
+// localStorage.clear() — unrelated app state (byok_provider, anthropic_api_key,
+// quarto-reader-mode, quarto-persistent-tabsets-data) survives. Removing the
+// counter is what un-locks a rate-capped learner (the counter is persistent now).
+export function clearKey(providerId) {
+  window.localStorage.removeItem(PROVIDERS[providerId].keySlot);
+  window.localStorage.removeItem(FEEDBACK_COUNT_KEY);
 }
 
 export function readProvider() {
-  const stored = window.sessionStorage.getItem("byok_provider");
+  const stored = window.localStorage.getItem("byok_provider");
   return stored && Object.hasOwn(PROVIDERS, stored) ? stored : DEFAULT_PROVIDER;
 }
 
 export function storeProvider(providerId) {
-  window.sessionStorage.setItem("byok_provider", providerId);
+  window.localStorage.setItem("byok_provider", providerId);
 }
 
 // The provider base URL. A `?provider=` override is the test seam (point rodney
@@ -359,7 +374,7 @@ function byokFireworks({ baseUrl, apiKey }) {
   };
 }
 
-// --- rate limiting (sessionStorage counter, ported from feedback.js) ------------
+// --- rate limiting (localStorage counter, ported from feedback.js) ---------------
 
 const FEEDBACK_COUNT_KEY = "bt_feedback_count";
 
@@ -367,20 +382,23 @@ const FEEDBACK_COUNT_KEY = "bt_feedback_count";
 // non-integer. The parseInt + || 0 guard ensures a corrupt value never yields
 // NaN (which would silently disable limiting — the negative case from the spec).
 export function feedbackCount() {
-  return parseInt(sessionStorage.getItem(FEEDBACK_COUNT_KEY)) || 0;
+  return parseInt(localStorage.getItem(FEEDBACK_COUNT_KEY)) || 0;
 }
 
-// Whether the learner has reached the per-session feedback request limit.
+// Whether the learner has reached the per-browser feedback request limit. The
+// counter lives in localStorage, so the cap is persistent across tabs and
+// reloads; clearKey() resets it. The maxFeedbackPerSession config key keeps its
+// name (smallest correct move) but now caps PER-BROWSER, not per-session.
 export function rateLimitReached() {
   const max =
     (window.__btConfig && window.__btConfig.maxFeedbackPerSession) || 0;
   return feedbackCount() >= max;
 }
 
-// Increment the per-session feedback request counter. Called AFTER the try/catch
+// Increment the per-browser feedback request counter. Called AFTER the try/catch
 // in handleSubmitForExercise — both successful and failed requests count.
 export function incrementFeedbackCount() {
-  sessionStorage.setItem(FEEDBACK_COUNT_KEY, String(feedbackCount() + 1));
+  localStorage.setItem(FEEDBACK_COUNT_KEY, String(feedbackCount() + 1));
 }
 
 // --- the per-exercise submit flow (effectful shell, REWRITTEN) -------------------
@@ -388,7 +406,7 @@ export function incrementFeedbackCount() {
 // The old feedback.js used a singleton #feedback container and window.__bt.
 // This module uses per-exercise containers (created in mountFeedback) and the
 // AC-4 registry entry's getSubmission(). The key handling is shared
-// (sessionStorage), so the key entered for exercise 1 is reused for exercise 2.
+// (localStorage), so the key entered for exercise 1 is reused for exercise 2.
 
 // Read the current lesson + the learner's code from the per-exercise registry
 // entry — no reach into runner internals (§3.4). The code comes from
@@ -409,7 +427,7 @@ function currentSubmissionForExercise(entry) {
 
 // Prompt the learner for a provider + key, with per-provider disclosure. The
 // provider chooser renders a <select data-byok="provider">. The key is stored
-// in the selected provider's sessionStorage slot (shared across exercises).
+// in the selected provider's localStorage slot (shared across exercises).
 function renderKeyPrompt(container) {
   const form = document.createElement("form");
   form.dataset.byok = "key-prompt";
@@ -503,7 +521,7 @@ function renderLimitReached(container) {
   const note = document.createElement("p");
   note.dataset.byok = "limit-reached";
   note.textContent =
-    "Feedback request limit reached for this session. Reload the page to reset.";
+    "Feedback request limit reached for this browser. Clear your saved API key to reset.";
   container.replaceChildren(note);
 }
 
@@ -558,7 +576,7 @@ function selectedModel(container, providerId) {
 //   picker shown     → build the prompt and send feedback through the chosen
 //                      provider's backend, using the chosen model.
 //
-// The provider + key are read from SHARED sessionStorage (entered once, reused).
+// The provider + key are read from SHARED localStorage (entered once, reused).
 // The submission is read from the per-exercise registry entry. The verdict
 // renders into the per-exercise container (no cross-exercise bleed).
 //
@@ -618,7 +636,7 @@ async function handleSubmitForExercise(entry) {
 // --- embedded key (build-time --embed-key, ported) ------------------------------
 //
 // Apply an embedded API key (if present). The decrypt shell sets
-// window.__btEmbeddedKey; applyEmbeddedKey stores it in sessionStorage and
+// window.__btEmbeddedKey; applyEmbeddedKey stores it in localStorage and
 // clears the global, so handleSubmitForExercise's key-entry phase is skipped
 // naturally. Exported, NOT called at module load — the caller invokes it before
 // mountAllFeedback (§2.1: no module-level effectful code).
@@ -637,7 +655,7 @@ export function applyEmbeddedKey() {
 // div.bt-exercise. Each exercise gets its own UI — no singleton #feedback.
 // The button triggers handleSubmitForExercise(entry), which reads the
 // submission from entry.getSubmission() (the per-exercise editor) and the key
-// from shared sessionStorage (entered once, reused).
+// from shared localStorage (entered once, reused).
 export function mountFeedback(entry) {
   // Create the feedback container inside the exercise div.
   const feedbackContainer = document.createElement("div");
@@ -669,7 +687,7 @@ export function mountFeedback(entry) {
 // Mount feedback UI for every exercise in the registry. Called by the page
 // AFTER start(registry, adapters) boots the runtime — each exercise already has
 // its editor + Run button wired by exercise-runtime.js. This adds the feedback
-// button + container per-exercise, using the shared sessionStorage key.
+// button + container per-exercise, using the shared localStorage key.
 export function mountAllFeedback(registry) {
   applyEmbeddedKey();
   for (const entry of registry) {

--- a/docs/evidence/162/run.log
+++ b/docs/evidence/162/run.log
@@ -1,0 +1,20 @@
+=== Issue #162 E2E evidence — localStorage migration of exercise-feedback.js ===
+date: 2026-08-06T19:27:47Z
+
+=== 1. cmp — demo-book mirror byte-identical to canonical ===
+PASS: mirror byte-identical
+
+=== 2. source-scan — zero sessionStorage tokens in canonical asset ===
+sessionStorage occurrences: 0 (expect 0)
+localStorage occurrences: 25
+
+=== 3. module imports cleanly in Node ===
+PASS: module imports, syntax OK
+
+=== 4. cargo test -p blendtutor-cli — crates/core/assets/shared/feedback.js untouched ===
+     Running tests/build.rs (target/debug/deps/build-5e581d7c94c9eab0)
+test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 99.46s
+
+NOTE: build.rs (22 passed) pins crates/core/assets/shared/feedback.js, which
+stays sessionStorage-backed by design — proves the two feedback systems are
+separate and this migration did not touch the Rust-built one.

--- a/docs/evidence/162/test-suite.log
+++ b/docs/evidence/162/test-suite.log
@@ -1,0 +1,86 @@
+=== AC-7 Per-exercise BYOK LLM feedback — test_quarto_feedback.py ===
+
+  PASS: exercise-feedback.js exists
+  PASS: feedback.qmd exists
+-- Clause 6: llm_evaluation_prompt ABSENT --
+  PASS: llm_evaluation_prompt ABSENT from exercise-feedback.js
+  PASS: llm_evaluation_prompt ABSENT from feedback.qmd
+
+-- Source-pattern checks --
+  PASS: pure function exported: neutralize
+  PASS: pure function exported: buildPrompt
+  PASS: pure function exported: parseModels
+  PASS: pure function exported: modelRoster
+  PASS: pure function exported: feedbackRequest
+  PASS: pure function exported: toVerdict
+  PASS: pure function exported: fireworksRequest
+  PASS: pure function exported: fireworksToVerdict
+  PASS: pure function exported: providerBaseUrl
+  PASS: STUDENT_CODE fences present in source
+  PASS: PROVIDERS map has fireworks + anthropic
+  PASS: provider-scoped key slots present (fireworks_api_key, anthropic_api_key)
+  PASS: key slot is provider-scoped (not exercise-scoped)
+  PASS: storeKey + readKey present (shared key handling)
+  PASS: clearKey present (scoped key + counter removal, issue #162)
+  PASS: storage backend is localStorage (shared, persistent)
+  PASS: zero sessionStorage tokens in exercise-feedback.js (P4)
+  PASS: no singleton getElementById('feedback') — per-exercise scoping
+  PASS: no window.__bt singleton access (uses __btExercises registry)
+  PASS: ?provider= override parsed via URLSearchParams
+  PASS: localhost-only gate present (non-local override rejected)
+  PASS: per-exercise concurrent feedback guard present
+  PASS: mountFeedback/mountAllFeedback present (per-exercise mount)
+  PASS: feedback UI elements carry data-byok/data-feedback markers
+  PASS: fetch() called in backends (feedback is not silently skipped)
+  PASS: no module-level applyEmbeddedKey() call (pure layer importable)
+
+-- Behavioral checks (Node.js) --
+  PASS: buildPrompt emits STUDENT_CODE_BEGIN fence
+  PASS: buildPrompt emits STUDENT_CODE_END fence
+  PASS: buildPrompt includes task
+  PASS: buildPrompt includes student code
+  PASS: buildPrompt includes captured output
+  PASS: buildPrompt includes checks
+  PASS: neutralize strips forged STUDENT_CODE_BEGIN
+  PASS: neutralize replaces with marker
+  PASS: P1: key round-trips through localStorage (entered once, reused)
+  PASS: P1: key stored under provider-scoped localStorage slot
+  PASS: P1: key NOT written to sessionStorage
+  PASS: P1: no zombie fallback — stale sessionStorage key ignored
+  PASS: provider switched to anthropic
+  PASS: provider choice stored in localStorage
+  PASS: provider switched back to fireworks
+  PASS: localhost override honored
+  PASS: non-local override rejected (key exfil prevented)
+  PASS: non-local override falls back to provider base URL
+  PASS: credentialed override rejected
+  PASS: parseModels extracts model ids
+  PASS: modelRoster falls back when list empty
+  PASS: feedbackRequest embeds prompt in messages
+  PASS: feedbackRequest forces feedback tool
+  PASS: toVerdict maps Anthropic tool call to Verdict
+  PASS: fireworksToVerdict maps OpenAI tool call to Verdict
+  PASS: P3: feedbackCount starts at 0
+  PASS: P3: incrementFeedbackCount increments the counter
+  PASS: P3: counter value lives in localStorage.bt_feedback_count
+  PASS: P3: counter NOT written to sessionStorage
+  PASS: P3: no zombie counter — stale sessionStorage count ignored
+  PASS: P2: clearKey removes the provider key
+  PASS: P2: fireworks_api_key removed from localStorage
+  PASS: P2: clearKey removes bt_feedback_count (no permanent rate-lock)
+  PASS: P2: feedbackCount resets to 0 after clearKey
+  PASS: P2: clearKey leaves anthropic_api_key intact
+  PASS: P2: clearKey leaves byok_provider intact
+  PASS: P2: clearKey leaves quarto-reader-mode intact
+  PASS: P2: clearKey leaves quarto-persistent-tabsets-data intact
+  PASS: P2: clearKey never calls localStorage.clear()
+  PASS: P7: readKey returns null when localStorage.getItem throws
+  PASS: Node.js behavioral tests passed (all pure-function assertions)
+
+-- feedback.qmd structure --
+  PASS: feedback.qmd has 2 exercises (>=2 for key-reuse test)
+  PASS: feedback.qmd imports exercise-feedback.js
+  PASS: feedback.qmd imports exercise-runtime.js (AC-4 dependency)
+  PASS: feedback.qmd calls mountFeedback/mountAllFeedback
+
+=== Results: 35 passed, 0 failed ===

--- a/scripts/tests/test_quarto_feedback.py
+++ b/scripts/tests/test_quarto_feedback.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python3
 """Executable spec for issue #112 — Per-exercise BYOK LLM feedback.
 
-Verifies the 9-clause predicate from AC-7:
-  1. key entered once — shared sessionStorage key slot (provider-scoped, not
+Verifies the 9-clause predicate from AC-7, plus the issue #162 localStorage
+migration (P1-P7):
+  1. key entered once — shared localStorage key slot (provider-scoped, not
      exercise-scoped); entered once, reused across exercises.
   2. per-exercise scoping — each exercise has its own feedback container; no
      singleton getElementById("feedback").
   3. key reused — readKey reads from the shared slot; second exercise skips
      the key prompt.
+  10. localStorage persistence (issue #162) — keys + provider + rate-limit
+      counter all live in localStorage (shared, persistent); clearKey(providerId)
+      removes the provider key AND bt_feedback_count; zero sessionStorage tokens
+      remain (P4); readKey degrades to null when localStorage is unavailable (P7).
   4. provider switch — PROVIDERS map + storeProvider/readProvider; the provider
      chooser renders a <select data-byok="provider">.
   5. ?provider= override — providerBaseUrl honors a localhost-only override and
@@ -132,11 +137,13 @@ def check_providers_map(src: str) -> None:
         ko("provider-scoped key slots missing")
 
 
-def check_shared_session_storage(src: str) -> None:
-    """Clause 1+3 (source): key slots are provider-scoped, NOT exercise-scoped.
+def check_shared_local_storage(src: str) -> None:
+    """Clause 1+3 (source): key slots are provider-scoped, NOT exercise-scoped,
+    and the whole module speaks ONE storage backend — localStorage (shared,
+    persistent across tabs/reloads, issue #162).
 
     The key entered for exercise 1 must be reusable for exercise 2 — the
-    sessionStorage slot is keyed by provider, not by exercise id.
+    localStorage slot is keyed by provider, not by exercise id.
     """
     # The key slot must NOT be parameterized by exercise id.
     if (
@@ -153,6 +160,33 @@ def check_shared_session_storage(src: str) -> None:
         ok("storeKey + readKey present (shared key handling)")
     else:
         ko("storeKey or readKey missing")
+
+    # clearKey is the scoped removal path (provider key + counter only).
+    if "clearKey" in src:
+        ok("clearKey present (scoped key + counter removal, issue #162)")
+    else:
+        ko("clearKey missing — no scoped removal path")
+
+    # The storage backend is localStorage everywhere (P4 keeps the stronger
+    # zero-token invariant: no sessionStorage anywhere in the asset).
+    if "localStorage" in src:
+        ok("storage backend is localStorage (shared, persistent)")
+    else:
+        ko("storage backend missing localStorage")
+
+
+def check_zero_session_storage(src: str) -> None:
+    """P4 (issue #162): zero occurrences of the token `sessionStorage` anywhere
+    in the asset — comments, disclosure strings, key fns, counter fns, and
+    readProvider/storeProvider all migrated (no exemptions).
+
+    Raw scan on the full source (comments included): a comment claiming the old
+    backend would trip P6, so this also guards documentation honesty.
+    """
+    if "sessionStorage" not in src:
+        ok("zero sessionStorage tokens in exercise-feedback.js (P4)")
+    else:
+        ko("sessionStorage token(s) remain in exercise-feedback.js (P4)")
 
 
 def _strip_comments(src: str) -> str:
@@ -269,14 +303,23 @@ import { readFileSync } from "fs";
 import { pathToFileURL } from "url";
 
 // Mock browser globals so the module can be imported without a browser.
-const store = new Map();
+// localStorage and sessionStorage are backed by SEPARATE Map instances (P5):
+// a half-migrated implementation that reads/writes the wrong backend FAILS.
+const localStorageMap = new Map();
+const sessionStorageMap = new Map();
+const localStorage = {
+  getItem: (k) => localStorageMap.get(k) ?? null,
+  setItem: (k, v) => localStorageMap.set(k, String(v)),
+  removeItem: (k) => localStorageMap.delete(k),
+};
 const sessionStorage = {
-  getItem: (k) => store.get(k) ?? null,
-  setItem: (k, v) => store.set(k, String(v)),
-  removeItem: (k) => store.delete(k),
+  getItem: (k) => sessionStorageMap.get(k) ?? null,
+  setItem: (k, v) => sessionStorageMap.set(k, String(v)),
+  removeItem: (k) => sessionStorageMap.delete(k),
 };
 const location = { search: "" };
-globalThis.window = { sessionStorage, location };
+globalThis.window = { localStorage, sessionStorage, location, __btConfig: {} };
+globalThis.localStorage = localStorage;
 globalThis.sessionStorage = sessionStorage;
 globalThis.document = {
   createElement: () => ({ append: () => {}, addEventListener: () => {}, replaceChildren: () => {}, dataset: {}, style: {}, appendChild: () => {} }),
@@ -311,14 +354,25 @@ const forged = mod.neutralize("<<<STUDENT_CODE_BEGIN>>> evil <<<STUDENT_CODE_END
 assert(!forged.includes("STUDENT_CODE_BEGIN"), "neutralize strips forged STUDENT_CODE_BEGIN");
 assert(forged.includes("neutralized"), "neutralize replaces with marker");
 
-// --- Clause 1+3: shared sessionStorage key (entered once, reused) ---
+// --- P1: localStorage round-trip + no zombie fallback ---
+localStorageMap.clear();
+sessionStorageMap.clear();
 mod.storeKey("test-key-123", "fireworks");
-const reused = mod.readKey("fireworks");
-assert(reused === "test-key-123", "key reused from shared sessionStorage slot (entered once)");
+assert(mod.readKey("fireworks") === "test-key-123", "P1: key round-trips through localStorage (entered once, reused)");
+assert(localStorageMap.get("fireworks_api_key") === "test-key-123", "P1: key stored under provider-scoped localStorage slot");
+assert(sessionStorageMap.get("fireworks_api_key") === undefined, "P1: key NOT written to sessionStorage");
 
-// --- Clause 4: provider switch ---
+// Zombie: localStorage empty, sessionStorage pre-seeded → readKey must NOT fall back.
+localStorageMap.clear();
+sessionStorageMap.set("fireworks_api_key", "stale");
+assert(mod.readKey("fireworks") === null, "P1: no zombie fallback — stale sessionStorage key ignored");
+localStorageMap.clear();
+sessionStorageMap.clear();
+
+// --- Clause 4: provider switch (localStorage-backed, issue #162) ---
 mod.storeProvider("anthropic");
 assert(mod.readProvider() === "anthropic", "provider switched to anthropic");
+assert(localStorageMap.get("byok_provider") === "anthropic", "provider choice stored in localStorage");
 mod.storeProvider("fireworks");
 assert(mod.readProvider() === "fireworks", "provider switched back to fireworks");
 
@@ -359,6 +413,48 @@ const fwVerdict = mod.fireworksToVerdict({
   choices: [{ message: { tool_calls: [{ function: { name: "respond_with_feedback", arguments: '{"is_correct":false,"feedback_message":"Try again"}' } } ] } }],
 });
 assert(fwVerdict.correct === false && fwVerdict.message === "Try again", "fireworksToVerdict maps OpenAI tool call to Verdict");
+
+// --- P3: counter migrated to localStorage ---
+localStorageMap.clear();
+sessionStorageMap.clear();
+assert(mod.feedbackCount() === 0, "P3: feedbackCount starts at 0");
+mod.incrementFeedbackCount();
+assert(mod.feedbackCount() === 1, "P3: incrementFeedbackCount increments the counter");
+assert(localStorageMap.get("bt_feedback_count") === "1", "P3: counter value lives in localStorage.bt_feedback_count");
+assert(sessionStorageMap.get("bt_feedback_count") === undefined, "P3: counter NOT written to sessionStorage");
+
+// Zombie counter: sessionStorage pre-seeded with 99, localStorage empty → 0.
+localStorageMap.delete("bt_feedback_count");
+sessionStorageMap.set("bt_feedback_count", "99");
+assert(mod.feedbackCount() === 0, "P3: no zombie counter — stale sessionStorage count ignored");
+localStorageMap.clear();
+sessionStorageMap.clear();
+
+// --- P2: clearKey is scoped (provider key + counter only) and resets the counter ---
+mod.storeKey("test-key-123", "fireworks");
+mod.storeProvider("fireworks");
+mod.incrementFeedbackCount(); // counter → 1
+localStorageMap.set("anthropic_api_key", "keep-me");
+localStorageMap.set("quarto-reader-mode", "keep");
+localStorageMap.set("quarto-persistent-tabsets-data", "keep");
+mod.clearKey("fireworks");
+assert(mod.readKey("fireworks") === null, "P2: clearKey removes the provider key");
+assert(localStorageMap.get("fireworks_api_key") === undefined, "P2: fireworks_api_key removed from localStorage");
+assert(localStorageMap.get("bt_feedback_count") === undefined, "P2: clearKey removes bt_feedback_count (no permanent rate-lock)");
+assert(mod.feedbackCount() === 0, "P2: feedbackCount resets to 0 after clearKey");
+assert(localStorageMap.get("anthropic_api_key") === "keep-me", "P2: clearKey leaves anthropic_api_key intact");
+assert(localStorageMap.get("byok_provider") === "fireworks", "P2: clearKey leaves byok_provider intact");
+assert(localStorageMap.get("quarto-reader-mode") === "keep", "P2: clearKey leaves quarto-reader-mode intact");
+assert(localStorageMap.get("quarto-persistent-tabsets-data") === "keep", "P2: clearKey leaves quarto-persistent-tabsets-data intact");
+assert(localStorageMap.size === 4, "P2: clearKey never calls localStorage.clear()");
+localStorageMap.clear();
+sessionStorageMap.clear();
+
+// --- P7: readKey returns null when localStorage is unavailable (private mode / file://) ---
+const realGetItem = localStorage.getItem;
+localStorage.getItem = () => { throw new Error("SecurityError: localStorage unavailable"); };
+assert(mod.readKey("fireworks") === null, "P7: readKey returns null when localStorage.getItem throws");
+localStorage.getItem = realGetItem;
 
 process.exit(failures > 0 ? 1 : 0);
 """
@@ -458,7 +554,8 @@ def main() -> int:
     check_pure_layer_exported(src)
     check_prompt_fences(src)
     check_providers_map(src)
-    check_shared_session_storage(src)
+    check_shared_local_storage(src)
+    check_zero_session_storage(src)
     check_no_singleton_feedback(src)
     check_provider_override(src)
     check_concurrent_guard(src)


### PR DESCRIPTION
## Summary
Switch Fireworks key persistence in `_extensions/blendtutor/assets/exercise-feedback.js` from sessionStorage to localStorage (issue #162 AC-1):

- **Storage migration**: `readKey`/`storeKey`/`readProvider`/`storeProvider` now use `window.localStorage`; `feedbackCount`/`incrementFeedbackCount` use bare `localStorage` (the find-replace-missed access pattern at the counter fns).
- **NEW `clearKey(providerId)`**: removes the provider's `keySlot` **and** `bt_feedback_count`; deliberately scoped — never `localStorage.clear()`, so `byok_provider`, `anthropic_api_key`, `quarto-reader-mode`, `quarto-persistent-tabsets-data` survive. Resetting the counter is what un-locks a rate-capped learner under persistent storage.
- **No zombie fallback**: `readKey` returns `null` when localStorage is empty even if sessionStorage carries a stale key (clean break, no migration).
- **`readKey` guard (P7)**: try/catch → `null` when `localStorage.getItem` throws (private mode / `file://`), so `handleSubmitForExercise` renders the key prompt instead of crashing.
- **Zero `sessionStorage` tokens** remain anywhere in the module — comments and disclosure strings now state localStorage persistence accurately; `maxFeedbackPerSession` config key NOT renamed, re-documented as a per-browser cap; limit-reached copy no longer claims reload resets the counter.
- **Demo-book mirror** re-synced byte-identical (`cmp` verified).

## Issue
Closes #162

## ACs implemented
- [x] Switch Fireworks key persistence from sessionStorage to localStorage (`readKey`/`storeKey` for `fireworks_api_key`, add `clearKey()`), migrate `bt_feedback_count` consistently; update `scripts/tests/test_quarto_feedback.py` Node/static tests that pin sessionStorage.

## Test plan
- [x] `python3 scripts/tests/test_quarto_feedback.py` — 35 passed, 0 failed (P1 round-trip/no-zombie, P2 clearKey scoped + counter reset, P3 counter-on-localStorage, P4 zero-sessionStorage source-scan, P5 separate-Map mock, P7 read-guard, plus legacy AC-7 clauses)
- [x] `cmp` canonical vs demo-book mirror — byte-identical
- [x] `cargo test -p blendtutor-cli` — all green incl. `tests/build.rs` (22 passed) pinning the untouched `crates/core/assets/shared/feedback.js` contract
- [x] E2E evidence at `docs/evidence/162/` (`test-suite.log`, `run.log`)

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested
- [x] Verification medium satisfied
- [x] Design intent respected
- [x] No scope creep