### PR TITLE
fix(ui): style Get feedback button + key page form, move feedback into toolbar

### DIFF
--- a/_extensions/blendtutor/assets/exercise-feedback.js
+++ b/_extensions/blendtutor/assets/exercise-feedback.js
@@ -588,6 +588,15 @@ export function applyEmbeddedKey() {
 // The button triggers handleSubmitForExercise(entry), which reads the
 // submission from entry.getSubmission() (the per-exercise editor) and the key
 // from shared localStorage (entered once, reused).
+//
+// Issue #182 (toolbar placement): when the runtime has exposed entry.controls
+// (the Run/Check/Show-solution row created by exercise-runtime.js
+// wireExercise), the Get feedback button is appended INTO that row so it sits
+// with the other control buttons (styled like the former Run button). The
+// feedback CONTAINER (verdict area, data-byok="feedback") stays as a direct
+// child of the exercise element below the controls. When entry.controls is
+// absent (standalone mounts, tests), the button falls back to a direct child
+// of the exercise element above the container.
 export function mountFeedback(entry) {
   // Create the feedback container inside the exercise div.
   const feedbackContainer = document.createElement("div");
@@ -608,10 +617,16 @@ export function mountFeedback(entry) {
     handleSubmitForExercise(entry);
   });
 
-  const wrapper = document.createElement("div");
-  wrapper.className = "bt-feedback-wrapper";
-  wrapper.append(feedbackBtn, feedbackContainer);
-  entry.element.appendChild(wrapper);
+  if (entry.controls) {
+    // Toolbar placement (issue #182): the button joins the Run/Check/Show
+    // solution row created by exercise-runtime.js wireExercise.
+    entry.controls.appendChild(feedbackBtn);
+  } else {
+    // Fallback for standalone mounts (no runtime controls row): the button
+    // sits directly above the container inside the exercise element.
+    entry.element.appendChild(feedbackBtn);
+  }
+  entry.element.appendChild(feedbackContainer);
 }
 
 // Mount feedback UI for every exercise in the registry. Called by the page

--- a/_extensions/blendtutor/assets/exercise-feedback.js
+++ b/_extensions/blendtutor/assets/exercise-feedback.js
@@ -590,13 +590,15 @@ export function applyEmbeddedKey() {
 // from shared localStorage (entered once, reused).
 //
 // Issue #182 (toolbar placement): when the runtime has exposed entry.controls
-// (the Run/Check/Show-solution row created by exercise-runtime.js
-// wireExercise), the Get feedback button is appended INTO that row so it sits
-// with the other control buttons (styled like the former Run button). The
-// feedback CONTAINER (verdict area, data-byok="feedback") stays as a direct
-// child of the exercise element below the controls. When entry.controls is
-// absent (standalone mounts, tests), the button falls back to a direct child
-// of the exercise element above the container.
+// (the Check/Show-solution row created by exercise-runtime.js
+// wireExercise), the Get feedback button is PREPENDED INTO that row so it
+// occupies the former Run button's slot — FIRST, before Check and Show
+// solution (the user's stated fix: "replace the Run button", which was
+// first in the toolbar). The feedback CONTAINER (verdict area,
+// data-byok="feedback") stays as a direct child of the exercise element
+// below the controls. When entry.controls is absent (standalone mounts,
+// tests), the button falls back to a direct child of the exercise element
+// above the container.
 export function mountFeedback(entry) {
   // Create the feedback container inside the exercise div.
   const feedbackContainer = document.createElement("div");
@@ -618,9 +620,11 @@ export function mountFeedback(entry) {
   });
 
   if (entry.controls) {
-    // Toolbar placement (issue #182): the button joins the Run/Check/Show
-    // solution row created by exercise-runtime.js wireExercise.
-    entry.controls.appendChild(feedbackBtn);
+    // Toolbar placement (issue #182): the button joins the Check/Show
+    // solution row created by exercise-runtime.js wireExercise — PREPENDED
+    // so Get feedback is first (the former Run button's slot, per the
+    // user's stated fix).
+    entry.controls.insertBefore(feedbackBtn, entry.controls.firstChild);
   } else {
     // Fallback for standalone mounts (no runtime controls row): the button
     // sits directly above the container inside the exercise element.

--- a/_extensions/blendtutor/assets/exercise-runtime.js
+++ b/_extensions/blendtutor/assets/exercise-runtime.js
@@ -2,7 +2,7 @@
 //
 // WHAT:  DOM scan, per-exercise registry, N CodeMirror editors, adapter injection,
 //        hints <details> toggle, solution reveal, check button conditional,
-//        Run button disable/enable, data-status state machine.
+//        controls container exposure (issue #182), data-status state machine.
 // WHERE: _extensions/blendtutor/assets/exercise-runtime.js
 // NOT:   NOT execution (delegated to adapter), NOT feedback (AC-7), NOT filter (AC-2).
 //        NOT adapter loading (AC-3 bootstrap owns that), NOT language defaulting —
@@ -289,16 +289,23 @@ function renderHintsForExercise(entry) {
 }
 
 /**
- * Wire Check/Run buttons and per-exercise state for a single exercise.
- * Creates hints <details>, controls (Run + Check + Solution buttons), status,
- * and output elements inside the exercise div, and binds
+ * Wire Check/Solution buttons and per-exercise state for a single exercise.
+ * Creates hints <details>, controls (Check + Solution buttons + the Get
+ * feedback button slot, which the feedback module fills via entry.controls),
+ * status, and output elements inside the exercise div, and binds
  * getSubmission/setEditorContent/setStatus/runSubmission to the entry.
  *
- * UX polish (AC-8):
+ * UX polish (AC-8) + issue #182:
  *   - Hints <details> toggle rendered before controls (clause 1).
  *   - Check button only when payload.checks is non-empty (clause 3).
  *   - Solution button only when payload.solution is non-null (clause 2).
- *   - Run button disabled during runSubmission, re-enabled in finally (clauses 4+7).
+ *   - Run button REMOVED (issue #182) — Check already runs the deterministic
+ *     tests; Get feedback (mounted by the feedback module into entry.controls)
+ *     replaces Run's toolbar slot.
+ *   - Controls container exposed as entry.controls so other modules (feedback)
+ *     can append into the same toolbar row.
+ *   - Check/Solution buttons disabled during runSubmission, re-enabled in
+ *     finally (clauses 4+7).
  *   - data-status closed set: idle → running → (pass | fail) (clause 6).
  *
  * @param {Object} entry — Registry entry (mutated: adds methods + state).
@@ -311,12 +318,9 @@ function wireExercise(entry, runtime) {
   // Create UI elements inside the exercise div
   const controls = document.createElement("div");
   controls.className = "bt-controls";
-
-  const runBtn = document.createElement("button");
-  runBtn.textContent = "Run";
-  runBtn.className = "bt-run-btn";
-
-  controls.appendChild(runBtn);
+  // Expose the toolbar on the entry (issue #182) so the feedback module can
+  // append the Get feedback button into the same row as Check/Solution.
+  entry.controls = controls;
 
   // Check button — only when the exercise has checks (clause 3: absent when
   // no checks). The button runs the same submission flow as Run.
@@ -387,8 +391,8 @@ function wireExercise(entry, runtime) {
 
   // Per-exercise runSubmission — evaluates via the injected runtime adapter.
   // Concurrent run safety: rejects if already running (§5.3).
-  // Disables THIS exercise's Run button only (clause 4: per-exercise, not
-  // singleton). Also disables Check/Solution buttons when present, so a
+  // Disables THIS exercise's Check/Solution buttons (issue #182: the Run
+  // button is gone; Get feedback is a separate flow with its own guard), so a
   // mid-run click cannot overwrite the editor or trigger a stale run.
   // Re-enables all in finally (clause 7: buttons re-enabled on pass).
   entry._running = false;
@@ -398,7 +402,6 @@ function wireExercise(entry, runtime) {
       return "fail";
     }
     entry._running = true;
-    runBtn.disabled = true;
     if (entry.checkBtn) entry.checkBtn.disabled = true;
     if (entry.solutionBtn) entry.solutionBtn.disabled = true;
     try {
@@ -414,16 +417,10 @@ function wireExercise(entry, runtime) {
       return ok ? "pass" : "fail";
     } finally {
       entry._running = false;
-      runBtn.disabled = false;
       if (entry.checkBtn) entry.checkBtn.disabled = false;
       if (entry.solutionBtn) entry.solutionBtn.disabled = false;
     }
   };
-
-  // Wire the Run button
-  runBtn.addEventListener("click", () => {
-    entry.runSubmission();
-  });
 }
 
 // ---------------------------------------------------------------------------

--- a/_extensions/blendtutor/assets/styles.css
+++ b/_extensions/blendtutor/assets/styles.css
@@ -519,7 +519,7 @@
  * What it does:
  *  - .bt-hints: expandable <details> panel for hints (clause 1).
  *  - .bt-feedback-btn / .bt-check-btn / .bt-solution-btn: control buttons.
- *    (issue #182: .bt-feedback-btn replaced .bt-run-btn — Get feedback takes
+ *    (issue 182: .bt-feedback-btn replaced .bt-run-btn — Get feedback takes
  *    Run's toolbar slot with Run's styling.)
  *  - button[disabled]: cursor not-allowed (clause 5).
  *  - .bt-status[data-status]: closed-set status badge (clause 6).
@@ -581,7 +581,7 @@
   background: var(--bt-color-brand-hover);
 }
 
-/* The former .bt-run-btn (issue #182) is REMOVED from the runtime — Check
+/* The former .bt-run-btn (issue 182) is REMOVED from the runtime — Check
  * runs the deterministic tests and Get feedback (.bt-feedback-btn) takes
  * Run's toolbar slot with Run's styling (above). */
 
@@ -792,7 +792,7 @@
   color: var(--bt-color-status-fail);
 }
 
-/* === Quarto path (per-exercise .bt-feedback) + key page (issue #182) ===
+/* === Quarto path (per-exercise .bt-feedback) + key page (issue 182) ===
  * The Quarto fork renders per-exercise feedback into a .bt-feedback container
  * (exercise-feedback.js mountFeedback) — the #feedback rules above serve the
  * crates site shell and are NOT matched by the new code. This section styles
@@ -803,7 +803,7 @@
  *    transform, EXCEPT selectors wrapped in :global(...) which pass through
  *    UNscoped. The key page (.blendtutor-key) sits OUTSIDE any .bt-exercise
  *    wrapper, so its form rules MUST use :global(...) — a scoped rule would
- *    never match the key page ("bizarre page" bug, issue #182).
+ *    never match the key page ("bizarre page" bug, issue 182).
  *  - The no-key link renders INSIDE .bt-feedback inside .bt-exercise — scoped.
  */
 
@@ -818,7 +818,7 @@
   font-family: var(--bt-font-family-ui);
 }
 
-/* No-key state (AC-4, issue #182): a real affordance — button-styled link,
+/* No-key state (AC-4, issue 182): a real affordance — button-styled link,
  * not a bare default anchor */
 
 .bt-exercise [data-byok="no-key"] {
@@ -885,7 +885,7 @@
   font-size: 0.875em;
 }
 
-/* === KEY PAGE (issue #182) — GLOBAL rules via :global(...) ===
+/* === KEY PAGE (issue 182) — GLOBAL rules via :global(...) ===
  * The key-management form (key-page.js mountKeyPage) renders into
  * <div class="blendtutor-key"> on the api-key page — OUTSIDE any
  * .bt-exercise wrapper. The sync transform passes :global(...) selectors

--- a/_extensions/blendtutor/assets/styles.css
+++ b/_extensions/blendtutor/assets/styles.css
@@ -511,14 +511,16 @@
 
 /* === exercise UX polish (AC-8) === */
 
-/* Per-exercise UX elements: hints <details> toggle, solution/check/run buttons,
+/* Per-exercise UX elements: hints <details> toggle, solution/check buttons,
  * data-status badge, and disabled-button cursor. These are the class-based
  * equivalents of the singleton #lesson-* selectors above, used by
  * exercise-runtime.js's per-exercise wireExercise().
  *
  * What it does:
  *  - .bt-hints: expandable <details> panel for hints (clause 1).
- *  - .bt-run-btn / .bt-check-btn / .bt-solution-btn: control buttons.
+ *  - .bt-feedback-btn / .bt-check-btn / .bt-solution-btn: control buttons.
+ *    (issue #182: .bt-feedback-btn replaced .bt-run-btn — Get feedback takes
+ *    Run's toolbar slot with Run's styling.)
  *  - button[disabled]: cursor not-allowed (clause 5).
  *  - .bt-status[data-status]: closed-set status badge (clause 6).
  *
@@ -563,7 +565,7 @@
   margin-bottom: var(--bt-space-sm);
 }
 
-.bt-exercise .bt-run-btn {
+.bt-exercise .bt-feedback-btn {
   background: var(--bt-color-brand);
   color: var(--bt-color-surface);
   border: none;
@@ -575,9 +577,13 @@
   font-weight: 600;
 }
 
-.bt-exercise .bt-run-btn:hover {
+.bt-exercise .bt-feedback-btn:hover {
   background: var(--bt-color-brand-hover);
 }
+
+/* The former .bt-run-btn (issue #182) is REMOVED from the runtime — Check
+ * runs the deterministic tests and Get feedback (.bt-feedback-btn) takes
+ * Run's toolbar slot with Run's styling (above). */
 
 .bt-exercise .bt-check-btn {
   background: transparent;
@@ -784,6 +790,176 @@
 
 .bt-exercise #feedback [data-byok="error"] {
   color: var(--bt-color-status-fail);
+}
+
+/* === Quarto path (per-exercise .bt-feedback) + key page (issue #182) ===
+ * The Quarto fork renders per-exercise feedback into a .bt-feedback container
+ * (exercise-feedback.js mountFeedback) — the #feedback rules above serve the
+ * crates site shell and are NOT matched by the new code. This section styles
+ * the per-exercise container, the no-key link, and the KEY PAGE form.
+ *
+ * Scoping notes (scripts/sync-quarto-assets.sh):
+ *  - Rules in this source file are prefixed with .bt-exercise by the sync
+ *    transform, EXCEPT selectors wrapped in :global(...) which pass through
+ *    UNscoped. The key page (.blendtutor-key) sits OUTSIDE any .bt-exercise
+ *    wrapper, so its form rules MUST use :global(...) — a scoped rule would
+ *    never match the key page ("bizarre page" bug, issue #182).
+ *  - The no-key link renders INSIDE .bt-feedback inside .bt-exercise — scoped.
+ */
+
+/* Per-exercise feedback container — cards the verdict/no-key/error area */
+
+.bt-exercise .bt-feedback {
+  margin-top: var(--bt-space-md);
+  padding: var(--bt-space-sm);
+  border: 1px solid var(--bt-color-border);
+  border-radius: var(--bt-radius-md);
+  background: var(--bt-color-surface);
+  font-family: var(--bt-font-family-ui);
+}
+
+/* No-key state (AC-4, issue #182): a real affordance — button-styled link,
+ * not a bare default anchor */
+
+.bt-exercise [data-byok="no-key"] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--bt-space-md);
+  color: var(--bt-color-text-secondary);
+  font-size: 0.875em;
+  line-height: var(--bt-line-height);
+}
+
+.bt-exercise [data-byok="no-key"] a {
+  display: inline-block;
+  background: var(--bt-color-brand);
+  color: var(--bt-color-surface);
+  border-radius: var(--bt-radius-sm);
+  padding: var(--bt-space-xs) var(--bt-space-sm);
+  font-family: var(--bt-font-family-ui);
+  font-size: var(--bt-font-size-base);
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.bt-exercise [data-byok="no-key"] a:hover {
+  background: var(--bt-color-brand-hover);
+}
+
+/* Verdict / pending / error / limit-reached inside the per-exercise container */
+
+.bt-exercise [data-byok="feedback"] [data-byok="verdict"][data-correct="true"] {
+  background: var(--bt-color-success-bg);
+  color: var(--bt-color-text-primary);
+  border-left: 4px solid var(--bt-color-status-pass);
+}
+
+.bt-exercise [data-byok="feedback"] [data-byok="verdict"][data-correct="true"] strong {
+  color: var(--bt-color-status-pass);
+}
+
+.bt-exercise [data-byok="feedback"] [data-byok="verdict"][data-correct="false"] {
+  background: var(--bt-color-danger-bg);
+  color: var(--bt-color-text-primary);
+  border-left: 4px solid var(--bt-color-status-fail);
+}
+
+.bt-exercise [data-byok="feedback"] [data-byok="verdict"][data-correct="false"] strong {
+  color: var(--bt-color-status-fail);
+}
+
+.bt-exercise [data-byok="feedback"] [data-byok="pending"] {
+  color: var(--bt-color-text-secondary);
+  animation: bt-pulse 1.5s ease-in-out infinite;
+}
+
+.bt-exercise [data-byok="feedback"] [data-byok="error"] {
+  color: var(--bt-color-status-fail);
+}
+
+.bt-exercise [data-byok="feedback"] [data-byok="limit-reached"] {
+  color: var(--bt-color-text-secondary);
+  font-size: 0.875em;
+}
+
+/* === KEY PAGE (issue #182) — GLOBAL rules via :global(...) ===
+ * The key-management form (key-page.js mountKeyPage) renders into
+ * <div class="blendtutor-key"> on the api-key page — OUTSIDE any
+ * .bt-exercise wrapper. The sync transform passes :global(...) selectors
+ * through unscoped so these rules reach the key page. */
+
+[data-byok="key-page-form"] {
+  display: flex;
+  flex-direction: column;
+  gap: var(--bt-space-md);
+  max-width: 28rem;
+  padding: var(--bt-space-lg);
+  border: 1px solid var(--bt-color-border);
+  border-radius: var(--bt-radius-md);
+  background: var(--bt-color-surface);
+  box-shadow: var(--bt-shadow-sm);
+  font-family: var(--bt-font-family-ui);
+}
+
+[data-byok="key-input"] {
+  border: 1px solid var(--bt-color-border);
+  border-radius: var(--bt-radius-sm);
+  padding: var(--bt-space-xs) var(--bt-space-sm);
+  background: var(--bt-color-surface);
+  color: var(--bt-color-text-primary);
+  font-family: var(--bt-font-family-ui);
+  font-size: var(--bt-font-size-base);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+[data-byok="key-input"]:focus {
+  outline: none;
+  border-color: var(--bt-color-brand);
+}
+
+[data-byok="save"] {
+  align-self: flex-start;
+  background: var(--bt-color-brand);
+  color: var(--bt-color-surface);
+  border: none;
+  border-radius: var(--bt-radius-sm);
+  padding: var(--bt-space-xs) var(--bt-space-sm);
+  font-family: var(--bt-font-family-ui);
+  font-size: var(--bt-font-size-base);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+[data-byok="save"]:hover {
+  background: var(--bt-color-brand-hover);
+}
+
+[data-byok="clear"] {
+  align-self: flex-start;
+  background: transparent;
+  border: 1px solid var(--bt-color-border);
+  color: var(--bt-color-text-primary);
+  border-radius: var(--bt-radius-sm);
+  padding: var(--bt-space-xs) var(--bt-space-sm);
+  font-family: var(--bt-font-family-ui);
+  font-size: var(--bt-font-size-base);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+[data-byok="clear"]:hover {
+  background: color-mix(in srgb, var(--bt-color-border) 20%, transparent);
+}
+
+[data-byok="key-status"] {
+  margin: 0;
+  color: var(--bt-color-text-secondary);
+  font-size: 0.875em;
+  line-height: var(--bt-line-height);
 }
 
 /* ── Dark mode ────────────────────────────────────────────────────

--- a/_extensions/blendtutor/blendtutor.lua
+++ b/_extensions/blendtutor/blendtutor.lua
@@ -666,6 +666,11 @@ local function build_bootstrap_script()
 
   parts[#parts + 1] = ''
   parts[#parts + 1] = '  const registry = buildRegistry(scanExercises());'
+  -- ISSUE #182: mountKeyPage runs BEFORE start() — a start() rejection (or a
+  -- synchronously-thrown adapter factory) must never skip the key-page mount
+  -- (previously it sat inside .then(), so a rejected boot left the key page
+  -- as bare placeholder text). mountKeyPage has no registry dependency.
+  parts[#parts + 1] = '  mountKeyPage(document.querySelector(".blendtutor-key"));'
   parts[#parts + 1] = '  start(registry, {'
   if has_r then
     parts[#parts + 1] = '    r: createWebRAdapter(),'
@@ -677,7 +682,6 @@ local function build_bootstrap_script()
   if not bt_feedback_optout then
     parts[#parts + 1] = '    mountAllFeedback(registry);'
   end
-  parts[#parts + 1] = '    mountKeyPage(document.querySelector(".blendtutor-key"));'
   parts[#parts + 1] = '  }).catch((err) => console.error("[blendtutor] auto-bootstrap failed", err));'
   parts[#parts + 1] = '</script>'
 

--- a/crates/core/assets/shared/styles.css
+++ b/crates/core/assets/shared/styles.css
@@ -495,7 +495,7 @@ footer.site-footer {
  * What it does:
  *  - .bt-hints: expandable <details> panel for hints (clause 1).
  *  - .bt-feedback-btn / .bt-check-btn / .bt-solution-btn: control buttons.
- *    (issue #182: .bt-feedback-btn replaced .bt-run-btn — Get feedback takes
+ *    (issue 182: .bt-feedback-btn replaced .bt-run-btn — Get feedback takes
  *    Run's toolbar slot with Run's styling.)
  *  - button[disabled]: cursor not-allowed (clause 5).
  *  - .bt-status[data-status]: closed-set status badge (clause 6).
@@ -557,7 +557,7 @@ footer.site-footer {
   background: var(--bt-color-brand-hover);
 }
 
-/* The former .bt-run-btn (issue #182) is REMOVED from the runtime — Check
+/* The former .bt-run-btn (issue 182) is REMOVED from the runtime — Check
  * runs the deterministic tests and Get feedback (.bt-feedback-btn) takes
  * Run's toolbar slot with Run's styling (above). */
 
@@ -759,7 +759,7 @@ button[disabled] {
   color: var(--bt-color-status-fail);
 }
 
-/* === Quarto path (per-exercise .bt-feedback) + key page (issue #182) ===
+/* === Quarto path (per-exercise .bt-feedback) + key page (issue 182) ===
  * The Quarto fork renders per-exercise feedback into a .bt-feedback container
  * (exercise-feedback.js mountFeedback) — the #feedback rules above serve the
  * crates site shell and are NOT matched by the new code. This section styles
@@ -770,7 +770,7 @@ button[disabled] {
  *    transform, EXCEPT selectors wrapped in :global(...) which pass through
  *    UNscoped. The key page (.blendtutor-key) sits OUTSIDE any .bt-exercise
  *    wrapper, so its form rules MUST use :global(...) — a scoped rule would
- *    never match the key page ("bizarre page" bug, issue #182).
+ *    never match the key page ("bizarre page" bug, issue 182).
  *  - The no-key link renders INSIDE .bt-feedback inside .bt-exercise — scoped.
  */
 
@@ -784,7 +784,7 @@ button[disabled] {
   font-family: var(--bt-font-family-ui);
 }
 
-/* No-key state (AC-4, issue #182): a real affordance — button-styled link,
+/* No-key state (AC-4, issue 182): a real affordance — button-styled link,
  * not a bare default anchor */
 [data-byok="no-key"] {
   display: flex;
@@ -849,7 +849,7 @@ button[disabled] {
   font-size: 0.875em;
 }
 
-/* === KEY PAGE (issue #182) — GLOBAL rules via :global(...) ===
+/* === KEY PAGE (issue 182) — GLOBAL rules via :global(...) ===
  * The key-management form (key-page.js mountKeyPage) renders into
  * <div class="blendtutor-key"> on the api-key page — OUTSIDE any
  * .bt-exercise wrapper. The sync transform passes :global(...) selectors

--- a/crates/core/assets/shared/styles.css
+++ b/crates/core/assets/shared/styles.css
@@ -487,14 +487,16 @@ footer.site-footer {
 }
 
 /* === exercise UX polish (AC-8) === */
-/* Per-exercise UX elements: hints <details> toggle, solution/check/run buttons,
+/* Per-exercise UX elements: hints <details> toggle, solution/check buttons,
  * data-status badge, and disabled-button cursor. These are the class-based
  * equivalents of the singleton #lesson-* selectors above, used by
  * exercise-runtime.js's per-exercise wireExercise().
  *
  * What it does:
  *  - .bt-hints: expandable <details> panel for hints (clause 1).
- *  - .bt-run-btn / .bt-check-btn / .bt-solution-btn: control buttons.
+ *  - .bt-feedback-btn / .bt-check-btn / .bt-solution-btn: control buttons.
+ *    (issue #182: .bt-feedback-btn replaced .bt-run-btn — Get feedback takes
+ *    Run's toolbar slot with Run's styling.)
  *  - button[disabled]: cursor not-allowed (clause 5).
  *  - .bt-status[data-status]: closed-set status badge (clause 6).
  *
@@ -539,7 +541,7 @@ footer.site-footer {
   margin-bottom: var(--bt-space-sm);
 }
 
-.bt-run-btn {
+.bt-feedback-btn {
   background: var(--bt-color-brand);
   color: var(--bt-color-surface);
   border: none;
@@ -551,9 +553,13 @@ footer.site-footer {
   font-weight: 600;
 }
 
-.bt-run-btn:hover {
+.bt-feedback-btn:hover {
   background: var(--bt-color-brand-hover);
 }
+
+/* The former .bt-run-btn (issue #182) is REMOVED from the runtime — Check
+ * runs the deterministic tests and Get feedback (.bt-feedback-btn) takes
+ * Run's toolbar slot with Run's styling (above). */
 
 .bt-check-btn {
   background: transparent;
@@ -751,6 +757,173 @@ button[disabled] {
 /* Error — text-only emphasis: fail color, no background tint (distinct from verdict) */
 #feedback [data-byok="error"] {
   color: var(--bt-color-status-fail);
+}
+
+/* === Quarto path (per-exercise .bt-feedback) + key page (issue #182) ===
+ * The Quarto fork renders per-exercise feedback into a .bt-feedback container
+ * (exercise-feedback.js mountFeedback) — the #feedback rules above serve the
+ * crates site shell and are NOT matched by the new code. This section styles
+ * the per-exercise container, the no-key link, and the KEY PAGE form.
+ *
+ * Scoping notes (scripts/sync-quarto-assets.sh):
+ *  - Rules in this source file are prefixed with .bt-exercise by the sync
+ *    transform, EXCEPT selectors wrapped in :global(...) which pass through
+ *    UNscoped. The key page (.blendtutor-key) sits OUTSIDE any .bt-exercise
+ *    wrapper, so its form rules MUST use :global(...) — a scoped rule would
+ *    never match the key page ("bizarre page" bug, issue #182).
+ *  - The no-key link renders INSIDE .bt-feedback inside .bt-exercise — scoped.
+ */
+
+/* Per-exercise feedback container — cards the verdict/no-key/error area */
+.bt-feedback {
+  margin-top: var(--bt-space-md);
+  padding: var(--bt-space-sm);
+  border: 1px solid var(--bt-color-border);
+  border-radius: var(--bt-radius-md);
+  background: var(--bt-color-surface);
+  font-family: var(--bt-font-family-ui);
+}
+
+/* No-key state (AC-4, issue #182): a real affordance — button-styled link,
+ * not a bare default anchor */
+[data-byok="no-key"] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--bt-space-md);
+  color: var(--bt-color-text-secondary);
+  font-size: 0.875em;
+  line-height: var(--bt-line-height);
+}
+
+[data-byok="no-key"] a {
+  display: inline-block;
+  background: var(--bt-color-brand);
+  color: var(--bt-color-surface);
+  border-radius: var(--bt-radius-sm);
+  padding: var(--bt-space-xs) var(--bt-space-sm);
+  font-family: var(--bt-font-family-ui);
+  font-size: var(--bt-font-size-base);
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+[data-byok="no-key"] a:hover {
+  background: var(--bt-color-brand-hover);
+}
+
+/* Verdict / pending / error / limit-reached inside the per-exercise container */
+[data-byok="feedback"] [data-byok="verdict"][data-correct="true"] {
+  background: var(--bt-color-success-bg);
+  color: var(--bt-color-text-primary);
+  border-left: 4px solid var(--bt-color-status-pass);
+}
+
+[data-byok="feedback"] [data-byok="verdict"][data-correct="true"] strong {
+  color: var(--bt-color-status-pass);
+}
+
+[data-byok="feedback"] [data-byok="verdict"][data-correct="false"] {
+  background: var(--bt-color-danger-bg);
+  color: var(--bt-color-text-primary);
+  border-left: 4px solid var(--bt-color-status-fail);
+}
+
+[data-byok="feedback"] [data-byok="verdict"][data-correct="false"] strong {
+  color: var(--bt-color-status-fail);
+}
+
+[data-byok="feedback"] [data-byok="pending"] {
+  color: var(--bt-color-text-secondary);
+  animation: bt-pulse 1.5s ease-in-out infinite;
+}
+
+[data-byok="feedback"] [data-byok="error"] {
+  color: var(--bt-color-status-fail);
+}
+
+[data-byok="feedback"] [data-byok="limit-reached"] {
+  color: var(--bt-color-text-secondary);
+  font-size: 0.875em;
+}
+
+/* === KEY PAGE (issue #182) — GLOBAL rules via :global(...) ===
+ * The key-management form (key-page.js mountKeyPage) renders into
+ * <div class="blendtutor-key"> on the api-key page — OUTSIDE any
+ * .bt-exercise wrapper. The sync transform passes :global(...) selectors
+ * through unscoped so these rules reach the key page. */
+
+:global([data-byok="key-page-form"]) {
+  display: flex;
+  flex-direction: column;
+  gap: var(--bt-space-md);
+  max-width: 28rem;
+  padding: var(--bt-space-lg);
+  border: 1px solid var(--bt-color-border);
+  border-radius: var(--bt-radius-md);
+  background: var(--bt-color-surface);
+  box-shadow: var(--bt-shadow-sm);
+  font-family: var(--bt-font-family-ui);
+}
+
+:global([data-byok="key-input"]) {
+  border: 1px solid var(--bt-color-border);
+  border-radius: var(--bt-radius-sm);
+  padding: var(--bt-space-xs) var(--bt-space-sm);
+  background: var(--bt-color-surface);
+  color: var(--bt-color-text-primary);
+  font-family: var(--bt-font-family-ui);
+  font-size: var(--bt-font-size-base);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+:global([data-byok="key-input"]:focus) {
+  outline: none;
+  border-color: var(--bt-color-brand);
+}
+
+:global([data-byok="save"]) {
+  align-self: flex-start;
+  background: var(--bt-color-brand);
+  color: var(--bt-color-surface);
+  border: none;
+  border-radius: var(--bt-radius-sm);
+  padding: var(--bt-space-xs) var(--bt-space-sm);
+  font-family: var(--bt-font-family-ui);
+  font-size: var(--bt-font-size-base);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+:global([data-byok="save"]:hover) {
+  background: var(--bt-color-brand-hover);
+}
+
+:global([data-byok="clear"]) {
+  align-self: flex-start;
+  background: transparent;
+  border: 1px solid var(--bt-color-border);
+  color: var(--bt-color-text-primary);
+  border-radius: var(--bt-radius-sm);
+  padding: var(--bt-space-xs) var(--bt-space-sm);
+  font-family: var(--bt-font-family-ui);
+  font-size: var(--bt-font-size-base);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+:global([data-byok="clear"]:hover) {
+  background: color-mix(in srgb, var(--bt-color-border) 20%, transparent);
+}
+
+:global([data-byok="key-status"]) {
+  margin: 0;
+  color: var(--bt-color-text-secondary);
+  font-size: 0.875em;
+  line-height: var(--bt-line-height);
 }
 
 /* ── Dark mode ────────────────────────────────────────────────────

--- a/demo-book/_extensions/mcmullarkey/blendtutor/assets/exercise-feedback.js
+++ b/demo-book/_extensions/mcmullarkey/blendtutor/assets/exercise-feedback.js
@@ -588,6 +588,15 @@ export function applyEmbeddedKey() {
 // The button triggers handleSubmitForExercise(entry), which reads the
 // submission from entry.getSubmission() (the per-exercise editor) and the key
 // from shared localStorage (entered once, reused).
+//
+// Issue #182 (toolbar placement): when the runtime has exposed entry.controls
+// (the Run/Check/Show-solution row created by exercise-runtime.js
+// wireExercise), the Get feedback button is appended INTO that row so it sits
+// with the other control buttons (styled like the former Run button). The
+// feedback CONTAINER (verdict area, data-byok="feedback") stays as a direct
+// child of the exercise element below the controls. When entry.controls is
+// absent (standalone mounts, tests), the button falls back to a direct child
+// of the exercise element above the container.
 export function mountFeedback(entry) {
   // Create the feedback container inside the exercise div.
   const feedbackContainer = document.createElement("div");
@@ -608,10 +617,16 @@ export function mountFeedback(entry) {
     handleSubmitForExercise(entry);
   });
 
-  const wrapper = document.createElement("div");
-  wrapper.className = "bt-feedback-wrapper";
-  wrapper.append(feedbackBtn, feedbackContainer);
-  entry.element.appendChild(wrapper);
+  if (entry.controls) {
+    // Toolbar placement (issue #182): the button joins the Run/Check/Show
+    // solution row created by exercise-runtime.js wireExercise.
+    entry.controls.appendChild(feedbackBtn);
+  } else {
+    // Fallback for standalone mounts (no runtime controls row): the button
+    // sits directly above the container inside the exercise element.
+    entry.element.appendChild(feedbackBtn);
+  }
+  entry.element.appendChild(feedbackContainer);
 }
 
 // Mount feedback UI for every exercise in the registry. Called by the page

--- a/demo-book/_extensions/mcmullarkey/blendtutor/assets/exercise-feedback.js
+++ b/demo-book/_extensions/mcmullarkey/blendtutor/assets/exercise-feedback.js
@@ -590,13 +590,15 @@ export function applyEmbeddedKey() {
 // from shared localStorage (entered once, reused).
 //
 // Issue #182 (toolbar placement): when the runtime has exposed entry.controls
-// (the Run/Check/Show-solution row created by exercise-runtime.js
-// wireExercise), the Get feedback button is appended INTO that row so it sits
-// with the other control buttons (styled like the former Run button). The
-// feedback CONTAINER (verdict area, data-byok="feedback") stays as a direct
-// child of the exercise element below the controls. When entry.controls is
-// absent (standalone mounts, tests), the button falls back to a direct child
-// of the exercise element above the container.
+// (the Check/Show-solution row created by exercise-runtime.js
+// wireExercise), the Get feedback button is PREPENDED INTO that row so it
+// occupies the former Run button's slot — FIRST, before Check and Show
+// solution (the user's stated fix: "replace the Run button", which was
+// first in the toolbar). The feedback CONTAINER (verdict area,
+// data-byok="feedback") stays as a direct child of the exercise element
+// below the controls. When entry.controls is absent (standalone mounts,
+// tests), the button falls back to a direct child of the exercise element
+// above the container.
 export function mountFeedback(entry) {
   // Create the feedback container inside the exercise div.
   const feedbackContainer = document.createElement("div");
@@ -618,9 +620,11 @@ export function mountFeedback(entry) {
   });
 
   if (entry.controls) {
-    // Toolbar placement (issue #182): the button joins the Run/Check/Show
-    // solution row created by exercise-runtime.js wireExercise.
-    entry.controls.appendChild(feedbackBtn);
+    // Toolbar placement (issue #182): the button joins the Check/Show
+    // solution row created by exercise-runtime.js wireExercise — PREPENDED
+    // so Get feedback is first (the former Run button's slot, per the
+    // user's stated fix).
+    entry.controls.insertBefore(feedbackBtn, entry.controls.firstChild);
   } else {
     // Fallback for standalone mounts (no runtime controls row): the button
     // sits directly above the container inside the exercise element.

--- a/demo-book/_extensions/mcmullarkey/blendtutor/assets/exercise-runtime.js
+++ b/demo-book/_extensions/mcmullarkey/blendtutor/assets/exercise-runtime.js
@@ -2,7 +2,7 @@
 //
 // WHAT:  DOM scan, per-exercise registry, N CodeMirror editors, adapter injection,
 //        hints <details> toggle, solution reveal, check button conditional,
-//        Run button disable/enable, data-status state machine.
+//        controls container exposure (issue #182), data-status state machine.
 // WHERE: _extensions/blendtutor/assets/exercise-runtime.js
 // NOT:   NOT execution (delegated to adapter), NOT feedback (AC-7), NOT filter (AC-2).
 //        NOT adapter loading (AC-3 bootstrap owns that), NOT language defaulting —
@@ -289,16 +289,23 @@ function renderHintsForExercise(entry) {
 }
 
 /**
- * Wire Check/Run buttons and per-exercise state for a single exercise.
- * Creates hints <details>, controls (Run + Check + Solution buttons), status,
- * and output elements inside the exercise div, and binds
+ * Wire Check/Solution buttons and per-exercise state for a single exercise.
+ * Creates hints <details>, controls (Check + Solution buttons + the Get
+ * feedback button slot, which the feedback module fills via entry.controls),
+ * status, and output elements inside the exercise div, and binds
  * getSubmission/setEditorContent/setStatus/runSubmission to the entry.
  *
- * UX polish (AC-8):
+ * UX polish (AC-8) + issue #182:
  *   - Hints <details> toggle rendered before controls (clause 1).
  *   - Check button only when payload.checks is non-empty (clause 3).
  *   - Solution button only when payload.solution is non-null (clause 2).
- *   - Run button disabled during runSubmission, re-enabled in finally (clauses 4+7).
+ *   - Run button REMOVED (issue #182) — Check already runs the deterministic
+ *     tests; Get feedback (mounted by the feedback module into entry.controls)
+ *     replaces Run's toolbar slot.
+ *   - Controls container exposed as entry.controls so other modules (feedback)
+ *     can append into the same toolbar row.
+ *   - Check/Solution buttons disabled during runSubmission, re-enabled in
+ *     finally (clauses 4+7).
  *   - data-status closed set: idle → running → (pass | fail) (clause 6).
  *
  * @param {Object} entry — Registry entry (mutated: adds methods + state).
@@ -311,12 +318,9 @@ function wireExercise(entry, runtime) {
   // Create UI elements inside the exercise div
   const controls = document.createElement("div");
   controls.className = "bt-controls";
-
-  const runBtn = document.createElement("button");
-  runBtn.textContent = "Run";
-  runBtn.className = "bt-run-btn";
-
-  controls.appendChild(runBtn);
+  // Expose the toolbar on the entry (issue #182) so the feedback module can
+  // append the Get feedback button into the same row as Check/Solution.
+  entry.controls = controls;
 
   // Check button — only when the exercise has checks (clause 3: absent when
   // no checks). The button runs the same submission flow as Run.
@@ -387,8 +391,8 @@ function wireExercise(entry, runtime) {
 
   // Per-exercise runSubmission — evaluates via the injected runtime adapter.
   // Concurrent run safety: rejects if already running (§5.3).
-  // Disables THIS exercise's Run button only (clause 4: per-exercise, not
-  // singleton). Also disables Check/Solution buttons when present, so a
+  // Disables THIS exercise's Check/Solution buttons (issue #182: the Run
+  // button is gone; Get feedback is a separate flow with its own guard), so a
   // mid-run click cannot overwrite the editor or trigger a stale run.
   // Re-enables all in finally (clause 7: buttons re-enabled on pass).
   entry._running = false;
@@ -398,7 +402,6 @@ function wireExercise(entry, runtime) {
       return "fail";
     }
     entry._running = true;
-    runBtn.disabled = true;
     if (entry.checkBtn) entry.checkBtn.disabled = true;
     if (entry.solutionBtn) entry.solutionBtn.disabled = true;
     try {
@@ -414,16 +417,10 @@ function wireExercise(entry, runtime) {
       return ok ? "pass" : "fail";
     } finally {
       entry._running = false;
-      runBtn.disabled = false;
       if (entry.checkBtn) entry.checkBtn.disabled = false;
       if (entry.solutionBtn) entry.solutionBtn.disabled = false;
     }
   };
-
-  // Wire the Run button
-  runBtn.addEventListener("click", () => {
-    entry.runSubmission();
-  });
 }
 
 // ---------------------------------------------------------------------------

--- a/demo-book/_extensions/mcmullarkey/blendtutor/assets/styles.css
+++ b/demo-book/_extensions/mcmullarkey/blendtutor/assets/styles.css
@@ -519,7 +519,7 @@
  * What it does:
  *  - .bt-hints: expandable <details> panel for hints (clause 1).
  *  - .bt-feedback-btn / .bt-check-btn / .bt-solution-btn: control buttons.
- *    (issue #182: .bt-feedback-btn replaced .bt-run-btn — Get feedback takes
+ *    (issue 182: .bt-feedback-btn replaced .bt-run-btn — Get feedback takes
  *    Run's toolbar slot with Run's styling.)
  *  - button[disabled]: cursor not-allowed (clause 5).
  *  - .bt-status[data-status]: closed-set status badge (clause 6).
@@ -581,7 +581,7 @@
   background: var(--bt-color-brand-hover);
 }
 
-/* The former .bt-run-btn (issue #182) is REMOVED from the runtime — Check
+/* The former .bt-run-btn (issue 182) is REMOVED from the runtime — Check
  * runs the deterministic tests and Get feedback (.bt-feedback-btn) takes
  * Run's toolbar slot with Run's styling (above). */
 
@@ -792,7 +792,7 @@
   color: var(--bt-color-status-fail);
 }
 
-/* === Quarto path (per-exercise .bt-feedback) + key page (issue #182) ===
+/* === Quarto path (per-exercise .bt-feedback) + key page (issue 182) ===
  * The Quarto fork renders per-exercise feedback into a .bt-feedback container
  * (exercise-feedback.js mountFeedback) — the #feedback rules above serve the
  * crates site shell and are NOT matched by the new code. This section styles
@@ -803,7 +803,7 @@
  *    transform, EXCEPT selectors wrapped in :global(...) which pass through
  *    UNscoped. The key page (.blendtutor-key) sits OUTSIDE any .bt-exercise
  *    wrapper, so its form rules MUST use :global(...) — a scoped rule would
- *    never match the key page ("bizarre page" bug, issue #182).
+ *    never match the key page ("bizarre page" bug, issue 182).
  *  - The no-key link renders INSIDE .bt-feedback inside .bt-exercise — scoped.
  */
 
@@ -818,7 +818,7 @@
   font-family: var(--bt-font-family-ui);
 }
 
-/* No-key state (AC-4, issue #182): a real affordance — button-styled link,
+/* No-key state (AC-4, issue 182): a real affordance — button-styled link,
  * not a bare default anchor */
 
 .bt-exercise [data-byok="no-key"] {
@@ -885,7 +885,7 @@
   font-size: 0.875em;
 }
 
-/* === KEY PAGE (issue #182) — GLOBAL rules via :global(...) ===
+/* === KEY PAGE (issue 182) — GLOBAL rules via :global(...) ===
  * The key-management form (key-page.js mountKeyPage) renders into
  * <div class="blendtutor-key"> on the api-key page — OUTSIDE any
  * .bt-exercise wrapper. The sync transform passes :global(...) selectors

--- a/demo-book/_extensions/mcmullarkey/blendtutor/assets/styles.css
+++ b/demo-book/_extensions/mcmullarkey/blendtutor/assets/styles.css
@@ -511,14 +511,16 @@
 
 /* === exercise UX polish (AC-8) === */
 
-/* Per-exercise UX elements: hints <details> toggle, solution/check/run buttons,
+/* Per-exercise UX elements: hints <details> toggle, solution/check buttons,
  * data-status badge, and disabled-button cursor. These are the class-based
  * equivalents of the singleton #lesson-* selectors above, used by
  * exercise-runtime.js's per-exercise wireExercise().
  *
  * What it does:
  *  - .bt-hints: expandable <details> panel for hints (clause 1).
- *  - .bt-run-btn / .bt-check-btn / .bt-solution-btn: control buttons.
+ *  - .bt-feedback-btn / .bt-check-btn / .bt-solution-btn: control buttons.
+ *    (issue #182: .bt-feedback-btn replaced .bt-run-btn — Get feedback takes
+ *    Run's toolbar slot with Run's styling.)
  *  - button[disabled]: cursor not-allowed (clause 5).
  *  - .bt-status[data-status]: closed-set status badge (clause 6).
  *
@@ -563,7 +565,7 @@
   margin-bottom: var(--bt-space-sm);
 }
 
-.bt-exercise .bt-run-btn {
+.bt-exercise .bt-feedback-btn {
   background: var(--bt-color-brand);
   color: var(--bt-color-surface);
   border: none;
@@ -575,9 +577,13 @@
   font-weight: 600;
 }
 
-.bt-exercise .bt-run-btn:hover {
+.bt-exercise .bt-feedback-btn:hover {
   background: var(--bt-color-brand-hover);
 }
+
+/* The former .bt-run-btn (issue #182) is REMOVED from the runtime — Check
+ * runs the deterministic tests and Get feedback (.bt-feedback-btn) takes
+ * Run's toolbar slot with Run's styling (above). */
 
 .bt-exercise .bt-check-btn {
   background: transparent;
@@ -784,6 +790,176 @@
 
 .bt-exercise #feedback [data-byok="error"] {
   color: var(--bt-color-status-fail);
+}
+
+/* === Quarto path (per-exercise .bt-feedback) + key page (issue #182) ===
+ * The Quarto fork renders per-exercise feedback into a .bt-feedback container
+ * (exercise-feedback.js mountFeedback) — the #feedback rules above serve the
+ * crates site shell and are NOT matched by the new code. This section styles
+ * the per-exercise container, the no-key link, and the KEY PAGE form.
+ *
+ * Scoping notes (scripts/sync-quarto-assets.sh):
+ *  - Rules in this source file are prefixed with .bt-exercise by the sync
+ *    transform, EXCEPT selectors wrapped in :global(...) which pass through
+ *    UNscoped. The key page (.blendtutor-key) sits OUTSIDE any .bt-exercise
+ *    wrapper, so its form rules MUST use :global(...) — a scoped rule would
+ *    never match the key page ("bizarre page" bug, issue #182).
+ *  - The no-key link renders INSIDE .bt-feedback inside .bt-exercise — scoped.
+ */
+
+/* Per-exercise feedback container — cards the verdict/no-key/error area */
+
+.bt-exercise .bt-feedback {
+  margin-top: var(--bt-space-md);
+  padding: var(--bt-space-sm);
+  border: 1px solid var(--bt-color-border);
+  border-radius: var(--bt-radius-md);
+  background: var(--bt-color-surface);
+  font-family: var(--bt-font-family-ui);
+}
+
+/* No-key state (AC-4, issue #182): a real affordance — button-styled link,
+ * not a bare default anchor */
+
+.bt-exercise [data-byok="no-key"] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--bt-space-md);
+  color: var(--bt-color-text-secondary);
+  font-size: 0.875em;
+  line-height: var(--bt-line-height);
+}
+
+.bt-exercise [data-byok="no-key"] a {
+  display: inline-block;
+  background: var(--bt-color-brand);
+  color: var(--bt-color-surface);
+  border-radius: var(--bt-radius-sm);
+  padding: var(--bt-space-xs) var(--bt-space-sm);
+  font-family: var(--bt-font-family-ui);
+  font-size: var(--bt-font-size-base);
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.bt-exercise [data-byok="no-key"] a:hover {
+  background: var(--bt-color-brand-hover);
+}
+
+/* Verdict / pending / error / limit-reached inside the per-exercise container */
+
+.bt-exercise [data-byok="feedback"] [data-byok="verdict"][data-correct="true"] {
+  background: var(--bt-color-success-bg);
+  color: var(--bt-color-text-primary);
+  border-left: 4px solid var(--bt-color-status-pass);
+}
+
+.bt-exercise [data-byok="feedback"] [data-byok="verdict"][data-correct="true"] strong {
+  color: var(--bt-color-status-pass);
+}
+
+.bt-exercise [data-byok="feedback"] [data-byok="verdict"][data-correct="false"] {
+  background: var(--bt-color-danger-bg);
+  color: var(--bt-color-text-primary);
+  border-left: 4px solid var(--bt-color-status-fail);
+}
+
+.bt-exercise [data-byok="feedback"] [data-byok="verdict"][data-correct="false"] strong {
+  color: var(--bt-color-status-fail);
+}
+
+.bt-exercise [data-byok="feedback"] [data-byok="pending"] {
+  color: var(--bt-color-text-secondary);
+  animation: bt-pulse 1.5s ease-in-out infinite;
+}
+
+.bt-exercise [data-byok="feedback"] [data-byok="error"] {
+  color: var(--bt-color-status-fail);
+}
+
+.bt-exercise [data-byok="feedback"] [data-byok="limit-reached"] {
+  color: var(--bt-color-text-secondary);
+  font-size: 0.875em;
+}
+
+/* === KEY PAGE (issue #182) — GLOBAL rules via :global(...) ===
+ * The key-management form (key-page.js mountKeyPage) renders into
+ * <div class="blendtutor-key"> on the api-key page — OUTSIDE any
+ * .bt-exercise wrapper. The sync transform passes :global(...) selectors
+ * through unscoped so these rules reach the key page. */
+
+[data-byok="key-page-form"] {
+  display: flex;
+  flex-direction: column;
+  gap: var(--bt-space-md);
+  max-width: 28rem;
+  padding: var(--bt-space-lg);
+  border: 1px solid var(--bt-color-border);
+  border-radius: var(--bt-radius-md);
+  background: var(--bt-color-surface);
+  box-shadow: var(--bt-shadow-sm);
+  font-family: var(--bt-font-family-ui);
+}
+
+[data-byok="key-input"] {
+  border: 1px solid var(--bt-color-border);
+  border-radius: var(--bt-radius-sm);
+  padding: var(--bt-space-xs) var(--bt-space-sm);
+  background: var(--bt-color-surface);
+  color: var(--bt-color-text-primary);
+  font-family: var(--bt-font-family-ui);
+  font-size: var(--bt-font-size-base);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+[data-byok="key-input"]:focus {
+  outline: none;
+  border-color: var(--bt-color-brand);
+}
+
+[data-byok="save"] {
+  align-self: flex-start;
+  background: var(--bt-color-brand);
+  color: var(--bt-color-surface);
+  border: none;
+  border-radius: var(--bt-radius-sm);
+  padding: var(--bt-space-xs) var(--bt-space-sm);
+  font-family: var(--bt-font-family-ui);
+  font-size: var(--bt-font-size-base);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+[data-byok="save"]:hover {
+  background: var(--bt-color-brand-hover);
+}
+
+[data-byok="clear"] {
+  align-self: flex-start;
+  background: transparent;
+  border: 1px solid var(--bt-color-border);
+  color: var(--bt-color-text-primary);
+  border-radius: var(--bt-radius-sm);
+  padding: var(--bt-space-xs) var(--bt-space-sm);
+  font-family: var(--bt-font-family-ui);
+  font-size: var(--bt-font-size-base);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+[data-byok="clear"]:hover {
+  background: color-mix(in srgb, var(--bt-color-border) 20%, transparent);
+}
+
+[data-byok="key-status"] {
+  margin: 0;
+  color: var(--bt-color-text-secondary);
+  font-size: 0.875em;
+  line-height: var(--bt-line-height);
 }
 
 /* ── Dark mode ────────────────────────────────────────────────────

--- a/demo-book/_extensions/mcmullarkey/blendtutor/blendtutor.lua
+++ b/demo-book/_extensions/mcmullarkey/blendtutor/blendtutor.lua
@@ -666,6 +666,11 @@ local function build_bootstrap_script()
 
   parts[#parts + 1] = ''
   parts[#parts + 1] = '  const registry = buildRegistry(scanExercises());'
+  -- ISSUE #182: mountKeyPage runs BEFORE start() — a start() rejection (or a
+  -- synchronously-thrown adapter factory) must never skip the key-page mount
+  -- (previously it sat inside .then(), so a rejected boot left the key page
+  -- as bare placeholder text). mountKeyPage has no registry dependency.
+  parts[#parts + 1] = '  mountKeyPage(document.querySelector(".blendtutor-key"));'
   parts[#parts + 1] = '  start(registry, {'
   if has_r then
     parts[#parts + 1] = '    r: createWebRAdapter(),'
@@ -677,7 +682,6 @@ local function build_bootstrap_script()
   if not bt_feedback_optout then
     parts[#parts + 1] = '    mountAllFeedback(registry);'
   end
-  parts[#parts + 1] = '    mountKeyPage(document.querySelector(".blendtutor-key"));'
   parts[#parts + 1] = '  }).catch((err) => console.error("[blendtutor] auto-bootstrap failed", err));'
   parts[#parts + 1] = '</script>'
 

--- a/demo-book/api-key.qmd
+++ b/demo-book/api-key.qmd
@@ -18,9 +18,7 @@ Create a Fireworks account and generate an API key from the
 
 ::: {.blendtutor-key}
 
-The key-management form appears here when the book is served over HTTP (see
-below). If you see nothing, open this page over HTTP — `file://` blocks the
-storage and module machinery the form needs.
+Loading API key settings…
 
 :::
 

--- a/docs/evidence/182/render-inspection.log
+++ b/docs/evidence/182/render-inspection.log
@@ -1,0 +1,52 @@
+# Issue #182 — UI fix evidence: Get feedback toolbar + key page styling
+
+Fix items (from the user report / fix spec):
+1. Get feedback button moved INTO the toolbar (div.bt-controls), styled like the removed Run button.
+2. Run button removed (redundant with Check; Get feedback takes its slot).
+3. `.bt-feedback-btn` styled like Run (brand-filled pill) via the crates source of truth.
+4. Key-page form styled via GLOBAL (unscoped) rules that pass through the sync `:global(...)` transform.
+5. No-key link styled as a real affordance (button-styled, not bare anchor).
+6. `mountKeyPage` decoupled from `start()` — runs BEFORE start, never skipped on boot failure.
+7. demo-book placeholder softened to "Loading API key settings…".
+
+## 1. Rendered demo-book inspection (quarto render demo-book)
+
+Rendered `_output/api-key.html`:
+
+- `.blendtutor-key` div present with softened placeholder:
+  `Loading API key settings`
+- Bootstrap order (issue #182 fix item 6): `mountKeyPage` BEFORE `start`:
+```
+  const registry = buildRegistry(scanExercises());
+  mountKeyPage(document.querySelector(".blendtutor-key"));
+  start(registry, {
+  }).then(() => {
+```
+- Stylesheet link resolves to the deployed libs CSS:
+  `href="site_libs/quarto-contrib/blendtutor-0.1.0/styles.css"`
+
+## 2. Deployed libs styles.css — key-page GLOBAL rules + toolbar rules present
+
+Selector occurrences in `_output/site_libs/quarto-contrib/blendtutor-0.1.0/styles.css`:
+
+```
+   2 .bt-exercise .bt-feedback-btn          (rule + hover — fix item 3)
+   2 .bt-exercise [data-byok="no-key"] a    (rule + hover — fix item 5)
+   2 [data-byok="clear"]                    (global — fix item 4)
+   2 [data-byok="key-input"]                (global + :focus — fix item 4)
+   1 [data-byok="key-page-form"]            (global — fix item 4)
+   1 [data-byok="key-status"]               (global — fix item 4)
+   2 [data-byok="save"]                     (rule + hover — fix item 4)
+```
+
+## 3. Key-page form GLOBAL (unscoped) — NOT .bt-exercise-prefixed (fix item 4)
+
+```
+[data-byok="key-page-form"] {
+  display: flex;
+  ...
+```
+The key page (.blendtutor-key) sits OUTSIDE any .bt-exercise wrapper, so the
+sync transform's `:global(...)` passthrough is what makes these rules reach it.
+A scoped `.bt-exercise [data-byok=...]` rule would miss the key page entirely
+(the "bizarre page" bug).

--- a/docs/evidence/182/sync-verification.log
+++ b/docs/evidence/182/sync-verification.log
@@ -1,0 +1,18 @@
+# Issue #182 — sync + vendored parity verification
+
+## scripts/sync-quarto-assets.sh (asset-parity gate)
+  ok: codemirror.js matches source
+  ok: styles.css matches source
+  ok: coi-serviceworker.js matches source
+All assets in sync.
+sync --check exit: 0
+
+## Vendored demo-book copies byte-identical (cmp)
+  PASS: exercise-runtime.js byte-identical
+  PASS: exercise-feedback.js byte-identical
+  PASS: styles.css byte-identical
+  PASS: blendtutor.lua byte-identical
+
+## test_sync_assets.sh (12 assertions incl. idempotency)
+=========================================
+All tests passed.

--- a/docs/evidence/182/test-suite.log
+++ b/docs/evidence/182/test-suite.log
@@ -1,0 +1,30 @@
+# Issue #182 — test-suite results (all DONE-condition suites)
+
+| Suite | Result | Notes |
+|-------|--------|-------|
+| test_quarto_feedback.py | 65 passed, 0 failed | includes AC-5 arm 14 (button-in-toolbar) |
+| test_quarto_key_page.py | 40 passed, 0 failed | |
+| test_quarto_bootstrap.sh | 73 passed, 0 failed | bootstrap order preserved (start < mount < catch) |
+| test_quarto_asset_deployment.sh | 68 passed, 0 failed | |
+| test_quarto_distribution.sh | 91 passed, 0 failed | |
+| test_demo_docs.sh | 22 passed, 0 failed | |
+| test_quarto_ux.py | 46 passed, 0 failed | re-run with 10GB target/ moved aside — env slowness (see Surprises) |
+| verify_asset_scoping.py | 15 passed, 0 failed | incl. Test 12: key-page rules GLOBAL |
+| test_sync_assets.sh | 12 passed, 0 failed | idempotency clean |
+| test_quarto_render.sh | 12 passed, 0 failed | CI extra |
+| test_quarto_filter.sh | 27 passed, 0 failed | CI extra |
+| test_pyodide_adapter.sh | 11 passed, 0 failed | CI extra |
+| test_demo_standalone_render.sh | 24 passed, 0 failed | CI extra |
+| test_quarto_install_render.sh | 13 passed, 0 failed | CI extra |
+
+## Surprises & Discoveries
+
+- The 10GB `target/` Rust build cache in the repo root slows `quarto render`
+  of quarto-fixture fixtures ~45x (1.3s → ~70-95s). test_quarto_ux.py's
+  60s subprocess timeout trips on this machine. NOT caused by issue #182 —
+  a fresh main checkout renders the same fixture in 1.3s. CI (fresh runner)
+  is unaffected. Worked around by moving `target/` aside for the ux re-run.
+
+- `quarto render demo-book` (book project, site_libs layout) is unaffected
+  by the target/ slowness — it completed normally and the rendered pages
+  carry all new styling rules.

--- a/docs/evidence/182/test-suite.log
+++ b/docs/evidence/182/test-suite.log
@@ -2,9 +2,9 @@
 
 | Suite | Result | Notes |
 |-------|--------|-------|
-| test_quarto_feedback.py | 65 passed, 0 failed | includes AC-5 arm 14 (button-in-toolbar) |
+| test_quarto_feedback.py | 65 passed, 0 failed | includes AC-5 arm 14 (button-in-toolbar FIRST: Get feedback · Check · Show solution) |
 | test_quarto_key_page.py | 40 passed, 0 failed | |
-| test_quarto_bootstrap.sh | 73 passed, 0 failed | bootstrap order preserved (start < mount < catch) |
+| test_quarto_bootstrap.sh | 74 passed, 0 failed | bootstrap order: keypage < start < mount < catch |
 | test_quarto_asset_deployment.sh | 68 passed, 0 failed | |
 | test_quarto_distribution.sh | 91 passed, 0 failed | |
 | test_demo_docs.sh | 22 passed, 0 failed | |

--- a/rodney-probes/exercise-ux.js
+++ b/rodney-probes/exercise-ux.js
@@ -234,7 +234,7 @@ function runProbes() {
   // ------------------------------------------------------------------
   screenshot(
     "01-initial-state",
-    "Initial render: three exercises with hints on ex0, no hints on ex2, Run/Check/Solution buttons",
+    "Initial render: three exercises with hints on ex0, no hints on ex2, Check/Solution/Get-feedback toolbar (issue #182: no Run button)",
     "AC-8 clause 1 (hints visible/absent), clause 3 (check button conditional), negative (solution button for empty exercise)",
   );
   rodneyAssert(
@@ -285,8 +285,28 @@ function runProbes() {
   );
 
   // ------------------------------------------------------------------
-  // Clause 4: Run disables ex-0 only (per-exercise, not singleton)
+  // Issue #182: Run button removed — Get feedback replaces its slot.
+  // Negative pin: no .bt-run-btn anywhere; ex0 (has checks) has a
+  // .bt-check-btn; the controls row exposes Get feedback's slot.
+  // ------------------------------------------------------------------
+  rodneyAssert(
+    "issue-182: no .bt-run-btn anywhere",
+    "return document.querySelectorAll('.bt-run-btn').length === 0",
+  );
+  rodneyAssert(
+    "issue-182: ex0 controls row exists with check + solution",
+    "const ex0 = document.querySelectorAll('.bt-exercise')[0]; " +
+      "return ex0.querySelector('.bt-controls') !== null && " +
+      "ex0.querySelector('.bt-check-btn') !== null && " +
+      "ex0.querySelector('.bt-solution-btn') !== null",
+  );
+
+  // ------------------------------------------------------------------
+  // Clause 4: per-exercise button disable (issue #182 reworked)
   // Patch the mock adapter to delay so we can inspect the disabled state.
+  // The ux fixture mounts NO feedback (its bootstrap calls start() only), so
+  // the only button on ex0 that exists on a checks-having exercise is Check;
+  // ex1/ex2 have no Check button at all — disable can never leak to them.
   // ------------------------------------------------------------------
   rodneyJs(
     "(() => { " +
@@ -298,22 +318,22 @@ function runProbes() {
   );
   rodneyJs(
     "(() => { " +
-      "document.querySelectorAll('.bt-exercise')[0].querySelector('.bt-run-btn').click(); " +
+      "document.querySelectorAll('.bt-exercise')[0].querySelector('.bt-check-btn').click(); " +
       "})()",
   );
   sleep(0.5);
   screenshot(
     "03-run-disabled-isolation",
-    "During exercise 0 run: ex0 Run button disabled, ex1 and ex2 Run buttons still enabled",
-    "AC-8 clause 4 (Run disables ex-0 only), clause 5 (cursor on disabled buttons), clause 7 (buttons re-enabled on pass)",
+    "During exercise 0 run: ex0 Check button disabled, ex1/ex2 have no Check button (per-exercise scoping, issue #182)",
+    "AC-8 clause 4 (per-exercise disable), clause 5 (cursor on disabled buttons), clause 7 (buttons re-enabled on pass)",
   );
   rodneyAssert(
-    "clause-4: Run disables ex-0 only",
+    "clause-4: Check disables ex-0 only (per-exercise, no singleton)",
     "const exercises = document.querySelectorAll('.bt-exercise'); " +
-      "const runBtn0 = exercises[0].querySelector('.bt-run-btn'); " +
-      "const runBtn1 = exercises[1].querySelector('.bt-run-btn'); " +
-      "const runBtn2 = exercises[2].querySelector('.bt-run-btn'); " +
-      "return runBtn0.disabled === true && runBtn1.disabled === false && runBtn2.disabled === false",
+      "const check0 = exercises[0].querySelector('.bt-check-btn'); " +
+      "return check0.disabled === true && " +
+      "exercises[1].querySelector('.bt-check-btn') === null && " +
+      "exercises[2].querySelector('.bt-check-btn') === null",
   );
 
   // ------------------------------------------------------------------
@@ -321,10 +341,10 @@ function runProbes() {
   // ------------------------------------------------------------------
   rodneyAssert(
     "clause-5: cursor not-allowed on disabled buttons",
-    "const runBtn0 = document.querySelectorAll('.bt-exercise')[0].querySelector('.bt-run-btn'); " +
-      "runBtn0.disabled = true; " +
-      "const cursor = getComputedStyle(runBtn0).cursor; " +
-      "runBtn0.disabled = false; " +
+    "const check0 = document.querySelectorAll('.bt-exercise')[0].querySelector('.bt-check-btn'); " +
+      "check0.disabled = true; " +
+      "const cursor = getComputedStyle(check0).cursor; " +
+      "check0.disabled = false; " +
       "return cursor === 'not-allowed'",
   );
 
@@ -346,15 +366,12 @@ function runProbes() {
   // ------------------------------------------------------------------
   rodneyAssert(
     "clause-7: buttons re-enabled on pass",
-    "const exercises = document.querySelectorAll('.bt-exercise'); " +
-      "const runBtn0 = exercises[0].querySelector('.bt-run-btn'); " +
-      "const runBtn1 = exercises[1].querySelector('.bt-run-btn'); " +
-      "const runBtn2 = exercises[2].querySelector('.bt-run-btn'); " +
-      "return runBtn0.disabled === false && runBtn1.disabled === false && runBtn2.disabled === false",
+    "const check0 = document.querySelectorAll('.bt-exercise')[0].querySelector('.bt-check-btn'); " +
+      "return check0.disabled === false",
   );
   screenshot(
     "04-status-pass",
-    "After exercise 0 run completes: status shows pass, all Run buttons re-enabled",
+    "After exercise 0 run completes: status shows pass, Check button re-enabled",
     "AC-8 clause 6 (data-status closed set), clause 7 (buttons re-enabled on pass)",
   );
 }

--- a/rodney-probes/key-page-probe.js
+++ b/rodney-probes/key-page-probe.js
@@ -317,7 +317,8 @@ function clearLocalStorageViaPage() {
 // ---------------------------------------------------------------------------
 function probeP6SaveFlow() {
   navigateTo(KEY_PAGE_URL);
-  // Wait for the key form to mount (mountKeyPage runs after start() resolves).
+  // Wait for the key form to mount (issue #182: mountKeyPage now runs BEFORE
+  // start() so a rejected boot can never skip the key page).
   const elapsed = waitForExpr(
     "document.querySelector('[data-byok=\"key-input\"]') !== null",
     15,

--- a/rodney-probes/mixed-runtime.js
+++ b/rodney-probes/mixed-runtime.js
@@ -225,8 +225,11 @@ function waitForExpr(expr, timeoutSeconds = 20) {
 }
 
 function clickRun(exerciseIndex) {
+  // Issue #182: the Run button is removed (Get feedback replaces its slot).
+  // The mock exercises have NO checks, so no Check button exists either —
+  // trigger execution through the registry entry's runSubmission() directly.
   rodneyJs(
-    `document.querySelectorAll('.bt-exercise')[${exerciseIndex}].querySelector('.bt-run-btn').click()`,
+    `(() => { const e = window.__btExercises[${exerciseIndex}]; if (!e) return false; e.runSubmission(); return true; })()`,
   );
 }
 

--- a/rodney-probes/pages-live.js
+++ b/rodney-probes/pages-live.js
@@ -14,7 +14,7 @@
  *              === true AND navigator.serviceWorker.controller !== null.
  *              Timeout → coi_failure verdict, P3/P4 skipped.
  *          P3  REAL R execution: setEditorContent('add <- function(a, b) { a
- *              + b }\nprint(add(1, 2))') → click .bt-run-btn → poll ≤120s
+ * + b }\nprint(add(1, 2))') → click .bt-check-btn (issue #182: Run button removed) → poll ≤120s
  *              (webR cold boot 30-90s) until data-status="pass" AND
  *              .bt-output textContent contains "3". Status-only is
  *              insufficient — webR ignores the checks param and a pure
@@ -462,7 +462,7 @@ function probeP3RExec() {
     return;
   }
 
-  rodney(["click", `${sel} .bt-run-btn`]);
+  rodney(["click", `${sel} .bt-check-btn`]);
   const elapsed = waitForExpr(
     `document.querySelector('${sel} .bt-status').dataset.status === 'pass'`,
     core.WEBR_TIMEOUT_S,
@@ -513,7 +513,7 @@ function probeP4PyExec() {
     rodneyJs(
       `(() => { const e = window.__btExercises.find(x => x.element.dataset.language === 'python'); if (!e) return false; e.setEditorContent(${JSON.stringify(code)}); return true; })()`,
     );
-    rodney(["click", `${sel} .bt-run-btn`]);
+    rodney(["click", `${sel} .bt-check-btn`]);
     return waitForExpr(
       `document.querySelector('${sel} .bt-status').dataset.status === 'pass'`,
       core.PYODIDE_TIMEOUT_S,
@@ -551,7 +551,7 @@ function probeP4PyExec() {
   rodneyJs(
     `(() => { const e = window.__btExercises.find(x => x.element.dataset.language === 'python'); if (!e) return false; e.setEditorContent(${JSON.stringify("def square(n):\n    return 0")}); return true; })()`,
   );
-  rodney(["click", `${sel} .bt-run-btn`]);
+  rodney(["click", `${sel} .bt-check-btn`]);
   const t1 = Date.now();
   const failElapsed = waitForExpr(
     `document.querySelector('${sel} .bt-status').dataset.status === 'fail'`,

--- a/scripts/sync-quarto-assets.sh
+++ b/scripts/sync-quarto-assets.sh
@@ -7,6 +7,11 @@
 # NOT:   Runtime loading, coi-serviceworker.js (AC-9), lesson-runner-core.js,
 #        feedback.js. Source files are READ-ONLY — never modify.
 #
+# CSS scoping: all selectors are prefixed with .bt-exercise EXCEPT :root,
+# body (→ .bt-exercise), and :global(...) wrappers (passthrough — see
+# scope_selector). The :global passthrough exists for the key-page form rules
+# (issue #182): the key page renders OUTSIDE any .bt-exercise wrapper.
+#
 # Modes:
 #   sync (default):  Write vendored files. Exit 0 on success.
 #   --check:         Regenerate to temp, compare with committed. Exit 0=match,
@@ -41,6 +46,9 @@ ASSET_FILES=(
 #   - body{}: transformed to .bt-exercise{}, page-layout props stripped
 #     (max-width, margin, padding, min-height, display, flex-direction)
 #   - Other rules: selectors prefixed with .bt-exercise (descendant combinator)
+#   - :global(...) wrappers: emitted UNscoped (passthrough). Used for the
+#     key-page form rules (issue #182) — the key page (.blendtutor-key) sits
+#     OUTSIDE any .bt-exercise wrapper, so its rules must NOT be prefixed.
 #   - @media: wrapper preserved, inner selectors scoped (except :root)
 #   - @keyframes: kept global (not scoped)
 #   - Comma-separated selectors: each individually prefixed
@@ -159,12 +167,21 @@ def scope_selector(selector):
     Exceptions (kept global, not scoped):
       - body: transformed to .bt-exercise (handled separately)
       - :root: kept as :root (design tokens are global)
+      - :global(...) wrapper: emitted UNscoped (passthrough) — used by the
+        key-page form rules (issue #182) which must match elements OUTSIDE
+        any .bt-exercise wrapper.
     """
     selector = selector.strip()
     if selector == "body":
         return SCOPE
     if selector == ":root":
         return selector
+    if selector.startswith(":global(") and selector.endswith(")"):
+        inner = selector[len(":global(") : -1].strip()
+        if not inner:
+            raise ValueError(f"empty :global() wrapper in selector {selector!r}")
+        parts = split_selectors(inner)
+        return ",\n".join(parts)
     parts = split_selectors(selector)
     scoped = [f"{SCOPE} {p}" for p in parts]
     return ",\n".join(scoped)

--- a/scripts/tests/test_quarto_bootstrap.sh
+++ b/scripts/tests/test_quarto_bootstrap.sh
@@ -531,6 +531,18 @@ if [ -f "$MIXED_HTML" ]; then
     ko "mountAllFeedback after start(, before .catch( — order start=$LINE_START mount=$LINE_MOUNT catch=$LINE_CATCH"
   fi
 
+  # C11 (issue #182): mountKeyPage( runs BEFORE start( — a start() rejection
+  # (or a synchronously-thrown adapter factory) must never skip the key-page
+  # mount. Pins the decoupling claim from issue #182: the key page is mounted
+  # unconditionally before the boot promise chain starts.
+  LINE_KEYPAGE=$(printf '%s\n' "$MIXED_BOOTSTRAP" | grep -n 'mountKeyPage(document.querySelector(".blendtutor-key"))' | head -1 | cut -d: -f1 || true)
+  if [ -n "$LINE_KEYPAGE" ] && [ -n "$LINE_START" ] \
+    && [ "$LINE_KEYPAGE" -lt "$LINE_START" ]; then
+    ok "mountKeyPage before start( (line order $LINE_KEYPAGE < $LINE_START)"
+  else
+    ko "mountKeyPage before start( — order keypage=$LINE_KEYPAGE start=$LINE_START"
+  fi
+
   # C11: .then( and .catch( both present.
   if has_token "$MIXED_BOOTSTRAP" '.then(' && has_token "$MIXED_BOOTSTRAP" '.catch('; then
     ok ".then( and .catch( both present"

--- a/scripts/tests/test_quarto_feedback.py
+++ b/scripts/tests/test_quarto_feedback.py
@@ -679,6 +679,15 @@ function mockElement(tag) {
       this.children.push(n);
       return n;
     },
+    insertBefore(n, ref) {
+      const idx = ref ? this.children.indexOf(ref) : -1;
+      if (idx < 0) this.children.push(n);
+      else this.children.splice(idx, 0, n);
+      return n;
+    },
+    get firstChild() {
+      return this.children.length > 0 ? this.children[0] : null;
+    },
     replaceChildren(...nodes) {
       this.children = [...nodes];
     },
@@ -1118,18 +1127,30 @@ if (promptZ) {
 }
 
 // Arm 14 (issue #182): Get feedback button moves into the toolbar
-// (entry.controls) when present — NOT the separate .bt-feedback-wrapper.
-// The feedback CONTAINER stays a direct child of the exercise element.
+// (entry.controls) when present — NOT the separate .bt-feedback-wrapper —
+// and takes the FIRST slot (the former Run button's position: Run was
+// first in the toolbar, and the user's stated fix was "replace the Run
+// button"). The feedback CONTAINER stays a direct child of the exercise
+// element.
 localStorageMap.clear();
 const eT = makeEntry({ id: "exT", output: "" });
 const controlsEl = mockElement("div");
 controlsEl.className = "bt-controls";
 eT.element.appendChild(controlsEl);
 eT.controls = controlsEl;
+// Simulate the runtime's wireExercise: Check then Show solution appended.
+const checkBtn = mockElement("button");
+checkBtn.className = "bt-check-btn";
+controlsEl.appendChild(checkBtn);
+const solutionBtn = mockElement("button");
+solutionBtn.className = "bt-solution-btn";
+controlsEl.appendChild(solutionBtn);
 mod.mountFeedback(eT);
 const btnT = eT.element.querySelector(".bt-feedback-btn");
 assert(btnT !== null, "AC-5 arm 14: feedback button exists after mount");
 assert(controlsEl.querySelector(".bt-feedback-btn") === btnT, "AC-5 arm 14: feedback button appended INTO entry.controls (toolbar)");
+assert(controlsEl.firstChild === btnT, "AC-5 arm 14: feedback button is FIRST in the toolbar (former Run slot, before Check/Show solution)");
+assert(controlsEl.children[0] === btnT && controlsEl.children[1] === checkBtn && controlsEl.children[2] === solutionBtn, "AC-5 arm 14: toolbar order is Get feedback · Check · Show solution");
 assert(eT.element.querySelector(".bt-feedback-wrapper") === null, "AC-5 arm 14: no .bt-feedback-wrapper created when controls present");
 assert(eT.feedbackContainer !== null && eT.element.querySelector('[data-byok="feedback"]') === eT.feedbackContainer, "AC-5 arm 14: feedback container is a direct child of the exercise element");
 

--- a/scripts/tests/test_quarto_feedback.py
+++ b/scripts/tests/test_quarto_feedback.py
@@ -1117,6 +1117,22 @@ if (promptZ) {
   assert(false, "AC-5 arm 13: expected a chat/completions POST");
 }
 
+// Arm 14 (issue #182): Get feedback button moves into the toolbar
+// (entry.controls) when present — NOT the separate .bt-feedback-wrapper.
+// The feedback CONTAINER stays a direct child of the exercise element.
+localStorageMap.clear();
+const eT = makeEntry({ id: "exT", output: "" });
+const controlsEl = mockElement("div");
+controlsEl.className = "bt-controls";
+eT.element.appendChild(controlsEl);
+eT.controls = controlsEl;
+mod.mountFeedback(eT);
+const btnT = eT.element.querySelector(".bt-feedback-btn");
+assert(btnT !== null, "AC-5 arm 14: feedback button exists after mount");
+assert(controlsEl.querySelector(".bt-feedback-btn") === btnT, "AC-5 arm 14: feedback button appended INTO entry.controls (toolbar)");
+assert(eT.element.querySelector(".bt-feedback-wrapper") === null, "AC-5 arm 14: no .bt-feedback-wrapper created when controls present");
+assert(eT.feedbackContainer !== null && eT.element.querySelector('[data-byok="feedback"]') === eT.feedbackContainer, "AC-5 arm 14: feedback container is a direct child of the exercise element");
+
 process.exit(failures > 0 ? 1 : 0);
 """
 

--- a/scripts/tests/test_quarto_ux.py
+++ b/scripts/tests/test_quarto_ux.py
@@ -8,16 +8,20 @@ Verifies the 7-clause predicate from AC-8:
      setEditorContent(payload.solution).
   3. check button absent when no checks — exercises with empty checks array
      do not render a Check button.
-  4. Run disables ex-0 only — clicking Run on exercise 0 disables only
-     exercise 0's Run button (per-exercise, not singleton).
+  4. per-exercise button disable — runSubmission disables THIS exercise's
+     control buttons only (per-exercise, not singleton). Issue #182 removes
+     the Run button (redundant with Check — Get feedback replaces its slot);
+     the disable/enable mechanism survives on the entry-scoped Check/Solution
+     button refs.
   5. cursor=not-allowed — disabled buttons have cursor: not-allowed in CSS.
   6. data-status closed set — the status element's data-status is a closed
      enum: idle, running, pass, fail.
-  7. buttons re-enabled on pass — after a run completes (pass), the Run button
-     is re-enabled.
+  7. buttons re-enabled on pass — after a run completes (pass), the control
+     buttons are re-enabled.
 
-Negative: Run disables all exercises (singleton leak). Solution button for
-empty exercise (no solution — button must not appear).
+Negative: disables all exercises (singleton leak). Solution button for
+empty exercise (no solution — button must not appear). Run button must NOT
+be created (issue #182).
 
 Usage: python3 scripts/tests/test_quarto_ux.py
 """
@@ -194,37 +198,38 @@ def check_check_button_conditional(src: str) -> None:
 
 
 def check_run_disable_per_exercise(src: str) -> None:
-    """Clause 4: Run disables ex-0 only (per-exercise, not singleton).
+    """Clause 4: per-exercise button disable (issue #182: Run button removed).
 
-    The runtime must disable the Run button per-exercise (entry-level), not
-    via a module-level singleton. The negative case is "Run disables all
-    exercises" — a singleton leak.
+    Issue #182 removes the Run button (redundant with Check — Get feedback
+    takes its toolbar slot). The disable/enable mechanism must remain
+    per-exercise (entry-level), not via a module-level singleton. The
+    negative case is "disables all exercises" — a singleton leak.
     """
     code = _strip_comments(src)
-    # Must NOT use a module-level runButton variable (singleton)
-    # The per-exercise pattern uses entry.runBtn or similar
-    if "runBtn" in code or "run-btn" in code or "runButton" in code:
-        ok("per-exercise Run button reference found")
+    # Negative: the runtime must NOT create a .bt-run-btn anymore.
+    if "bt-run-btn" in code or "runBtn" in code or "runButton" in code:
+        ko("no .bt-run-btn — Run button removed (issue #182)")
     else:
-        ko("per-exercise Run button reference missing")
+        ok("no .bt-run-btn — Run button removed (issue #182)")
 
-    # Must disable the button via entry (per-exercise), not module-level
-    if "disabled" in code or "data-disabled" in code:
-        ok("button disable/enable mechanism present")
+    # Per-exercise disable mechanism: entry-scoped button refs toggled inside
+    # runSubmission (the old module-level runButton singleton is gone).
+    if "entry.checkBtn" in code and "disabled" in code:
+        ok("per-exercise button disable via entry-scoped refs")
     else:
-        ko("button disable/enable mechanism missing")
+        ko("per-exercise button disable via entry-scoped refs — entry.checkBtn/disabled missing")
 
-    # Must NOT use document.getElementById for the run button (singleton)
+    # Must NOT use document.getElementById for any control button (singleton)
     if 'getElementById("run")' in code or "getElementById('run')" in code:
         ko("singleton getElementById('run') found — not per-exercise")
     else:
-        ok("no singleton getElementById('run') — per-exercise Run button")
+        ok("no singleton getElementById('run') — per-exercise buttons")
 
 
 def check_buttons_reenabled(src: str) -> None:
     """Clause 7: buttons re-enabled on pass.
 
-    After a run completes (pass), the Run button must be re-enabled.
+    After a run completes (pass), the control buttons must be re-enabled.
     The runtime must set the button back to enabled in the finally block
     or after the run completes.
     """
@@ -843,7 +848,7 @@ def main() -> int:
     print("\n-- Clause 3: check button absent when no checks --")
     check_check_button_conditional(src)
 
-    print("\n-- Clause 4: Run disables ex-0 only (per-exercise) --")
+    print("\n-- Clause 4: per-exercise button disable (issue #182: no Run button) --")
     check_run_disable_per_exercise(src)
 
     print("\n-- Clause 5: cursor=not-allowed --")

--- a/scripts/tests/verify_asset_scoping.py
+++ b/scripts/tests/verify_asset_scoping.py
@@ -38,6 +38,21 @@ TYPOGRAPHY_PROPS = frozenset({
     "font-family", "font-size", "line-height", "color", "background",
 })
 
+# Issue #182: the key-page form rules are deliberately GLOBAL — the key page
+# (.blendtutor-key) renders OUTSIDE any .bt-exercise wrapper. The sync
+# transform passes :global(...) selectors through unscoped; these selectors
+# are the ONLY allowed unscoped rules (tests 9/10 skip them).
+GLOBAL_ALLOWLIST = frozenset({
+    '[data-byok="key-page-form"]',
+    '[data-byok="key-input"]',
+    '[data-byok="key-input"]:focus',
+    '[data-byok="save"]',
+    '[data-byok="save"]:hover',
+    '[data-byok="clear"]',
+    '[data-byok="clear"]:hover',
+    '[data-byok="key-status"]',
+})
+
 PASS = 0
 FAIL = 0
 
@@ -345,7 +360,7 @@ def main() -> int:
 
     # ------------------------------------------------------------------
     # Test 9 — All selectors scoped under .bt-exercise
-    #          (except :root, @media, @keyframes)
+    #          (except :root and the :global(...) key-page allowlist)
     # ------------------------------------------------------------------
 
     print("== Test 9: all selectors scoped under .bt-exercise ==")
@@ -360,13 +375,17 @@ def main() -> int:
         # Check each comma-separated part.
         parts = split_selectors(selector)
         for part in parts:
-            if not part.startswith(SCOPE_PREFIX):
-                unscoped_selectors.append(part)
+            if part.startswith(SCOPE_PREFIX):
+                continue
+            if part in GLOBAL_ALLOWLIST:
+                # Issue #182: key-page form rules pass through :global(...)
+                continue
+            unscoped_selectors.append(part)
 
     if unscoped_selectors:
         ko(f"all selectors scoped — unscoped: {unscoped_selectors[:5]}")
     else:
-        ok("all selectors scoped under .bt-exercise (except :root)")
+        ok("all selectors scoped under .bt-exercise (except :root + key-page allowlist)")
 
     # ------------------------------------------------------------------
     # Test 10 — No unscoped page-level IDs
@@ -418,6 +437,44 @@ def main() -> int:
         ko(f"@media inner selectors scoped — unscoped: {unscoped_media[:5]}")
     else:
         ok("@media inner selectors scoped (except :root)")
+
+    # ------------------------------------------------------------------
+    # Test 12 (issue #182) — key-page form rules emitted GLOBAL.
+    # The key page (.blendtutor-key) sits OUTSIDE any .bt-exercise wrapper,
+    # so the key-page form selectors MUST appear unscoped in the vendored
+    # styles.css. If the transform ever scopes them (drops :global passthrough
+    # or the source wraps wrong), the key page loses ALL styling — the
+    # "bizarre page" bug. Pins BOTH the source :global(...) wrappers AND the
+    # transform passthrough.
+    # ------------------------------------------------------------------
+
+    print("== Test 12: key-page form rules emitted GLOBAL (issue #182) ==")
+
+    source_has_global = all(
+        f':global({sel})' in SOURCE_CSS.read_text()
+        for sel in sorted(GLOBAL_ALLOWLIST)
+    )
+    if source_has_global:
+        ok("source styles.css wraps all key-page selectors in :global(...)")
+    else:
+        ko("source styles.css wraps all key-page selectors in :global(...)")
+
+    scoped_selector_set = set()
+    for item in scoped_items:
+        if item[0] != "rule":
+            continue
+        scoped_selector_set.update(split_selectors(item[1].selector))
+    missing_global = sorted(GLOBAL_ALLOWLIST - scoped_selector_set)
+    if missing_global:
+        ko(f"key-page selectors emitted GLOBAL — missing: {missing_global}")
+    else:
+        ok("key-page selectors present unscoped in vendored styles.css")
+
+    scoped_leak = [sel for sel in sorted(GLOBAL_ALLOWLIST) if f".bt-exercise {sel}" in scoped_selector_set]
+    if scoped_leak:
+        ko(f"key-page selectors NOT double-scoped — found scoped variant: {scoped_leak}")
+    else:
+        ok("key-page selectors not scoped under .bt-exercise")
 
     # ------------------------------------------------------------------
     # Summary

--- a/scripts/tests/webr-probe.js
+++ b/scripts/tests/webr-probe.js
@@ -89,9 +89,11 @@ async function runProbe() {
 
   // 3. First Run: boot progress shown
   await asyncTest("3. First Run: boot progress shown", async () => {
-    // Click Run on Exercise 1
-    const runBtn = reg[0].element.querySelector(".bt-run-btn");
-    assert(runBtn !== null, "Exercise 1 Run button not found");
+    // Trigger execution (issue #182: the Run button is removed; the webr
+    // fixture exercises have no checks, so no Check button exists either —
+    // drive runSubmission() directly like the concurrent-guard test does).
+    const reg0 = reg[0];
+    assert(reg0.element.querySelector(".bt-run-btn") === null, "Exercise 1 has no .bt-run-btn (issue #182)");
 
     // Record output before run
     const outputEl = reg[0].element.querySelector(".bt-output");
@@ -99,8 +101,8 @@ async function runProbe() {
     assert(outputEl !== null, "Exercise 1 output element not found");
     assert(statusEl !== null, "Exercise 1 status element not found");
 
-    // Click Run
-    runBtn.click();
+    // Trigger run
+    reg[0].runSubmission();
 
     // Wait for boot progress to appear (status should show booting/booting…)
     const bootProgressSeen = await waitFor(() => {
@@ -134,9 +136,8 @@ async function runProbe() {
     // Record resource count before second run
     const resourcesBefore = performance.getEntriesByType("resource").length;
 
-    // Click Run on Exercise 2
-    const runBtn = reg[1].element.querySelector(".bt-run-btn");
-    assert(runBtn !== null, "Exercise 2 Run button not found");
+    // Trigger run on Exercise 2 (issue #182: no Run button — direct call)
+    assert(reg[1].element.querySelector(".bt-run-btn") === null, "Exercise 2 has no .bt-run-btn (issue #182)");
 
     const statusEl = reg[1].element.querySelector(".bt-status");
     const outputEl = reg[1].element.querySelector(".bt-output");
@@ -144,8 +145,8 @@ async function runProbe() {
     // Record status before run
     const statusBefore = statusEl.dataset.status;
 
-    // Click Run
-    runBtn.click();
+    // Trigger run
+    reg[1].runSubmission();
 
     // Wait for run to complete
     await waitFor(() => {
@@ -180,8 +181,7 @@ async function runProbe() {
 
   // 7. Concurrent run guard: second concurrent Run rejected
   await asyncTest("7. Concurrent run guard: second concurrent Run rejected", async () => {
-    // Start a run on Exercise 1
-    const runBtn0 = reg[0].element.querySelector(".bt-run-btn");
+    // Start a run on Exercise 1 (issue #182: no Run button — direct call)
     const runPromise = reg[0].runSubmission();
 
     // Immediately try to run Exercise 2 (concurrent)


### PR DESCRIPTION
## Summary

Fixes the user-reported visual defect on the shipped BYOK feature (#179 + feature issues #162-#181): the key page rendered as bare browser widgets ("bizarre page"), the Get feedback button was unstyled and sat below the toolbar, and the no-key link was a bare default anchor.

Per the user's stated fix, Get feedback now takes the Run button's toolbar slot and styling; the Run button is removed (redundant with Check, which runs the deterministic tests).

## Issue

Closes #182

## Fix items

1. **Get feedback into the toolbar**: exercise-runtime.js exposes the controls row as `entry.controls`; exercise-feedback.js `mountFeedback` PREPENDS the button INTO `entry.controls` — first, in the former Run button's slot (fallback: direct child of the exercise element). The feedback CONTAINER (verdict area) stays below.
2. **Run button removed**: `wireExercise` no longer creates `.bt-run-btn`. Toolbar = Get feedback · Check · Show solution. All tests/probes referencing `bt-run-btn` updated (webr-probe drives `runSubmission()` directly — fixture has no checks; pages-live clicks `.bt-check-btn`; mixed-runtime calls `runSubmission()`).
3. **Get feedback styled like Run**: crates source-of-truth styles.css styles `.bt-feedback-btn` exactly like the former `.bt-run-btn` (brand-filled pill, hover). Synced to the extension.
4. **Key-page form styled (GLOBAL rules)**: `[data-byok="key-page-form"/key-input/save/clear/key-status]` rules wrapped in `:global(...)` — the sync transform now passes `:global(...)` selectors through unscoped, because the key page sits OUTSIDE any `.bt-exercise` wrapper. verify_asset_scoping.py Test 12 pins them GLOBAL (negative guard).
5. **No-key link styled**: button-styled affordance (brand-filled pill) inside a subtle info layout, not a bare anchor.
6. **Key-page mount decoupled from start()**: bootstrap calls `mountKeyPage(...)` BEFORE `start(...)` so a rejected boot can never skip the key-page mount.
7. **Placeholder softened**: demo-book `api-key.qmd` placeholder is now neutral "Loading API key settings…".

## ACs implemented

- Get feedback button in toolbar, styled like Run; Run button removed
- Key page form styled (global rules pass through sync transform)
- No-key link styled as real affordance
- Key-page mount survives start() rejection
- demo-book placeholder neutral
- Asset parity: sync clean, vendored copies byte-identical

## Test plan

- [x] All tests pass: feedback 65/65, key_page 40/40, bootstrap 73/73, asset_deployment 68/68, distribution 91/91, demo_docs 22/22, ux 46/46, verify_asset_scoping 15/15, sync_assets 12/12 (+ render/filter/pyodide/standalone/install CI extras)
- [x] `quarto render demo-book` works; api-key.html carries the styled key-page selectors via deployed libs CSS
- [x] Evidence at docs/evidence/182/ (render inspection, sync parity, test suites)

## Self-Review

- [x] All fix items exercised by tests
- [x] Negative cases tested (no Run button, key-page rules not scoped)
- [x] Design intent respected (button in toolbar, styled like Run, key page styled)
- [x] No scope creep (crates Rust untouched; only styles.css asset)

## Notes

- `test_quarto_ux.py` has a 60s render timeout; this machine's 10GB `target/` Rust cache slows quarto renders ~45x (pre-existing env issue, not this change — fresh main checkout renders in 1.3s). Re-ran ux with `target/` moved aside: 46/46 green. CI (fresh runner) unaffected.
