### PR TITLE
[feature] Scope learner UX to Fireworks-only (#167)

### DIFF
--- a/_extensions/blendtutor/assets/exercise-feedback.js
+++ b/_extensions/blendtutor/assets/exercise-feedback.js
@@ -425,30 +425,21 @@ function currentSubmissionForExercise(entry) {
   };
 }
 
-// Prompt the learner for a provider + key, with per-provider disclosure. The
-// provider chooser renders a <select data-byok="provider">. The key is stored
-// in the selected provider's localStorage slot (shared across exercises).
-function renderKeyPrompt(container) {
+// Prompt the learner for a key, with the Fireworks disclosure. Learner-facing
+// UX is Fireworks-only: there is NO provider chooser — the learner path cannot
+// represent a non-fireworks provider (the <select> is gone, so the illegal
+// state "learner chose anthropic" is unrepresentable). The Anthropic backend
+// SURVIVES in PROVIDERS for the ?provider= test seam + embedded-key builds.
+// The key is stored in the Fireworks localStorage slot (shared across
+// exercises). Exported so tests can render the prompt without a browser.
+export function renderKeyPrompt(container) {
   const form = document.createElement("form");
   form.dataset.byok = "key-prompt";
 
   const disclosure = document.createElement("p");
   disclosure.id = "byok-disclosure";
-
-  const provLabel = document.createElement("label");
-  provLabel.textContent = "Provider: ";
-  const provSelect = document.createElement("select");
-  provSelect.dataset.byok = "provider";
-  for (const [id, provider] of Object.entries(PROVIDERS)) {
-    const option = document.createElement("option");
-    option.value = id;
-    option.textContent = provider.label;
-    if (id === DEFAULT_PROVIDER) {
-      option.selected = true;
-    }
-    provSelect.append(option);
-  }
-  provLabel.append(provSelect);
+  const provider = PROVIDERS[DEFAULT_PROVIDER];
+  disclosure.textContent = PROVIDER_DISCLOSURES[DEFAULT_PROVIDER];
 
   const keyLabel = document.createElement("label");
   keyLabel.textContent = "API key: ";
@@ -456,29 +447,21 @@ function renderKeyPrompt(container) {
   keyInput.type = "password";
   keyInput.name = "provider-key";
   keyInput.autocomplete = "off";
+  keyInput.placeholder = "Paste your " + provider.label + " API key";
   keyLabel.append(keyInput);
-
-  function updateDisclosure() {
-    const prov = PROVIDERS[provSelect.value];
-    disclosure.textContent = PROVIDER_DISCLOSURES[provSelect.value];
-    keyInput.placeholder = "Paste your " + prov.label + " API key";
-    keyInput.value = "";
-  }
-  provSelect.addEventListener("change", updateDisclosure);
-  updateDisclosure();
 
   const save = document.createElement("button");
   save.type = "submit";
   save.textContent = "Save key & get feedback";
 
-  form.append(disclosure, provLabel, keyLabel, save);
+  form.append(disclosure, keyLabel, save);
   form.addEventListener("submit", (event) => {
     event.preventDefault();
     const key = keyInput.value.trim();
     if (!key) {
       return;
     }
-    const providerId = provSelect.value;
+    const providerId = DEFAULT_PROVIDER;
     storeProvider(providerId);
     storeKey(key, providerId);
     handleSubmitForExercise(container._entry);

--- a/demo-book/_extensions/mcmullarkey/blendtutor/assets/exercise-feedback.js
+++ b/demo-book/_extensions/mcmullarkey/blendtutor/assets/exercise-feedback.js
@@ -425,30 +425,21 @@ function currentSubmissionForExercise(entry) {
   };
 }
 
-// Prompt the learner for a provider + key, with per-provider disclosure. The
-// provider chooser renders a <select data-byok="provider">. The key is stored
-// in the selected provider's localStorage slot (shared across exercises).
-function renderKeyPrompt(container) {
+// Prompt the learner for a key, with the Fireworks disclosure. Learner-facing
+// UX is Fireworks-only: there is NO provider chooser — the learner path cannot
+// represent a non-fireworks provider (the <select> is gone, so the illegal
+// state "learner chose anthropic" is unrepresentable). The Anthropic backend
+// SURVIVES in PROVIDERS for the ?provider= test seam + embedded-key builds.
+// The key is stored in the Fireworks localStorage slot (shared across
+// exercises). Exported so tests can render the prompt without a browser.
+export function renderKeyPrompt(container) {
   const form = document.createElement("form");
   form.dataset.byok = "key-prompt";
 
   const disclosure = document.createElement("p");
   disclosure.id = "byok-disclosure";
-
-  const provLabel = document.createElement("label");
-  provLabel.textContent = "Provider: ";
-  const provSelect = document.createElement("select");
-  provSelect.dataset.byok = "provider";
-  for (const [id, provider] of Object.entries(PROVIDERS)) {
-    const option = document.createElement("option");
-    option.value = id;
-    option.textContent = provider.label;
-    if (id === DEFAULT_PROVIDER) {
-      option.selected = true;
-    }
-    provSelect.append(option);
-  }
-  provLabel.append(provSelect);
+  const provider = PROVIDERS[DEFAULT_PROVIDER];
+  disclosure.textContent = PROVIDER_DISCLOSURES[DEFAULT_PROVIDER];
 
   const keyLabel = document.createElement("label");
   keyLabel.textContent = "API key: ";
@@ -456,29 +447,21 @@ function renderKeyPrompt(container) {
   keyInput.type = "password";
   keyInput.name = "provider-key";
   keyInput.autocomplete = "off";
+  keyInput.placeholder = "Paste your " + provider.label + " API key";
   keyLabel.append(keyInput);
-
-  function updateDisclosure() {
-    const prov = PROVIDERS[provSelect.value];
-    disclosure.textContent = PROVIDER_DISCLOSURES[provSelect.value];
-    keyInput.placeholder = "Paste your " + prov.label + " API key";
-    keyInput.value = "";
-  }
-  provSelect.addEventListener("change", updateDisclosure);
-  updateDisclosure();
 
   const save = document.createElement("button");
   save.type = "submit";
   save.textContent = "Save key & get feedback";
 
-  form.append(disclosure, provLabel, keyLabel, save);
+  form.append(disclosure, keyLabel, save);
   form.addEventListener("submit", (event) => {
     event.preventDefault();
     const key = keyInput.value.trim();
     if (!key) {
       return;
     }
-    const providerId = provSelect.value;
+    const providerId = DEFAULT_PROVIDER;
     storeProvider(providerId);
     storeKey(key, providerId);
     handleSubmitForExercise(container._entry);

--- a/docs/evidence/167/run.log
+++ b/docs/evidence/167/run.log
@@ -1,0 +1,57 @@
+E2E run log — issue #167: Scope learner UX to Fireworks-only (AC-6)
+====================================================================
+Date: 2026-08-06
+Branch: 167-fireworks-only
+Verification: code (pytest + jsdom DOM render/submit via Node mock)
+
+The AC-6 change removes the provider <select> from the learner key prompt,
+keeps readProvider default-when-absent, keeps the Anthropic backend +
+?provider= seam, and updates disclosure copy to localStorage wording.
+Because the probe is the extended test file itself (jsdom render of
+renderKeyPrompt + jsdom submit), the behavioral evidence IS the run log
+below: the key prompt is actually rendered into a DOM container and the
+save form is actually submitted.
+
+1) Full test suite (40/40): docs/evidence/167/test-suite.log
+
+2) AC-6 C1-C6 behavioral assertions (extract from test-suite.log):
+   PASS: C1 (source): no data-byok="provider" literal in exercise-feedback.js
+   PASS: C1 (source): no provider <select> creation pattern (dataset.byok = "provider")
+   PASS: C3 (source): PROVIDERS.anthropic keeps the byokAnthropic factory
+   PASS: C6 (source): no orphaned provSelect references
+   PASS: C5 (source): BOTH provider disclosures state localStorage wording
+   PASS: C2: empty storage defaults to fireworks
+   PASS: C3: PROVIDERS.anthropic survives (backend not deleted)
+   PASS: C3: anthropic keySlot preserved
+   PASS: C3: anthropic baseUrl preserved
+   PASS: C3: anthropic factory builds the byok-anthropic backend
+   PASS: C1: key prompt renders NO provider <select> (absent, not hidden)
+   PASS: C1: key prompt renders ZERO <option> elements
+   PASS: C5: rendered disclosure states localStorage
+   PASS: C5: rendered disclosure does NOT state sessionStorage
+   PASS: C5: rendered disclosure names Fireworks (default provider)
+   PASS: C6: key prompt submit does not throw after select removal
+   PASS: C6: storeProvider called with fireworks
+   PASS: C6: key stored in the fireworks localStorage slot
+
+3) Negative control — dangling provSelect.value in submit handler:
+   (temporarily reverted `const providerId = DEFAULT_PROVIDER;` back to
+   `const providerId = provSelect.value;`)
+   FAIL: C6: key prompt submit does not throw after select removal
+   FAIL: C6: storeProvider called with fireworks
+   FAIL: C6: key stored in the fireworks localStorage slot
+   FAIL: C6 (source): provSelect reference survives — submit would throw
+   (restored; 40/40 green again) — proves the C6 test pins the regression.
+
+4) Three-copy propagation — demo-book mirror byte-identical:
+   $ cmp _extensions/blendtutor/assets/exercise-feedback.js \
+        demo-book/_extensions/mcmullarkey/blendtutor/assets/exercise-feedback.js
+   MIRROR BYTE-IDENTICAL
+
+5) Unaffected systems:
+   - crates/core/assets/shared/feedback.js NOT touched (separate Rust system,
+     pinned by crates/cli/tests/build.rs)
+   - rodney-probes/ NOT touched (AC-8 ownership)
+   - readProvider diff = ZERO lines (default-when-absent already in place)
+   - C4 (?provider= localhost seam) assertions unchanged, still green
+   - Sibling suite test_quarto_ux.py: 46 passed, 0 failed

--- a/docs/evidence/167/test-suite.log
+++ b/docs/evidence/167/test-suite.log
@@ -1,0 +1,107 @@
+[blendtutor] Exercise "c6-exercise" feedback already in flight, ignoring concurrent request.
+=== AC-7 Per-exercise BYOK LLM feedback — test_quarto_feedback.py ===
+
+  PASS: exercise-feedback.js exists
+  PASS: feedback.qmd exists
+-- Clause 6: llm_evaluation_prompt ABSENT --
+  PASS: llm_evaluation_prompt ABSENT from exercise-feedback.js
+  PASS: llm_evaluation_prompt ABSENT from feedback.qmd
+
+-- Source-pattern checks --
+  PASS: pure function exported: neutralize
+  PASS: pure function exported: buildPrompt
+  PASS: pure function exported: parseModels
+  PASS: pure function exported: modelRoster
+  PASS: pure function exported: feedbackRequest
+  PASS: pure function exported: toVerdict
+  PASS: pure function exported: fireworksRequest
+  PASS: pure function exported: fireworksToVerdict
+  PASS: pure function exported: providerBaseUrl
+  PASS: STUDENT_CODE fences present in source
+  PASS: PROVIDERS map has fireworks + anthropic
+  PASS: provider-scoped key slots present (fireworks_api_key, anthropic_api_key)
+  PASS: C1 (source): no data-byok="provider" literal in exercise-feedback.js
+  PASS: C1 (source): no provider <select> creation pattern (dataset.byok = "provider")
+  PASS: C3 (source): PROVIDERS.anthropic keeps the byokAnthropic factory
+  PASS: C6 (source): no orphaned provSelect references
+  PASS: C5 (source): BOTH provider disclosures state localStorage wording
+  PASS: key slot is provider-scoped (not exercise-scoped)
+  PASS: storeKey + readKey present (shared key handling)
+  PASS: clearKey present (scoped key + counter removal, issue #162)
+  PASS: storage backend is localStorage (shared, persistent)
+  PASS: zero sessionStorage tokens in exercise-feedback.js (P4)
+  PASS: no singleton getElementById('feedback') — per-exercise scoping
+  PASS: no window.__bt singleton access (uses __btExercises registry)
+  PASS: ?provider= override parsed via URLSearchParams
+  PASS: localhost-only gate present (non-local override rejected)
+  PASS: per-exercise concurrent feedback guard present
+  PASS: mountFeedback/mountAllFeedback present (per-exercise mount)
+  PASS: feedback UI elements carry data-byok/data-feedback markers
+  PASS: fetch() called in backends (feedback is not silently skipped)
+  PASS: no module-level applyEmbeddedKey() call (pure layer importable)
+
+-- Behavioral checks (Node.js) --
+  PASS: buildPrompt emits STUDENT_CODE_BEGIN fence
+  PASS: buildPrompt emits STUDENT_CODE_END fence
+  PASS: buildPrompt includes task
+  PASS: buildPrompt includes student code
+  PASS: buildPrompt includes captured output
+  PASS: buildPrompt includes checks
+  PASS: neutralize strips forged STUDENT_CODE_BEGIN
+  PASS: neutralize replaces with marker
+  PASS: P1: key round-trips through localStorage (entered once, reused)
+  PASS: P1: key stored under provider-scoped localStorage slot
+  PASS: P1: key NOT written to sessionStorage
+  PASS: P1: no zombie fallback — stale sessionStorage key ignored
+  PASS: provider switched to anthropic
+  PASS: provider choice stored in localStorage
+  PASS: provider switched back to fireworks
+  PASS: localhost override honored
+  PASS: non-local override rejected (key exfil prevented)
+  PASS: non-local override falls back to provider base URL
+  PASS: credentialed override rejected
+  PASS: parseModels extracts model ids
+  PASS: modelRoster falls back when list empty
+  PASS: feedbackRequest embeds prompt in messages
+  PASS: feedbackRequest forces feedback tool
+  PASS: toVerdict maps Anthropic tool call to Verdict
+  PASS: fireworksToVerdict maps OpenAI tool call to Verdict
+  PASS: P3: feedbackCount starts at 0
+  PASS: P3: incrementFeedbackCount increments the counter
+  PASS: P3: counter value lives in localStorage.bt_feedback_count
+  PASS: P3: counter NOT written to sessionStorage
+  PASS: P3: no zombie counter — stale sessionStorage count ignored
+  PASS: P2: clearKey removes the provider key
+  PASS: P2: fireworks_api_key removed from localStorage
+  PASS: P2: clearKey removes bt_feedback_count (no permanent rate-lock)
+  PASS: P2: feedbackCount resets to 0 after clearKey
+  PASS: P2: clearKey leaves anthropic_api_key intact
+  PASS: P2: clearKey leaves byok_provider intact
+  PASS: P2: clearKey leaves quarto-reader-mode intact
+  PASS: P2: clearKey leaves quarto-persistent-tabsets-data intact
+  PASS: P2: clearKey never calls localStorage.clear()
+  PASS: P7: readKey returns null when localStorage.getItem throws
+  PASS: C2: empty storage defaults to fireworks
+  PASS: C3: PROVIDERS.anthropic survives (backend not deleted)
+  PASS: C3: anthropic keySlot preserved
+  PASS: C3: anthropic baseUrl preserved
+  PASS: C3: anthropic factory wired
+  PASS: C3: anthropic factory builds the byok-anthropic backend
+  PASS: C3: fireworks factory builds the byok-fireworks backend (pair intact)
+  PASS: C1: key prompt renders NO provider <select> (absent, not hidden)
+  PASS: C1: key prompt renders ZERO <option> elements
+  PASS: C5: rendered disclosure states localStorage
+  PASS: C5: rendered disclosure does NOT state sessionStorage
+  PASS: C5: rendered disclosure names Fireworks (default provider)
+  PASS: C6: key prompt submit does not throw after select removal
+  PASS: C6: storeProvider called with fireworks
+  PASS: C6: key stored in the fireworks localStorage slot
+  PASS: Node.js behavioral tests passed (all pure-function assertions)
+
+-- feedback.qmd structure --
+  PASS: feedback.qmd has 2 exercises (>=2 for key-reuse test)
+  PASS: feedback.qmd imports exercise-feedback.js
+  PASS: feedback.qmd imports exercise-runtime.js (AC-4 dependency)
+  PASS: feedback.qmd calls mountFeedback/mountAllFeedback
+
+=== Results: 40 passed, 0 failed ===

--- a/scripts/tests/test_quarto_feedback.py
+++ b/scripts/tests/test_quarto_feedback.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Executable spec for issue #112 — Per-exercise BYOK LLM feedback.
 
-Verifies the 9-clause predicate from AC-7, plus the issue #162 localStorage
-migration (P1-P7):
+Verifies the 9-clause predicate from AC-7, the issue #162 localStorage
+migration (P1-P7), and the issue #167 Fireworks-only learner UX (C1-C6):
   1. key entered once — shared localStorage key slot (provider-scoped, not
      exercise-scoped); entered once, reused across exercises.
   2. per-exercise scoping — each exercise has its own feedback container; no
@@ -13,8 +13,11 @@ migration (P1-P7):
       counter all live in localStorage (shared, persistent); clearKey(providerId)
       removes the provider key AND bt_feedback_count; zero sessionStorage tokens
       remain (P4); readKey degrades to null when localStorage is unavailable (P7).
-  4. provider switch — PROVIDERS map + storeProvider/readProvider; the provider
-     chooser renders a <select data-byok="provider">.
+  4. provider switch — PROVIDERS map + storeProvider/readProvider; Fireworks-only
+     learner UX (issue #167): renderKeyPrompt renders NO provider <select>
+     (C1 — absent, not hidden), the anthropic backend + ?provider= seam survive
+     (C3/C4), both disclosures state localStorage wording (C5), and submit
+     stores under fireworks with no dangling provSelect ref (C6).
   5. ?provider= override — providerBaseUrl honors a localhost-only override and
      rejects non-local / credentialed overrides.
   6. llm_evaluation_prompt ABSENT — never in the JS source or the qmd fixture.
@@ -241,6 +244,42 @@ def check_provider_override(src: str) -> None:
         ko("localhost-only gate missing — key could be exfiltrated")
 
 
+def check_fireworks_only_ux(src: str) -> None:
+    """AC-6 (source): learner-facing UX is Fireworks-only.
+
+    C1 (source): the provider <select> literal AND its creation pattern are
+    absent — no data-byok="provider" in source. DOM absence is asserted in the
+    Node behavioral section; a hidden/display:none select would still trip the
+    render checks (absence, not concealment).
+    C3 (source): the anthropic backend factory stays wired in PROVIDERS.
+    C5 (source): BOTH disclosure strings state localStorage wording.
+    C6 (source): no dangling provSelect reference survives in the submit path.
+    """
+    if 'data-byok="provider"' not in src:
+        ok('C1 (source): no data-byok="provider" literal in exercise-feedback.js')
+    else:
+        ko('C1 (source): data-byok="provider" literal still in source')
+    if 'dataset.byok = "provider"' not in src:
+        ok('C1 (source): no provider <select> creation pattern (dataset.byok = "provider")')
+    else:
+        ko("C1 (source): provider <select> creation pattern still present")
+    if "factory: byokAnthropic" in src:
+        ok("C3 (source): PROVIDERS.anthropic keeps the byokAnthropic factory")
+    else:
+        ko("C3 (source): byokAnthropic factory missing from PROVIDERS map")
+    if "provSelect" not in src:
+        ok("C6 (source): no orphaned provSelect references")
+    else:
+        ko("C6 (source): provSelect reference survives — submit would throw")
+    if (
+        "Your Fireworks API key is stored in this browser (localStorage)" in src
+        and "Your Anthropic API key is stored in this browser (localStorage)" in src
+    ):
+        ok("C5 (source): BOTH provider disclosures state localStorage wording")
+    else:
+        ko("C5 (source): one or both disclosures missing localStorage wording")
+
+
 def check_concurrent_guard(src: str) -> None:
     """Clause 8 (source): per-exercise concurrent feedback guard."""
     if (
@@ -321,8 +360,79 @@ const location = { search: "" };
 globalThis.window = { localStorage, sessionStorage, location, __btConfig: {} };
 globalThis.localStorage = localStorage;
 globalThis.sessionStorage = sessionStorage;
+
+// Minimal DOM mock for renderKeyPrompt (AC-6 C1/C5/C6). Supports the element
+// operations renderKeyPrompt uses: append, replaceChildren, addEventListener,
+// dataset, querySelector/querySelectorAll, and submit dispatch. Selector
+// matching covers the selectors the assertions query — NOT a general CSS engine.
+function elementMatches(el, selector) {
+  if (selector === "option" || selector === "form" || selector === "p") {
+    return el.tagName === selector.toUpperCase();
+  }
+  const m = /^([a-z]+)\[data-byok="([^"]+)"\]$/.exec(selector);
+  if (m) return el.tagName === m[1].toUpperCase() && el.dataset.byok === m[2];
+  const mn = /^input\[name="([^"]+)"\]$/.exec(selector);
+  if (mn) return el.tagName === "INPUT" && el.name === mn[1];
+  const mi = /^#([A-Za-z0-9_-]+)$/.exec(selector);
+  if (mi) return el.id === mi[1];
+  return false;
+}
+function matchFirst(root, selector) {
+  if (elementMatches(root, selector)) return root;
+  for (const child of root.children || []) {
+    const found = matchFirst(child, selector);
+    if (found) return found;
+  }
+  return null;
+}
+function collectMatches(root, selector, out) {
+  if (elementMatches(root, selector)) out.push(root);
+  for (const child of root.children || []) collectMatches(child, selector, out);
+}
+function mockElement(tag) {
+  return {
+    tagName: tag.toUpperCase(),
+    dataset: {},
+    children: [],
+    _handlers: {},
+    value: "",
+    textContent: "",
+    placeholder: "",
+    type: "",
+    name: "",
+    autocomplete: "",
+    selected: false,
+    id: "",
+    append(...nodes) {
+      for (const n of nodes) this.children.push(n);
+    },
+    appendChild(n) {
+      this.children.push(n);
+      return n;
+    },
+    replaceChildren(...nodes) {
+      this.children = [...nodes];
+    },
+    addEventListener(type, fn) {
+      (this._handlers[type] || (this._handlers[type] = [])).push(fn);
+    },
+    dispatchEvent(event) {
+      const fns = this._handlers[event.type] || [];
+      for (const fn of fns) fn(event);
+      return true;
+    },
+    querySelector(selector) {
+      return matchFirst(this, selector);
+    },
+    querySelectorAll(selector) {
+      const out = [];
+      collectMatches(this, selector, out);
+      return out;
+    },
+  };
+}
 globalThis.document = {
-  createElement: () => ({ append: () => {}, addEventListener: () => {}, replaceChildren: () => {}, dataset: {}, style: {}, appendChild: () => {} }),
+  createElement: mockElement,
   getElementById: () => null,
   querySelector: () => null,
 };
@@ -456,6 +566,52 @@ localStorage.getItem = () => { throw new Error("SecurityError: localStorage unav
 assert(mod.readKey("fireworks") === null, "P7: readKey returns null when localStorage.getItem throws");
 localStorage.getItem = realGetItem;
 
+// --- AC-6 C2: empty storage defaults to fireworks (readProvider NOT made
+//     unconditional — semantics stay default-when-absent) ---
+localStorageMap.clear();
+assert(mod.readProvider() === "fireworks", "C2: empty storage defaults to fireworks");
+
+// --- AC-6 C3: PROVIDERS.anthropic survives (backend kept for ?provider= seam
+//     + embedded-key builds — no overzealous cleanup) ---
+assert(Object.hasOwn(mod.PROVIDERS, "anthropic"), "C3: PROVIDERS.anthropic survives (backend not deleted)");
+assert(mod.PROVIDERS.anthropic.keySlot === "anthropic_api_key", "C3: anthropic keySlot preserved");
+assert(mod.PROVIDERS.anthropic.baseUrl === "https://api.anthropic.com", "C3: anthropic baseUrl preserved");
+assert(typeof mod.PROVIDERS.anthropic.factory === "function", "C3: anthropic factory wired");
+const anthropicBackend = mod.PROVIDERS.anthropic.factory({ baseUrl: "https://api.anthropic.com", apiKey: "k" });
+assert(anthropicBackend.name === "byok-anthropic", "C3: anthropic factory builds the byok-anthropic backend");
+const fireworksBackend = mod.PROVIDERS.fireworks.factory({ baseUrl: "https://api.fireworks.ai/inference/v1", apiKey: "k" });
+assert(fireworksBackend.name === "byok-fireworks", "C3: fireworks factory builds the byok-fireworks backend (pair intact)");
+
+// --- AC-6 C1+C5: renderKeyPrompt renders NO provider <select> and the
+//     disclosure states localStorage ---
+const keyPromptContainer = mockElement("div");
+mod.renderKeyPrompt(keyPromptContainer);
+assert(keyPromptContainer.querySelector('select[data-byok="provider"]') === null, "C1: key prompt renders NO provider <select> (absent, not hidden)");
+assert(keyPromptContainer.querySelectorAll("option").length === 0, "C1: key prompt renders ZERO <option> elements");
+const keyPromptDisclosure = keyPromptContainer.querySelector("#byok-disclosure").textContent;
+assert(keyPromptDisclosure.includes("localStorage"), "C5: rendered disclosure states localStorage");
+assert(!keyPromptDisclosure.includes("sessionStorage"), "C5: rendered disclosure does NOT state sessionStorage");
+assert(keyPromptDisclosure.includes("Fireworks"), "C5: rendered disclosure names Fireworks (default provider)");
+
+// --- AC-6 C6: submit with non-empty key stores fireworks — no dangling
+//     provSelect.value ReferenceError after the select is removed ---
+localStorageMap.clear();
+const c6Container = mockElement("div");
+const c6Entry = { id: "c6-exercise", feedbackContainer: c6Container, _feedbackRunning: true };
+c6Container._entry = c6Entry; // back-ref mirrors mountFeedback
+mod.renderKeyPrompt(c6Container);
+const c6Form = c6Container.querySelector("form");
+c6Form.querySelector('input[name="provider-key"]').value = "fw-key-abc";
+let submitThrew = null;
+try {
+  c6Form.dispatchEvent({ type: "submit", preventDefault() {} });
+} catch (err) {
+  submitThrew = err;
+}
+assert(submitThrew === null, "C6: key prompt submit does not throw after select removal");
+assert(localStorageMap.get("byok_provider") === "fireworks", "C6: storeProvider called with fireworks");
+assert(localStorageMap.get("fireworks_api_key") === "fw-key-abc", "C6: key stored in the fireworks localStorage slot");
+
 process.exit(failures > 0 ? 1 : 0);
 """
 
@@ -554,6 +710,7 @@ def main() -> int:
     check_pure_layer_exported(src)
     check_prompt_fences(src)
     check_providers_map(src)
+    check_fireworks_only_ux(src)
     check_shared_local_storage(src)
     check_zero_session_storage(src)
     check_no_singleton_feedback(src)


### PR DESCRIPTION
## Summary

Scope the learner-facing key prompt UX to Fireworks-only (issue #167, AC-6 of byok-api-key):

- **Remove the provider `<select>` from `renderKeyPrompt`** — the learner path can no longer represent a non-fireworks provider (illegal state unrepresentable). Not hidden — absent. The `<option>` loop, provider label, and the `updateDisclosure` provider-switch are gone.
- **`readProvider` untouched (zero-line diff)** — it already defaults to fireworks when storage is empty via `DEFAULT_PROVIDER` + the `Object.hasOwn` clamp. Fireworks-only comes from removing the writer (the select), not changing the reader.
- **`PROVIDERS.anthropic` + `?provider=` localhost seam survive** — the Anthropic backend stays for the test seam and embedded-key builds; `providerBaseUrl` host-gating assertions unchanged and still green.
- **Submit hardcodes `DEFAULT_PROVIDER`** — no dangling `provSelect.value` ReferenceError on save.
- **Disclosures already state localStorage** (AC-1); tests now pin the rendered disclosure wording (localStorage, not sessionStorage) and the absence-not-concealment of the select via jsdom render + submit.
- **`renderKeyPrompt` exported** so the probe can render it without a browser (jsdom-render equivalent in the hand-rolled Node DOM mock — repo has no jsdom dependency).

## Issue

Closes #167

## ACs implemented

- [x] Scope learner-facing UX to Fireworks only: provider `<select>` removed from the key prompt path (C1: absent, not hidden); `readProvider()` stays default-when-absent (C2); Anthropic backend code path + `?provider=` localhost stub override intact (C3/C4); disclosure copy updated to localStorage wording (C5); submit stores under `fireworks` with no orphaned `provSelect` refs (C6).

## Test plan

- [x] `uv run python scripts/tests/test_quarto_feedback.py` — **40/40** (was 35/35; +C1–C6 clauses, jsdom render + submit)
- [x] `uv run python scripts/tests/test_quarto_ux.py` — 46/46 (sibling suite unaffected)
- [x] Negative control: reverting submit to `provSelect.value` → 4 C6 failures (ReferenceError), restored → green
- [x] `cmp` demo-book mirror byte-identical
- [x] `bash scripts/sync-quarto-assets.sh --check` — all assets in sync (asset-parity CI gate)
- [x] `bash scripts/check-model-alignment.sh` — OK (Rust/JS model id agreement)
- [x] `quarto render demo-book --to html` — renders clean
- [x] E2E evidence: `docs/evidence/167/test-suite.log` + `docs/evidence/167/run.log`

## Self-Review

- [x] All ACs exercised by tests
- [x] Predicates match spec (C1–C6)
- [x] Negative case tested (absent-not-hidden; dangling provSelect; over-scope anthropic deletion)
- [x] Verification medium satisfied (code)
- [x] Design intent respected (no readProvider change, no AC-4 pre-emption, no migration branch)
- [x] No scope creep (crates feedback.js, rodney-probes, blendtutor.lua untouched)
