### PR TITLE
feat: inline API key entry in exercise feedback area

### DIFF
--- a/_extensions/blendtutor/assets/exercise-feedback.js
+++ b/_extensions/blendtutor/assets/exercise-feedback.js
@@ -40,6 +40,13 @@
 //   invokes it AFTER the runtime boots. Pure functions are importable in
 //   Node.js without side effects, so they are testable without a browser.
 
+// Issue #186: the no-key state mounts the key-management form (key-page.js
+// mountKeyPage) INLINE into the feedback container — no navigation link. The
+// import is a cycle (key-page.js imports the storage/provider contract from
+// this module) — safe: both modules use imported bindings only at call time,
+// never at module-eval time (ES live bindings resolve by then).
+import { mountKeyPage } from "./key-page.js";
+
 // --- prompt structure (the single source, ported from feedback.js) -------------
 //
 // Byte-identical to the Rust core::llm prompt constants (pinned by the
@@ -77,8 +84,8 @@ export const DEFAULT_PROVIDER = "fireworks";
 
 // Per-provider disclosure texts — literal strings so the static scan can
 // verify BOTH are present. Documentation of the privacy promise shown to
-// learners; the no-key state no longer renders them inline (AC-4 routes
-// learners to the key page), but the copy stays pinned in source.
+// learners; the no-key state mounts the key-page form inline (issue #186)
+// without repeating the disclosures, but the copy stays pinned in source.
 const PROVIDER_DISCLOSURES = {
   fireworks: "Your Fireworks API key is stored in this browser (localStorage) " +
     "and sent only to Fireworks to fetch feedback — never to this site's " +
@@ -408,23 +415,31 @@ function currentSubmissionForExercise(entry) {
   };
 }
 
-// --- the no-key state (AC-4): link to the key page, no inline form ----------
+// --- the no-key state (issue #186): INLINE key form, no navigation link ----
 //
-// The learner clicks "Get feedback" with no stored key → the container renders
-// a single link to the key page instead of an inline key-entry form (the
-// inline form's job moved to the dedicated key page, assets/key-page.js,
-// AC-2). The link opens in a new tab (target=_blank + rel=noopener) so the
-// learner's in-progress code in the exercise editor survives the detour.
+// The learner clicks "Get feedback" with no stored key → the feedback
+// container mounts the key-management form (key-page.js mountKeyPage) INLINE
+// instead of rendering a link to a separate key page (the user-reported fix:
+// the old link navigated away to a confusing page and dropped the learner's
+// context). The container itself is the mount target — key-page.js renders
+// its password input + Save button into it.
 //
-// The link target comes from window.__btConfig.keyPageUrl, emitted by the
-// blendtutor.lua head script (AC-3) from the bt-key-page YAML meta. It is read
-// LAZILY at render time (never cached at module init — §2.1: no module-level
-// effectful read) so a dynamically-set config value is honored.
+// Save-continuation: onSaved re-invokes handleSubmitForExercise once the key
+// is stored, so the same click path proceeds to the rate-limit check + fetch
+// without a second user action. The callback only fires on a successful
+// storeKey (optimistic contract — key stored = proceed); a rejected or
+// unreachable advisory validation is copy on the form's status line and must
+// NOT block continuation.
+//
+// keyPageUrl() is retained for the standalone api-key chapter (the demo-book
+// index + the lua bt-key-page emission still point at it) and stays exported
+// (Node-tested by key-page-url.test.js).
 
-// Pure-ish: the key-page URL for the no-key link. Reads window.__btConfig at
-// CALL time, rejects javascript:/data: schemes (defense in depth against a
-// crafted config), falls back to the default page. Total: never throws, never
-// returns "". Exported so it is Node-testable without a browser.
+// Pure-ish: the key-page URL for the standalone api-key chapter. Reads
+// window.__btConfig at CALL time, rejects javascript:/data: schemes (defense
+// in depth against a crafted config), falls back to the default page. Total:
+// never throws, never returns "". Exported so it is Node-testable without a
+// browser.
 export function keyPageUrl() {
   const config = typeof window !== "undefined" ? window.__btConfig : null;
   let candidate = config && config.keyPageUrl;
@@ -443,26 +458,6 @@ export function keyPageUrl() {
     }
   }
   return candidate;
-}
-
-// Render the no-key state: a single DOM-built anchor to the key page. The
-// anchor is built with createElement + .href/.textContent — never innerHTML
-// with URL interpolation. The copy is the AC literal "Enter your API key
-// first". Exported so tests can render the prompt without a browser.
-export function renderKeyPrompt(container) {
-  const wrapper = document.createElement("div");
-  wrapper.dataset.byok = "no-key";
-
-  // Lazy read at render time — never cached at module init (§2.1).
-  const href = keyPageUrl();
-  const link = document.createElement("a");
-  link.href = href;
-  link.target = "_blank";
-  link.rel = "noopener";
-  link.textContent = "Enter your API key first";
-
-  wrapper.append(link);
-  container.replaceChildren(wrapper);
 }
 
 // Render the verdict. textContent only — the message is model output (untrusted),
@@ -504,7 +499,9 @@ function renderLimitReached(container) {
 }
 
 // Orchestrate one submit for a single exercise, in three named states:
-//   no key            → render the no-key link to the key page (AC-4);
+//   no key            → mount the key form INLINE (key-page.js mountKeyPage)
+//                        with an onSaved save-continuation that re-runs this
+//                        handler once the key is stored (issue #186);
 //   rate-limited      → render the limit-reached message (no fetch);
 //   key present       → build the prompt (task + student code + captured
 //                        .bt-output + checks) and send feedback through the
@@ -537,7 +534,11 @@ async function handleSubmitForExercise(entry) {
   const providerId = readProvider();
   const apiKey = readKey(providerId);
   if (!apiKey) {
-    renderKeyPrompt(container);
+    // Inline key form (issue #186): mount key-page.js INTO the feedback
+    // container. The onSaved continuation re-runs this handler once the key
+    // is stored — the key check then passes and the flow proceeds to the
+    // rate-limit check + fetch without a second user action.
+    mountKeyPage(container, { onSaved: () => handleSubmitForExercise(entry) });
     return;
   }
   // Rate-limit check BEFORE the fetch — a capped learner never fires a

--- a/_extensions/blendtutor/assets/key-page.js
+++ b/_extensions/blendtutor/assets/key-page.js
@@ -97,8 +97,10 @@ function renderKeySet(container) {
 }
 
 // No-key mount state: password input + Save. `initialReason` seeds the status
-// line (used after Clear to report the removal).
-function renderKeyForm(container, initialReason) {
+// line (used after Clear to report the removal). `onSaved` (optional, issue
+// #186) is threaded to handleSave — an inline caller (the exercise feedback
+// no-key state) re-runs its submit flow once the key is stored.
+function renderKeyForm(container, initialReason, onSaved) {
   const form = document.createElement("form");
   form.dataset.byok = "key-page-form";
 
@@ -119,7 +121,7 @@ function renderKeyForm(container, initialReason) {
   form.append(status, input, save);
   form.addEventListener("submit", (event) => {
     event.preventDefault();
-    return handleSave(input, status);
+    return handleSave(input, status, onSaved);
   });
 
   if (initialReason) {
@@ -131,10 +133,15 @@ function renderKeyForm(container, initialReason) {
 // Save flow: empty input is a no-op (stored key survives, no fetch); otherwise
 // store optimistically via the imported contract, reset the input immediately
 // (no password-manager capture, no echo), then validate (advisory status).
+// `onSaved` (optional, issue #186) fires ONCE right after the key is stored —
+// before the advisory validation resolves — so an inline caller can re-run its
+// submit flow with the key now present. The optimistic contract: key stored =
+// proceed; a rejected/network validation is advisory copy only and must NOT
+// block continuation.
 // When storage is unavailable (storeKey throws — private mode, quota exceeded),
 // report a friendly storage status and STOP: no fetch, input keeps its value so
 // the user can retry. The key is only cleared from the input on the success path.
-function handleSave(input, status) {
+function handleSave(input, status, onSaved) {
   const value = input.value.trim();
   if (!value) {
     setStatus(status, "empty");
@@ -147,6 +154,9 @@ function handleSave(input, status) {
     return;
   }
   input.value = "";
+  if (typeof onSaved === "function") {
+    onSaved();
+  }
   return validateAndReport(status, value);
 }
 
@@ -173,7 +183,11 @@ async function validateAndReport(status, key) {
 
 // Mount the key-management UI into `target`. No-op when the target is absent
 // or already mounted (idempotent — one save issues exactly one fetch).
-export function mountKeyPage(target) {
+// `opts.onSaved` (optional, issue #186) is called once after a successful
+// save — the exercise feedback inline mount uses it to re-run the submit flow
+// once the key exists. Backward-compatible: existing callers pass no opts and
+// get the mount-only behavior (blendtutor.lua bootstrap passes none).
+export function mountKeyPage(target, opts = {}) {
   if (!target || mountedTargets.has(target)) {
     return;
   }
@@ -181,6 +195,6 @@ export function mountKeyPage(target) {
   if (readKey(PROVIDER_ID)) {
     renderKeySet(target);
   } else {
-    renderKeyForm(target);
+    renderKeyForm(target, undefined, opts.onSaved);
   }
 }

--- a/_extensions/blendtutor/assets/styles.css
+++ b/_extensions/blendtutor/assets/styles.css
@@ -796,7 +796,8 @@
  * The Quarto fork renders per-exercise feedback into a .bt-feedback container
  * (exercise-feedback.js mountFeedback) — the #feedback rules above serve the
  * crates site shell and are NOT matched by the new code. This section styles
- * the per-exercise container, the no-key link, and the KEY PAGE form.
+ * the per-exercise container, the INLINE key form (issue #186), and the
+ * KEY PAGE form.
  *
  * Scoping notes (scripts/sync-quarto-assets.sh):
  *  - Rules in this source file are prefixed with .bt-exercise by the sync
@@ -804,10 +805,12 @@
  *    UNscoped. The key page (.blendtutor-key) sits OUTSIDE any .bt-exercise
  *    wrapper, so its form rules MUST use :global(...) — a scoped rule would
  *    never match the key page ("bizarre page" bug, issue 182).
- *  - The no-key link renders INSIDE .bt-feedback inside .bt-exercise — scoped.
+ *  - The INLINE key form (issue #186) renders INSIDE .bt-feedback inside
+ *    .bt-exercise — scoped. The flatten override below cancels the :global
+ *    card styling so there is no card-in-card.
  */
 
-/* Per-exercise feedback container — cards the verdict/no-key/error area */
+/* Per-exercise feedback container — cards the verdict/inline-form/error area */
 
 .bt-exercise .bt-feedback {
   margin-top: var(--bt-space-md);
@@ -818,35 +821,18 @@
   font-family: var(--bt-font-family-ui);
 }
 
-/* No-key state (AC-4, issue 182): a real affordance — button-styled link,
- * not a bare default anchor */
+/* Inline key form inside the feedback container (issue #186): the key-page
+ * form rules are :global passthrough (card styling for the standalone key
+ * page). When the form mounts INLINE inside the .bt-feedback card, flatten
+ * the card-in-card — the container already supplies border/background/padding.
+ * This scoped rule beats the :global passthrough by specificity. */
 
-.bt-exercise [data-byok="no-key"] {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--bt-space-md);
-  color: var(--bt-color-text-secondary);
-  font-size: 0.875em;
-  line-height: var(--bt-line-height);
-}
-
-.bt-exercise [data-byok="no-key"] a {
-  display: inline-block;
-  background: var(--bt-color-brand);
-  color: var(--bt-color-surface);
-  border-radius: var(--bt-radius-sm);
-  padding: var(--bt-space-xs) var(--bt-space-sm);
-  font-family: var(--bt-font-family-ui);
-  font-size: var(--bt-font-size-base);
-  font-weight: 600;
-  text-decoration: none;
-  cursor: pointer;
-  white-space: nowrap;
-}
-
-.bt-exercise [data-byok="no-key"] a:hover {
-  background: var(--bt-color-brand-hover);
+.bt-exercise .bt-feedback [data-byok="key-page-form"] {
+  max-width: none;
+  border: none;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
 }
 
 /* Verdict / pending / error / limit-reached inside the per-exercise container */

--- a/_extensions/blendtutor/assets/styles.css
+++ b/_extensions/blendtutor/assets/styles.css
@@ -796,7 +796,7 @@
  * The Quarto fork renders per-exercise feedback into a .bt-feedback container
  * (exercise-feedback.js mountFeedback) — the #feedback rules above serve the
  * crates site shell and are NOT matched by the new code. This section styles
- * the per-exercise container, the INLINE key form (issue #186), and the
+ * the per-exercise container, the INLINE key form (issue 186), and the
  * KEY PAGE form.
  *
  * Scoping notes (scripts/sync-quarto-assets.sh):
@@ -805,7 +805,7 @@
  *    UNscoped. The key page (.blendtutor-key) sits OUTSIDE any .bt-exercise
  *    wrapper, so its form rules MUST use :global(...) — a scoped rule would
  *    never match the key page ("bizarre page" bug, issue 182).
- *  - The INLINE key form (issue #186) renders INSIDE .bt-feedback inside
+ *  - The INLINE key form (issue 186) renders INSIDE .bt-feedback inside
  *    .bt-exercise — scoped. The flatten override below cancels the :global
  *    card styling so there is no card-in-card.
  */
@@ -821,7 +821,7 @@
   font-family: var(--bt-font-family-ui);
 }
 
-/* Inline key form inside the feedback container (issue #186): the key-page
+/* Inline key form inside the feedback container (issue 186): the key-page
  * form rules are :global passthrough (card styling for the standalone key
  * page). When the form mounts INLINE inside the .bt-feedback card, flatten
  * the card-in-card — the container already supplies border/background/padding.

--- a/crates/core/assets/shared/styles.css
+++ b/crates/core/assets/shared/styles.css
@@ -763,7 +763,7 @@ button[disabled] {
  * The Quarto fork renders per-exercise feedback into a .bt-feedback container
  * (exercise-feedback.js mountFeedback) — the #feedback rules above serve the
  * crates site shell and are NOT matched by the new code. This section styles
- * the per-exercise container, the INLINE key form (issue #186), and the
+ * the per-exercise container, the INLINE key form (issue 186), and the
  * KEY PAGE form.
  *
  * Scoping notes (scripts/sync-quarto-assets.sh):
@@ -772,7 +772,7 @@ button[disabled] {
  *    UNscoped. The key page (.blendtutor-key) sits OUTSIDE any .bt-exercise
  *    wrapper, so its form rules MUST use :global(...) — a scoped rule would
  *    never match the key page ("bizarre page" bug, issue 182).
- *  - The INLINE key form (issue #186) renders INSIDE .bt-feedback inside
+ *  - The INLINE key form (issue 186) renders INSIDE .bt-feedback inside
  *    .bt-exercise — scoped. The flatten override below cancels the :global
  *    card styling so there is no card-in-card.
  */
@@ -787,7 +787,7 @@ button[disabled] {
   font-family: var(--bt-font-family-ui);
 }
 
-/* Inline key form inside the feedback container (issue #186): the key-page
+/* Inline key form inside the feedback container (issue 186): the key-page
  * form rules are :global passthrough (card styling for the standalone key
  * page). When the form mounts INLINE inside the .bt-feedback card, flatten
  * the card-in-card — the container already supplies border/background/padding.

--- a/crates/core/assets/shared/styles.css
+++ b/crates/core/assets/shared/styles.css
@@ -763,7 +763,8 @@ button[disabled] {
  * The Quarto fork renders per-exercise feedback into a .bt-feedback container
  * (exercise-feedback.js mountFeedback) — the #feedback rules above serve the
  * crates site shell and are NOT matched by the new code. This section styles
- * the per-exercise container, the no-key link, and the KEY PAGE form.
+ * the per-exercise container, the INLINE key form (issue #186), and the
+ * KEY PAGE form.
  *
  * Scoping notes (scripts/sync-quarto-assets.sh):
  *  - Rules in this source file are prefixed with .bt-exercise by the sync
@@ -771,10 +772,12 @@ button[disabled] {
  *    UNscoped. The key page (.blendtutor-key) sits OUTSIDE any .bt-exercise
  *    wrapper, so its form rules MUST use :global(...) — a scoped rule would
  *    never match the key page ("bizarre page" bug, issue 182).
- *  - The no-key link renders INSIDE .bt-feedback inside .bt-exercise — scoped.
+ *  - The INLINE key form (issue #186) renders INSIDE .bt-feedback inside
+ *    .bt-exercise — scoped. The flatten override below cancels the :global
+ *    card styling so there is no card-in-card.
  */
 
-/* Per-exercise feedback container — cards the verdict/no-key/error area */
+/* Per-exercise feedback container — cards the verdict/inline-form/error area */
 .bt-feedback {
   margin-top: var(--bt-space-md);
   padding: var(--bt-space-sm);
@@ -784,34 +787,17 @@ button[disabled] {
   font-family: var(--bt-font-family-ui);
 }
 
-/* No-key state (AC-4, issue 182): a real affordance — button-styled link,
- * not a bare default anchor */
-[data-byok="no-key"] {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--bt-space-md);
-  color: var(--bt-color-text-secondary);
-  font-size: 0.875em;
-  line-height: var(--bt-line-height);
-}
-
-[data-byok="no-key"] a {
-  display: inline-block;
-  background: var(--bt-color-brand);
-  color: var(--bt-color-surface);
-  border-radius: var(--bt-radius-sm);
-  padding: var(--bt-space-xs) var(--bt-space-sm);
-  font-family: var(--bt-font-family-ui);
-  font-size: var(--bt-font-size-base);
-  font-weight: 600;
-  text-decoration: none;
-  cursor: pointer;
-  white-space: nowrap;
-}
-
-[data-byok="no-key"] a:hover {
-  background: var(--bt-color-brand-hover);
+/* Inline key form inside the feedback container (issue #186): the key-page
+ * form rules are :global passthrough (card styling for the standalone key
+ * page). When the form mounts INLINE inside the .bt-feedback card, flatten
+ * the card-in-card — the container already supplies border/background/padding.
+ * This scoped rule beats the :global passthrough by specificity. */
+.bt-feedback [data-byok="key-page-form"] {
+  max-width: none;
+  border: none;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
 }
 
 /* Verdict / pending / error / limit-reached inside the per-exercise container */

--- a/demo-book/_extensions/mcmullarkey/blendtutor/assets/exercise-feedback.js
+++ b/demo-book/_extensions/mcmullarkey/blendtutor/assets/exercise-feedback.js
@@ -40,6 +40,13 @@
 //   invokes it AFTER the runtime boots. Pure functions are importable in
 //   Node.js without side effects, so they are testable without a browser.
 
+// Issue #186: the no-key state mounts the key-management form (key-page.js
+// mountKeyPage) INLINE into the feedback container — no navigation link. The
+// import is a cycle (key-page.js imports the storage/provider contract from
+// this module) — safe: both modules use imported bindings only at call time,
+// never at module-eval time (ES live bindings resolve by then).
+import { mountKeyPage } from "./key-page.js";
+
 // --- prompt structure (the single source, ported from feedback.js) -------------
 //
 // Byte-identical to the Rust core::llm prompt constants (pinned by the
@@ -77,8 +84,8 @@ export const DEFAULT_PROVIDER = "fireworks";
 
 // Per-provider disclosure texts — literal strings so the static scan can
 // verify BOTH are present. Documentation of the privacy promise shown to
-// learners; the no-key state no longer renders them inline (AC-4 routes
-// learners to the key page), but the copy stays pinned in source.
+// learners; the no-key state mounts the key-page form inline (issue #186)
+// without repeating the disclosures, but the copy stays pinned in source.
 const PROVIDER_DISCLOSURES = {
   fireworks: "Your Fireworks API key is stored in this browser (localStorage) " +
     "and sent only to Fireworks to fetch feedback — never to this site's " +
@@ -408,23 +415,31 @@ function currentSubmissionForExercise(entry) {
   };
 }
 
-// --- the no-key state (AC-4): link to the key page, no inline form ----------
+// --- the no-key state (issue #186): INLINE key form, no navigation link ----
 //
-// The learner clicks "Get feedback" with no stored key → the container renders
-// a single link to the key page instead of an inline key-entry form (the
-// inline form's job moved to the dedicated key page, assets/key-page.js,
-// AC-2). The link opens in a new tab (target=_blank + rel=noopener) so the
-// learner's in-progress code in the exercise editor survives the detour.
+// The learner clicks "Get feedback" with no stored key → the feedback
+// container mounts the key-management form (key-page.js mountKeyPage) INLINE
+// instead of rendering a link to a separate key page (the user-reported fix:
+// the old link navigated away to a confusing page and dropped the learner's
+// context). The container itself is the mount target — key-page.js renders
+// its password input + Save button into it.
 //
-// The link target comes from window.__btConfig.keyPageUrl, emitted by the
-// blendtutor.lua head script (AC-3) from the bt-key-page YAML meta. It is read
-// LAZILY at render time (never cached at module init — §2.1: no module-level
-// effectful read) so a dynamically-set config value is honored.
+// Save-continuation: onSaved re-invokes handleSubmitForExercise once the key
+// is stored, so the same click path proceeds to the rate-limit check + fetch
+// without a second user action. The callback only fires on a successful
+// storeKey (optimistic contract — key stored = proceed); a rejected or
+// unreachable advisory validation is copy on the form's status line and must
+// NOT block continuation.
+//
+// keyPageUrl() is retained for the standalone api-key chapter (the demo-book
+// index + the lua bt-key-page emission still point at it) and stays exported
+// (Node-tested by key-page-url.test.js).
 
-// Pure-ish: the key-page URL for the no-key link. Reads window.__btConfig at
-// CALL time, rejects javascript:/data: schemes (defense in depth against a
-// crafted config), falls back to the default page. Total: never throws, never
-// returns "". Exported so it is Node-testable without a browser.
+// Pure-ish: the key-page URL for the standalone api-key chapter. Reads
+// window.__btConfig at CALL time, rejects javascript:/data: schemes (defense
+// in depth against a crafted config), falls back to the default page. Total:
+// never throws, never returns "". Exported so it is Node-testable without a
+// browser.
 export function keyPageUrl() {
   const config = typeof window !== "undefined" ? window.__btConfig : null;
   let candidate = config && config.keyPageUrl;
@@ -443,26 +458,6 @@ export function keyPageUrl() {
     }
   }
   return candidate;
-}
-
-// Render the no-key state: a single DOM-built anchor to the key page. The
-// anchor is built with createElement + .href/.textContent — never innerHTML
-// with URL interpolation. The copy is the AC literal "Enter your API key
-// first". Exported so tests can render the prompt without a browser.
-export function renderKeyPrompt(container) {
-  const wrapper = document.createElement("div");
-  wrapper.dataset.byok = "no-key";
-
-  // Lazy read at render time — never cached at module init (§2.1).
-  const href = keyPageUrl();
-  const link = document.createElement("a");
-  link.href = href;
-  link.target = "_blank";
-  link.rel = "noopener";
-  link.textContent = "Enter your API key first";
-
-  wrapper.append(link);
-  container.replaceChildren(wrapper);
 }
 
 // Render the verdict. textContent only — the message is model output (untrusted),
@@ -504,7 +499,9 @@ function renderLimitReached(container) {
 }
 
 // Orchestrate one submit for a single exercise, in three named states:
-//   no key            → render the no-key link to the key page (AC-4);
+//   no key            → mount the key form INLINE (key-page.js mountKeyPage)
+//                        with an onSaved save-continuation that re-runs this
+//                        handler once the key is stored (issue #186);
 //   rate-limited      → render the limit-reached message (no fetch);
 //   key present       → build the prompt (task + student code + captured
 //                        .bt-output + checks) and send feedback through the
@@ -537,7 +534,11 @@ async function handleSubmitForExercise(entry) {
   const providerId = readProvider();
   const apiKey = readKey(providerId);
   if (!apiKey) {
-    renderKeyPrompt(container);
+    // Inline key form (issue #186): mount key-page.js INTO the feedback
+    // container. The onSaved continuation re-runs this handler once the key
+    // is stored — the key check then passes and the flow proceeds to the
+    // rate-limit check + fetch without a second user action.
+    mountKeyPage(container, { onSaved: () => handleSubmitForExercise(entry) });
     return;
   }
   // Rate-limit check BEFORE the fetch — a capped learner never fires a

--- a/demo-book/_extensions/mcmullarkey/blendtutor/assets/key-page.js
+++ b/demo-book/_extensions/mcmullarkey/blendtutor/assets/key-page.js
@@ -97,8 +97,10 @@ function renderKeySet(container) {
 }
 
 // No-key mount state: password input + Save. `initialReason` seeds the status
-// line (used after Clear to report the removal).
-function renderKeyForm(container, initialReason) {
+// line (used after Clear to report the removal). `onSaved` (optional, issue
+// #186) is threaded to handleSave — an inline caller (the exercise feedback
+// no-key state) re-runs its submit flow once the key is stored.
+function renderKeyForm(container, initialReason, onSaved) {
   const form = document.createElement("form");
   form.dataset.byok = "key-page-form";
 
@@ -119,7 +121,7 @@ function renderKeyForm(container, initialReason) {
   form.append(status, input, save);
   form.addEventListener("submit", (event) => {
     event.preventDefault();
-    return handleSave(input, status);
+    return handleSave(input, status, onSaved);
   });
 
   if (initialReason) {
@@ -131,10 +133,15 @@ function renderKeyForm(container, initialReason) {
 // Save flow: empty input is a no-op (stored key survives, no fetch); otherwise
 // store optimistically via the imported contract, reset the input immediately
 // (no password-manager capture, no echo), then validate (advisory status).
+// `onSaved` (optional, issue #186) fires ONCE right after the key is stored —
+// before the advisory validation resolves — so an inline caller can re-run its
+// submit flow with the key now present. The optimistic contract: key stored =
+// proceed; a rejected/network validation is advisory copy only and must NOT
+// block continuation.
 // When storage is unavailable (storeKey throws — private mode, quota exceeded),
 // report a friendly storage status and STOP: no fetch, input keeps its value so
 // the user can retry. The key is only cleared from the input on the success path.
-function handleSave(input, status) {
+function handleSave(input, status, onSaved) {
   const value = input.value.trim();
   if (!value) {
     setStatus(status, "empty");
@@ -147,6 +154,9 @@ function handleSave(input, status) {
     return;
   }
   input.value = "";
+  if (typeof onSaved === "function") {
+    onSaved();
+  }
   return validateAndReport(status, value);
 }
 
@@ -173,7 +183,11 @@ async function validateAndReport(status, key) {
 
 // Mount the key-management UI into `target`. No-op when the target is absent
 // or already mounted (idempotent — one save issues exactly one fetch).
-export function mountKeyPage(target) {
+// `opts.onSaved` (optional, issue #186) is called once after a successful
+// save — the exercise feedback inline mount uses it to re-run the submit flow
+// once the key exists. Backward-compatible: existing callers pass no opts and
+// get the mount-only behavior (blendtutor.lua bootstrap passes none).
+export function mountKeyPage(target, opts = {}) {
   if (!target || mountedTargets.has(target)) {
     return;
   }
@@ -181,6 +195,6 @@ export function mountKeyPage(target) {
   if (readKey(PROVIDER_ID)) {
     renderKeySet(target);
   } else {
-    renderKeyForm(target);
+    renderKeyForm(target, undefined, opts.onSaved);
   }
 }

--- a/demo-book/_extensions/mcmullarkey/blendtutor/assets/styles.css
+++ b/demo-book/_extensions/mcmullarkey/blendtutor/assets/styles.css
@@ -796,7 +796,8 @@
  * The Quarto fork renders per-exercise feedback into a .bt-feedback container
  * (exercise-feedback.js mountFeedback) — the #feedback rules above serve the
  * crates site shell and are NOT matched by the new code. This section styles
- * the per-exercise container, the no-key link, and the KEY PAGE form.
+ * the per-exercise container, the INLINE key form (issue #186), and the
+ * KEY PAGE form.
  *
  * Scoping notes (scripts/sync-quarto-assets.sh):
  *  - Rules in this source file are prefixed with .bt-exercise by the sync
@@ -804,10 +805,12 @@
  *    UNscoped. The key page (.blendtutor-key) sits OUTSIDE any .bt-exercise
  *    wrapper, so its form rules MUST use :global(...) — a scoped rule would
  *    never match the key page ("bizarre page" bug, issue 182).
- *  - The no-key link renders INSIDE .bt-feedback inside .bt-exercise — scoped.
+ *  - The INLINE key form (issue #186) renders INSIDE .bt-feedback inside
+ *    .bt-exercise — scoped. The flatten override below cancels the :global
+ *    card styling so there is no card-in-card.
  */
 
-/* Per-exercise feedback container — cards the verdict/no-key/error area */
+/* Per-exercise feedback container — cards the verdict/inline-form/error area */
 
 .bt-exercise .bt-feedback {
   margin-top: var(--bt-space-md);
@@ -818,35 +821,18 @@
   font-family: var(--bt-font-family-ui);
 }
 
-/* No-key state (AC-4, issue 182): a real affordance — button-styled link,
- * not a bare default anchor */
+/* Inline key form inside the feedback container (issue #186): the key-page
+ * form rules are :global passthrough (card styling for the standalone key
+ * page). When the form mounts INLINE inside the .bt-feedback card, flatten
+ * the card-in-card — the container already supplies border/background/padding.
+ * This scoped rule beats the :global passthrough by specificity. */
 
-.bt-exercise [data-byok="no-key"] {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--bt-space-md);
-  color: var(--bt-color-text-secondary);
-  font-size: 0.875em;
-  line-height: var(--bt-line-height);
-}
-
-.bt-exercise [data-byok="no-key"] a {
-  display: inline-block;
-  background: var(--bt-color-brand);
-  color: var(--bt-color-surface);
-  border-radius: var(--bt-radius-sm);
-  padding: var(--bt-space-xs) var(--bt-space-sm);
-  font-family: var(--bt-font-family-ui);
-  font-size: var(--bt-font-size-base);
-  font-weight: 600;
-  text-decoration: none;
-  cursor: pointer;
-  white-space: nowrap;
-}
-
-.bt-exercise [data-byok="no-key"] a:hover {
-  background: var(--bt-color-brand-hover);
+.bt-exercise .bt-feedback [data-byok="key-page-form"] {
+  max-width: none;
+  border: none;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
 }
 
 /* Verdict / pending / error / limit-reached inside the per-exercise container */

--- a/demo-book/_extensions/mcmullarkey/blendtutor/assets/styles.css
+++ b/demo-book/_extensions/mcmullarkey/blendtutor/assets/styles.css
@@ -796,7 +796,7 @@
  * The Quarto fork renders per-exercise feedback into a .bt-feedback container
  * (exercise-feedback.js mountFeedback) — the #feedback rules above serve the
  * crates site shell and are NOT matched by the new code. This section styles
- * the per-exercise container, the INLINE key form (issue #186), and the
+ * the per-exercise container, the INLINE key form (issue 186), and the
  * KEY PAGE form.
  *
  * Scoping notes (scripts/sync-quarto-assets.sh):
@@ -805,7 +805,7 @@
  *    UNscoped. The key page (.blendtutor-key) sits OUTSIDE any .bt-exercise
  *    wrapper, so its form rules MUST use :global(...) — a scoped rule would
  *    never match the key page ("bizarre page" bug, issue 182).
- *  - The INLINE key form (issue #186) renders INSIDE .bt-feedback inside
+ *  - The INLINE key form (issue 186) renders INSIDE .bt-feedback inside
  *    .bt-exercise — scoped. The flatten override below cancels the :global
  *    card styling so there is no card-in-card.
  */
@@ -821,7 +821,7 @@
   font-family: var(--bt-font-family-ui);
 }
 
-/* Inline key form inside the feedback container (issue #186): the key-page
+/* Inline key form inside the feedback container (issue 186): the key-page
  * form rules are :global passthrough (card styling for the standalone key
  * page). When the form mounts INLINE inside the .bt-feedback card, flatten
  * the card-in-card — the container already supplies border/background/padding.

--- a/docs/evidence/186/asset-parity.log
+++ b/docs/evidence/186/asset-parity.log
@@ -1,0 +1,10 @@
+=== sync-quarto-assets.sh --check ===
+  ok: codemirror.js matches source
+  ok: styles.css matches source
+  ok: coi-serviceworker.js matches source
+All assets in sync.
+
+=== cmp vendored copies ===
+exercise-feedback.js byte-identical
+key-page.js byte-identical
+styles.css byte-identical

--- a/docs/evidence/186/ci-fix.log
+++ b/docs/evidence/186/ci-fix.log
@@ -1,0 +1,122 @@
+# CI fix — PR #187 (issue #186 inline API key entry)
+
+Date: 2026-08-07
+Branch: 186-inline-api-key-entry
+
+Three CI failures root-caused from CI logs and fixed. All mechanical — no
+redesign, no re-review.
+
+## Failure 1 — Node TDZ in test_quarto_feedback.py NODE_TEST_SCRIPT
+
+`ReferenceError: Cannot access 'fetchCalls' before initialization` at
+installFetchSpy (tmp.mjs:357) called from module top-level (tmp.mjs:301).
+
+The committed NODE_TEST_SCRIPT ran the issue #186 no-key block at module
+top-level BEFORE `let fetchCalls = []` was declared: installFetchSpy() closes
+over fetchCalls, so the call at top-level hit the TDZ. The block was moved
+below the helper definitions (`fetchCalls`, installFetchSpy, makeEntry,
+mountAndClick, flush, promptBodyAt) so all state the spy closes over is
+initialized before installFetchSpy() is invoked.
+
+Verify (local):
+```
+=== Results: 64 passed, 0 failed ===
+```
+
+## Failure 2 — cargo nextest hex-regex: `#186` in new CSS comments
+
+build.rs Clause 7 (`crates/cli/tests/build.rs`) scans the ENTIRE built
+styles.css for `#[0-9a-fA-F]{3}\b` literals outside `:root` blocks — and
+comments count. The issue #186 fix added `issue #186` comments to
+crates/core/assets/shared/styles.css; `#186` matched the hex regex
+(`186` = 3 hex digits). Same trap as `#182` in PR #183.
+
+Failures (all three named build tests):
+- build_pyodide_emits_a_deployable_python_lesson_site
+- build_dark_mode_token_overrides
+- build_webr_emits_a_deployable_r_lesson_site
+
+Fix: `issue #186` → `issue 186` in the 3 comment lines of
+crates/core/assets/shared/styles.css, then re-ran
+`bash scripts/sync-quarto-assets.sh` (regenerates the scoped
+_extensions/blendtutor/assets/styles.css) and re-copied to the demo-book
+vendored copy (demo-book/_extensions/mcmullarkey/blendtutor/assets/styles.css).
+
+Verify (local):
+```
+cargo nextest run -p blendtutor-cli
+Summary [  60.273s] 105 tests run: 105 passed, 0 skipped
+```
+(including the three named tests, all PASS)
+
+Future footgun scan: only `issue #186` occurrences existed; no other `#NNN`
+issue references in styles.css comments. Remaining comment hex `#ffffff`
+(line 83) sits inside the `:root` block — allowed by Clause 7.
+
+## Failure 3 — rodney probe P5 state leak from new P11
+
+P5 vacuous guard failed: "key form mounted: no [data-byok=key-input] after
+15s" then "element not found: .bt-exercise:first-of-type .bt-feedback-btn".
+
+Root cause: the #186 P11 rewrite (runner order: P11 → P5 → P10) SAVES a key
+via the inline form and leaves `fireworks_api_key = 'fw_inline_probe_789'`
+in localStorage. P5 then opens api-key.html in the SAME browser
+session/origin; mountKeyPage renders renderKeySet (status + Clear button, NO
+key-input) instead of renderKeyForm → P5's guard expecting
+[data-byok=key-input] fails, and the subsequent .bt-feedback-btn click times
+out (different page state).
+
+Fix (option a — P5's semantic is "empty storage → key-page UI → save →
+cross-page persistence", it MUST start from empty): explicit
+`localStorage.clear()` through the page at P5 start, before navigating to the
+key page. P10 still runs after P5 and consumes P5's key (`fw_cross_page_456`)
+— the clear only resets P11's leftover state, not P5's own save.
+
+Verify (local): `node --check rodney-probes/feedback-probe.js` passes.
+Rodney harness needs Chrome — CI rodney job re-verifies P5/P10/P11 ordering
+end-to-end.
+
+## Re-run logs
+
+### python3 scripts/tests/test_quarto_feedback.py
+```
+=== Results: 64 passed, 0 failed ===
+```
+
+### cargo nextest run -p blendtutor-cli (full suite)
+```
+Summary [  60.273s] 105 tests run: 105 passed, 0 skipped
+```
+Named failures (all PASS):
+- blendtutor-cli::build build_webr_emits_a_deployable_r_lesson_site
+- blendtutor-cli::build build_pyodide_emits_a_deployable_python_lesson_site
+- blendtutor-cli::build build_dark_mode_token_overrides
+
+### bash scripts/sync-quarto-assets.sh --check
+```
+  ok: codemirror.js matches source
+  ok: styles.css matches source
+  ok: coi-serviceworker.js matches source
+All assets in sync.
+```
+
+### cmp vendored copies (byte-identical)
+```
+cmp _extensions/blendtutor/assets/styles.css
+    demo-book/_extensions/mcmullarkey/blendtutor/assets/styles.css
+→ identical
+```
+
+### node --check rodney-probes/feedback-probe.js
+```
+NODE-SYNTAX-OK
+```
+
+## Diff stats
+- scripts/tests/test_quarto_feedback.py — reorder #186 block after fetch-spy
+  helpers (28+/28-)
+- crates/core/assets/shared/styles.css — `issue #186` → `issue 186` (3 comment
+  lines)
+- _extensions/blendtutor/assets/styles.css — regenerated scoped copy (sync)
+- demo-book/_extensions/mcmullarkey/blendtutor/assets/styles.css — re-copied
+- rodney-probes/feedback-probe.js — P5 start localStorage clear + note

--- a/docs/evidence/186/rendered-page.log
+++ b/docs/evidence/186/rendered-page.log
@@ -1,0 +1,21 @@
+=== demo-book render: bootstrap imports (rendered r-exercises.html) ===
+83:  import { mountAllFeedback } from "./site_libs/quarto-contrib/blendtutor-0.1.0/exercise-feedback.js";
+84:  import { mountKeyPage } from "./site_libs/quarto-contrib/blendtutor-0.1.0/key-page.js";
+88:  mountKeyPage(document.querySelector(".blendtutor-key"));
+92:    mountAllFeedback(registry);
+
+=== deployed libs copy byte-identical to extension source ===
+deployed exercise-feedback.js == extension source
+deployed key-page.js == extension source
+
+=== inline mount + save-continuation in deployed JS ===
+43:// Issue #186: the no-key state mounts the key-management form (key-page.js
+87:// learners; the no-key state mounts the key-page form inline (issue #186)
+418:// --- the no-key state (issue #186): INLINE key form, no navigation link ----
+427:// Save-continuation: onSaved re-invokes handleSubmitForExercise once the key
+503://                        with an onSaved save-continuation that re-runs this
+538:    // container. The onSaved continuation re-runs this handler once the key
+541:    mountKeyPage(container, { onSaved: () => handleSubmitForExercise(entry) });
+
+=== scoped CSS flatten override in deployed book ===
+830:.bt-exercise .bt-feedback [data-byok="key-page-form"] {

--- a/docs/evidence/186/shell-suites.log
+++ b/docs/evidence/186/shell-suites.log
@@ -1,0 +1,10 @@
+=== test_quarto_asset_deployment.sh ===
+  Results: 68 passed, 0 failed
+All tests passed.
+
+=== test_quarto_bootstrap.sh ===
+  Results: 74 passed, 0 failed
+All tests passed.
+
+=== test_quarto_ux.py ===
+=== Results: 46 passed, 0 failed ===

--- a/docs/evidence/186/test-suite.log
+++ b/docs/evidence/186/test-suite.log
@@ -1,8 +1,12 @@
-=== test_quarto_feedback.py ===
+=== AC-7 Per-exercise BYOK LLM feedback — test_quarto_feedback.py ===
+
   PASS: exercise-feedback.js exists
   PASS: feedback.qmd exists
+-- Clause 6: llm_evaluation_prompt ABSENT --
   PASS: llm_evaluation_prompt ABSENT from exercise-feedback.js
   PASS: llm_evaluation_prompt ABSENT from feedback.qmd
+
+-- Source-pattern checks --
   PASS: pure function exported: neutralize
   PASS: pure function exported: buildPrompt
   PASS: pure function exported: parseModels
@@ -42,6 +46,8 @@
   PASS: feedback UI elements carry data-byok markers (dataset.byok)
   PASS: fetch() called in backends (feedback is not silently skipped)
   PASS: no module-level applyEmbeddedKey() call (pure layer importable)
+
+-- AC-5 source checks (issue #166) --
   PASS: AC-5 arm 3 (source): FIREWORKS_MODEL pinned to deepseek-v4-flash-0731 at both uses (fallbackModel + const)
   PASS: AC-5 arm 3 (source): no unpinned deepseek-v4-flash model literal remains
   PASS: AC-5 arm 4 (source): renderModelPicker removed
@@ -54,9 +60,14 @@
   PASS: AC-5 arm 1 (source): exercise-runtime.js has zero exercise-feedback references
   PASS: AC-5 (fixture): feedback.qmd sets window.__btConfig.maxFeedbackPerSession
   PASS: AC-5 (fixture): __btConfig uses the C22 merge pattern (no keyPageUrl clobber)
+
+-- Issue #179 lua emission check --
   PASS: issue #179 (source): blendtutor.lua emits maxFeedbackPerSession default 20 (crates parity)
   PASS: issue #179 (source): __btConfig merge pattern in blendtutor.lua (no keyPageUrl clobber)
   PASS: issue #179 (source): build_key_page_config_script has no bare __btConfig clobber
+
+-- Behavioral checks (Node.js) --
+[blendtutor] Exercise "exC" feedback already in flight, ignoring concurrent request.
   PASS: buildPrompt emits STUDENT_CODE_BEGIN fence
   PASS: buildPrompt emits STUDENT_CODE_END fence
   PASS: buildPrompt includes task
@@ -172,115 +183,70 @@
   PASS: AC-5 arm 14: no .bt-feedback-wrapper created when controls present
   PASS: AC-5 arm 14: feedback container is a direct child of the exercise element
   PASS: Node.js behavioral tests passed (all pure-function assertions)
+TAP version 13
+# Subtest: keyPageUrl() returns api-key.html when window is absent (Node, no DOM)
+ok 1 - keyPageUrl() returns api-key.html when window is absent (Node, no DOM)
+  ---
+  duration_ms: 2.245916
+  type: 'test'
+  ...
+# Subtest: keyPageUrl() returns api-key.html when __btConfig is undefined
+ok 2 - keyPageUrl() returns api-key.html when __btConfig is undefined
+  ---
+  duration_ms: 0.09225
+  type: 'test'
+  ...
+# Subtest: keyPageUrl() returns api-key.html when the config key is absent
+ok 3 - keyPageUrl() returns api-key.html when the config key is absent
+  ---
+  duration_ms: 0.0665
+  type: 'test'
+  ...
+# Subtest: keyPageUrl() returns api-key.html when the config key is empty
+ok 4 - keyPageUrl() returns api-key.html when the config key is empty
+  ---
+  duration_ms: 0.058166
+  type: 'test'
+  ...
+# Subtest: keyPageUrl() returns the configured value verbatim
+ok 5 - keyPageUrl() returns the configured value verbatim
+  ---
+  duration_ms: 0.138584
+  type: 'test'
+  ...
+# Subtest: keyPageUrl() rejects the javascript: scheme (case-insensitive, trimmed)
+ok 6 - keyPageUrl() rejects the javascript: scheme (case-insensitive, trimmed)
+  ---
+  duration_ms: 0.083667
+  type: 'test'
+  ...
+# Subtest: keyPageUrl() rejects the data: scheme
+ok 7 - keyPageUrl() rejects the data: scheme
+  ---
+  duration_ms: 0.125709
+  type: 'test'
+  ...
+# Subtest: keyPageUrl() allows ordinary relative and https URLs through
+ok 8 - keyPageUrl() allows ordinary relative and https URLs through
+  ---
+  duration_ms: 0.059916
+  type: 'test'
+  ...
+1..8
+# tests 8
+# suites 0
+# pass 8
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 59.25225
   PASS: keyPageUrl standalone node:test suite passed (8 tests, incl. typeof-window-absent branch)
+
+-- feedback.qmd structure --
   PASS: feedback.qmd has 2 exercises (>=2 for key-reuse test)
   PASS: feedback.qmd imports exercise-feedback.js
   PASS: feedback.qmd imports exercise-runtime.js (AC-4 dependency)
   PASS: feedback.qmd calls mountFeedback/mountAllFeedback
-=== Results: 64 passed, 0 failed ===
 
-=== test_quarto_key_page.py ===
-  PASS: key-page.js exists
-  PASS: exercise-feedback.js exists (import contract source)
-  PASS: P1: key-page.js imports from './exercise-feedback.js'
-  PASS: P1: import contract includes readKey
-  PASS: P1: import contract includes storeKey
-  PASS: P1: import contract includes clearKey
-  PASS: P1: import contract includes providerBaseUrl
-  PASS: P1: import contract includes PROVIDERS
-  PASS: P1: no literal 'fireworks_api_key' anywhere in source
-  PASS: P1: no literal 'anthropic_api_key' anywhere in source
-  PASS: P1: no literal 'byok_provider' anywhere in source
-  PASS: P1: no literal 'bt_feedback_count' anywhere in source
-  PASS: P1: no literal 'api.fireworks.ai' anywhere in source
-  PASS: P1: no literal 'sessionStorage' anywhere in source
-  PASS: P3: classifyValidation present (discriminated result)
-  PASS: P3: validation does NOT reuse listModels (401 must not collapse into []/network)
-  PASS: P5: zero console. calls (key never logged)
-  PASS: P5: zero innerHTML usage (textContent-only rendering)
-  PASS: P5: rendering is textContent-based
-  PASS: P6: password input has type=password
-  PASS: P6: password input has autocomplete=off
-  PASS: P15: buildValidationUrl is an exported pure function
-  PASS: P15: buildValidationUrl body contains no fetch(
-  PASS: P15: buildValidationUrl body contains no localStorage
-  PASS: P15: buildValidationUrl body contains no document.
-  PASS: P15: classifyValidation is an exported pure function
-  PASS: P15: classifyValidation body contains no fetch(
-  PASS: P15: classifyValidation body contains no localStorage
-  PASS: P15: classifyValidation body contains no document.
-  PASS: P15: statusMessage is an exported pure function
-  PASS: P15: statusMessage body contains no fetch(
-  PASS: P15: statusMessage body contains no localStorage
-  PASS: P15: statusMessage body contains no document.
-  PASS: P16: docstring header names WHAT/WHERE/NOT
-  PASS: P16: at most 5 public exports (found 4)
-  PASS: P16: public export buildValidationUrl
-  PASS: P16: public export classifyValidation
-  PASS: P16: public export statusMessage
-  PASS: P16: public export mountKeyPage
-  PASS: P3: 2xx -> {ok:true}
-  PASS: P3: any 2xx is ok
-  PASS: P3: 401 -> invalid-key
-  PASS: P3: 403 -> invalid-key
-  PASS: P3: other non-2xx -> network
-  PASS: P3: thrown fetch -> network
-  PASS: P4: statusMessage(saved) has friendly copy
-  PASS: P4: statusMessage(invalid-key) has friendly copy
-  PASS: P4: statusMessage(network) has friendly copy
-  PASS: P4: statusMessage(empty) has friendly copy
-  PASS: P4: statusMessage(cleared) has friendly copy
-  PASS: P2: validation URL honors localhost ?provider= override
-  PASS: P2: default validation URL ends with /models
-  PASS: P10: no-key mount renders a form
-  PASS: P10: no-key mount renders a password input
-  PASS: P6: input type is password
-  PASS: P6: input autocomplete is off
-  PASS: P10: no-key mount renders the Save button
-  PASS: P10: no-key mount has no Clear button
-  PASS: P13: submit handler calls preventDefault
-  PASS: P7: Save stores key via imported storeKey (AC-1 signature, key first)
-  PASS: P7: readKey round-trips the saved key
-  PASS: P14: input value reset to empty AFTER storeKey
-  PASS: P11: one save issues exactly one fetch
-  PASS: P2: validation fetch targets the host-gated models URL
-  PASS: key rides Authorization header, never the body
-  PASS: P7: save reports saved status on 2xx
-  PASS: P5: key never echoed into any DOM textContent
-  PASS: P5: at least one non-empty textContent after save
-  PASS: P9: empty save does NOT clear the existing key
-  PASS: P9: empty save issues no fetch
-  PASS: P9: empty save reports the empty status
-  PASS: P10: key-set mount shows 'key is set' status
-  PASS: P10: key-set mount shows the Clear button
-  PASS: P10: key-set mount renders NO input — the key is never pre-filled
-  PASS: P8: Clear removes the provider key slot
-  PASS: P8: Clear removes bt_feedback_count (no rate-lock)
-  PASS: P8: readKey returns null after Clear
-  PASS: P10: after Clear, UI returns to the empty input form
-  PASS: P10: post-Clear input starts empty
-  PASS: after Clear, the Clear button is gone
-  PASS: P4: Clear reports the cleared status
-  PASS: P11: double mount does not re-render (same form instance)
-  PASS: P11: double mount does not duplicate the submit listener
-  PASS: P11: double mount -> one save -> exactly one fetch
-  PASS: P11: save still works after double mount
-  PASS: P12: mountKeyPage(null/undefined) no-op without crash
-  PASS: P3: 401 save reports invalid-key (not collapsed into network)
-  PASS: 401 save issued one fetch
-  PASS: advisory: key stored even when validation rejects
-  PASS: P3: thrown fetch reports network
-  PASS: network save issued one fetch
-  PASS: storage-unavailable: ZERO fetches issued when storeKey throws
-  PASS: storage-unavailable: friendly storage status rendered
-  PASS: storage-unavailable: key NOT stored
-  PASS: storage-unavailable: input keeps its value for retry (no silent wipe)
-  PASS: P17: empty save does NOT fire onSaved
-  PASS: P17: empty save still reports the empty status
-  PASS: P17: storage-unavailable save does NOT fire onSaved
-  PASS: P17: storage-unavailable save issues no fetch (onSaved would continue a doomed flow)
-  PASS: P17: successful save fires onSaved EXACTLY once
-  PASS: P17: key stored alongside onSaved (onSaved runs after storeKey)
-  PASS: P17: successful save still issues one validation fetch
-  PASS: Node.js behavioral tests passed (all key-page assertions)
-=== Results: 40 passed, 0 failed ===
+=== Results: 64 passed, 0 failed ===

--- a/docs/evidence/186/test-suite.log
+++ b/docs/evidence/186/test-suite.log
@@ -1,0 +1,286 @@
+=== test_quarto_feedback.py ===
+  PASS: exercise-feedback.js exists
+  PASS: feedback.qmd exists
+  PASS: llm_evaluation_prompt ABSENT from exercise-feedback.js
+  PASS: llm_evaluation_prompt ABSENT from feedback.qmd
+  PASS: pure function exported: neutralize
+  PASS: pure function exported: buildPrompt
+  PASS: pure function exported: parseModels
+  PASS: pure function exported: modelRoster
+  PASS: pure function exported: feedbackRequest
+  PASS: pure function exported: toVerdict
+  PASS: pure function exported: fireworksRequest
+  PASS: pure function exported: fireworksToVerdict
+  PASS: pure function exported: providerBaseUrl
+  PASS: STUDENT_CODE fences present in source
+  PASS: PROVIDERS map has fireworks + anthropic
+  PASS: provider-scoped key slots present (fireworks_api_key, anthropic_api_key)
+  PASS: C1 (source): no data-byok="provider" literal in exercise-feedback.js
+  PASS: C1 (source): no provider <select> creation pattern (dataset.byok = "provider")
+  PASS: C3 (source): PROVIDERS.anthropic keeps the byokAnthropic factory
+  PASS: C6 (source): no orphaned provSelect references
+  PASS: C5 (source): BOTH provider disclosures state localStorage wording
+  PASS: issue #186 (source): `import { mountKeyPage } from "./key-page.js"` present
+  PASS: issue #186 (source): no-key guard mounts the inline form with save-continuation (`if (!apiKey) { mountKeyPage(container, { onSaved: () => handleSubmitForExercise(entry) }); return; }`) first in submit flow
+  PASS: issue #186 (source): keyPageUrl region keeps the window.__btConfig read
+  PASS: issue #186 (source): default api-key.html fallback present
+  PASS: issue #186 (source): keyPageUrl() exported (api-key chapter + key-page-url.test.js)
+  PASS: issue #186 (source): renderKeyPrompt GONE (no link renderer)
+  PASS: issue #186 (source): [data-byok="no-key"] marker ABSENT (no link wrapper)
+  PASS: issue #186 (source): target=_blank ABSENT (no new-tab navigation)
+  PASS: key slot is provider-scoped (not exercise-scoped)
+  PASS: storeKey + readKey present (shared key handling)
+  PASS: clearKey present (scoped key + counter removal, issue #162)
+  PASS: storage backend is localStorage (shared, persistent)
+  PASS: zero sessionStorage tokens in exercise-feedback.js (P4)
+  PASS: no singleton getElementById('feedback') — per-exercise scoping
+  PASS: no window.__bt singleton access (uses __btExercises registry)
+  PASS: ?provider= override parsed via URLSearchParams
+  PASS: localhost-only gate present (non-local override rejected)
+  PASS: per-exercise concurrent feedback guard present
+  PASS: mountFeedback/mountAllFeedback present (per-exercise mount)
+  PASS: feedback UI elements carry data-byok markers (dataset.byok)
+  PASS: fetch() called in backends (feedback is not silently skipped)
+  PASS: no module-level applyEmbeddedKey() call (pure layer importable)
+  PASS: AC-5 arm 3 (source): FIREWORKS_MODEL pinned to deepseek-v4-flash-0731 at both uses (fallbackModel + const)
+  PASS: AC-5 arm 3 (source): no unpinned deepseek-v4-flash model literal remains
+  PASS: AC-5 arm 4 (source): renderModelPicker removed
+  PASS: AC-5 arm 4 (source): modelPickerPresent removed
+  PASS: AC-5 arm 4 (source): selectedModel removed
+  PASS: AC-5 arm 4 (source): data-byok="model-picker" literal absent (never rendered)
+  PASS: AC-5 arm 4 (source): submit flow is key check → rate-limit check → fetch (no picker phase)
+  PASS: AC-5 arm 8 (source): zero innerHTML (verdict render is textContent-only)
+  PASS: AC-5 arm 9 (source): rateLimitReached() evaluated before getFeedback
+  PASS: AC-5 arm 1 (source): exercise-runtime.js has zero exercise-feedback references
+  PASS: AC-5 (fixture): feedback.qmd sets window.__btConfig.maxFeedbackPerSession
+  PASS: AC-5 (fixture): __btConfig uses the C22 merge pattern (no keyPageUrl clobber)
+  PASS: issue #179 (source): blendtutor.lua emits maxFeedbackPerSession default 20 (crates parity)
+  PASS: issue #179 (source): __btConfig merge pattern in blendtutor.lua (no keyPageUrl clobber)
+  PASS: issue #179 (source): build_key_page_config_script has no bare __btConfig clobber
+  PASS: buildPrompt emits STUDENT_CODE_BEGIN fence
+  PASS: buildPrompt emits STUDENT_CODE_END fence
+  PASS: buildPrompt includes task
+  PASS: buildPrompt includes student code
+  PASS: buildPrompt includes captured output
+  PASS: buildPrompt includes checks
+  PASS: neutralize strips forged STUDENT_CODE_BEGIN
+  PASS: neutralize replaces with marker
+  PASS: P1: key round-trips through localStorage (entered once, reused)
+  PASS: P1: key stored under provider-scoped localStorage slot
+  PASS: P1: key NOT written to sessionStorage
+  PASS: P1: no zombie fallback — stale sessionStorage key ignored
+  PASS: provider switched to anthropic
+  PASS: provider choice stored in localStorage
+  PASS: provider switched back to fireworks
+  PASS: localhost override honored
+  PASS: non-local override rejected (key exfil prevented)
+  PASS: non-local override falls back to provider base URL
+  PASS: credentialed override rejected
+  PASS: parseModels extracts model ids
+  PASS: modelRoster falls back when list empty
+  PASS: feedbackRequest embeds prompt in messages
+  PASS: feedbackRequest forces feedback tool
+  PASS: toVerdict maps Anthropic tool call to Verdict
+  PASS: fireworksToVerdict maps OpenAI tool call to Verdict
+  PASS: P3: feedbackCount starts at 0
+  PASS: P3: incrementFeedbackCount increments the counter
+  PASS: P3: counter value lives in localStorage.bt_feedback_count
+  PASS: P3: counter NOT written to sessionStorage
+  PASS: P3: no zombie counter — stale sessionStorage count ignored
+  PASS: P2: clearKey removes the provider key
+  PASS: P2: fireworks_api_key removed from localStorage
+  PASS: P2: clearKey removes bt_feedback_count (no permanent rate-lock)
+  PASS: P2: feedbackCount resets to 0 after clearKey
+  PASS: P2: clearKey leaves anthropic_api_key intact
+  PASS: P2: clearKey leaves byok_provider intact
+  PASS: P2: clearKey leaves quarto-reader-mode intact
+  PASS: P2: clearKey leaves quarto-persistent-tabsets-data intact
+  PASS: P2: clearKey never calls localStorage.clear()
+  PASS: P7: readKey returns null when localStorage.getItem throws
+  PASS: C2: empty storage defaults to fireworks
+  PASS: C3: PROVIDERS.anthropic survives (backend not deleted)
+  PASS: C3: anthropic keySlot preserved
+  PASS: C3: anthropic baseUrl preserved
+  PASS: C3: anthropic factory wired
+  PASS: C3: anthropic factory builds the byok-anthropic backend
+  PASS: C3: fireworks factory builds the byok-fireworks backend (pair intact)
+  PASS: AC-4 arm 7: keyPageUrl() falls back to api-key.html when config key absent
+  PASS: AC-4 arm 7: keyPageUrl() returns configured value verbatim
+  PASS: AC-4 arm 6: javascript: scheme rejected
+  PASS: AC-4 arm 6: javascript: rejection is case-insensitive
+  PASS: AC-4 arm 6: javascript: rejection trims whitespace
+  PASS: AC-4 arm 6: data: scheme rejected
+  PASS: AC-4 arm 3: empty keyPageUrl falls back
+  PASS: AC-4 arm 3: undefined keyPageUrl falls back
+  PASS: AC-4 arm 3: window.__btConfig undefined → default (never throws)
+  PASS: AC-5 arm 5 (Node): buildPrompt emits <<<CAPTURED_OUTPUT>>> exactly once
+  PASS: AC-5 arm 6 (Node): buildPrompt emits <<<CHECK_RESULTS>>> exactly once
+  PASS: AC-5 arm 5 (Node): output text appears exactly once
+  PASS: AC-5 arm 6 (Node): buildPrompt includes Task line
+  PASS: AC-5 arm 6 (Node): buildPrompt includes code fences
+  PASS: AC-5 arm 13 (Node): empty output still yields CAPTURED_OUTPUT section (not an error)
+  PASS: AC-5 arm 13 (Node): empty output never injects undefined/null
+  PASS: AC-5 arm 3 (Node): PROVIDERS.fireworks.fallbackModel pinned to -0731
+  PASS: issue #186 (Node): no key → ZERO fetches (inline form shown, no auto-fire)
+  PASS: issue #186 (Node): inline key form mounted inside the feedback container
+  PASS: issue #186 (Node): password input present
+  PASS: issue #186 (Node): Save button present
+  PASS: issue #186 (Node): NO data-byok=no-key anchor
+  PASS: issue #186 (Node): NO anchor rendered (no navigation link)
+  PASS: issue #186 (Node): save stored the key via shared localStorage
+  PASS: issue #186 (Node): save-continuation fires EXACTLY ONE /chat/completions fetch
+  PASS: issue #186 (Node): verdict rendered after save-continuation
+  PASS: issue #186 (Node): no error state after save-continuation
+  PASS: AC-5 arm 1: mounting feedback triggers ZERO fetches (no auto-fire)
+  PASS: AC-5 arm 2: ONE click after key stored → exactly ONE fetch
+  PASS: AC-5 arm 2: fetch POST to ${providerBaseUrl('fireworks')}/chat/completions
+  PASS: AC-5 arm 2: fetch method is POST
+  PASS: AC-5 arm 3: request body model is the pinned -0731 model
+  PASS: AC-5 arm 5: prompt contains <<<CAPTURED_OUTPUT>>> exactly once
+  PASS: AC-5 arm 5: prompt contains this exercise's .bt-output text exactly once
+  PASS: AC-5 arm 5: output text is fenced under the CAPTURED_OUTPUT label
+  PASS: AC-5 arm 6: prompt contains <<<CHECK_RESULTS>>> block
+  PASS: AC-5 arm 6: prompt contains student code fences
+  PASS: AC-5 arm 6: prompt contains Task line + lesson prompt
+  PASS: AC-5 arm 4: NO model-picker rendered — single click goes straight to fetch
+  PASS: AC-5 arm 2: verdict rendered after fetch
+  PASS: AC-5 arm 2: button textContent EXACT 'Get feedback'
+  PASS: AC-5 arm 13: button enabled (not disabled-gated) before Check
+  PASS: AC-5 arm 7: two exercises → two fetches (one per click)
+  PASS: AC-5 arm 7: exercise A's prompt has A's output, NOT B's
+  PASS: AC-5 arm 7: exercise B's prompt has B's output, NOT A's
+  PASS: AC-5 arm 8: XSS payload renders as literal text
+  PASS: AC-5 arm 8: window.__xss stays undefined — payload NOT executed
+  PASS: AC-5 arm 9: counter at cap → ZERO fetches
+  PASS: AC-5 arm 9: limit-reached message rendered
+  PASS: AC-5 arm 10: no key → ZERO fetches (inline form shown, no auto-fire)
+  PASS: AC-5 arm 10: inline key form rendered in feedback container
+  PASS: AC-5 arm 10: NO no-key link rendered
+  PASS: AC-5 arm 10: key input present for save
+  PASS: AC-5 arm 10: save → EXACTLY ONE /chat/completions fetch (save-continuation)
+  PASS: AC-5 arm 10: verdict rendered after save-continuation
+  PASS: AC-5 arm 11: error state rendered via textContent
+  PASS: AC-5 arm 11: session counter incremented on failed fetch
+  PASS: AC-5 arm 12: two rapid clicks → exactly ONE fetch (_feedbackRunning guard)
+  PASS: AC-5 arm 13: empty .bt-output → fetch still fires (explicit click, no gate)
+  PASS: AC-5 arm 13: prompt still has CAPTURED_OUTPUT section
+  PASS: AC-5 arm 13: empty output does not inject undefined/null
+  PASS: AC-5 arm 14: feedback button exists after mount
+  PASS: AC-5 arm 14: feedback button appended INTO entry.controls (toolbar)
+  PASS: AC-5 arm 14: feedback button is FIRST in the toolbar (former Run slot, before Check/Show solution)
+  PASS: AC-5 arm 14: toolbar order is Get feedback · Check · Show solution
+  PASS: AC-5 arm 14: no .bt-feedback-wrapper created when controls present
+  PASS: AC-5 arm 14: feedback container is a direct child of the exercise element
+  PASS: Node.js behavioral tests passed (all pure-function assertions)
+  PASS: keyPageUrl standalone node:test suite passed (8 tests, incl. typeof-window-absent branch)
+  PASS: feedback.qmd has 2 exercises (>=2 for key-reuse test)
+  PASS: feedback.qmd imports exercise-feedback.js
+  PASS: feedback.qmd imports exercise-runtime.js (AC-4 dependency)
+  PASS: feedback.qmd calls mountFeedback/mountAllFeedback
+=== Results: 64 passed, 0 failed ===
+
+=== test_quarto_key_page.py ===
+  PASS: key-page.js exists
+  PASS: exercise-feedback.js exists (import contract source)
+  PASS: P1: key-page.js imports from './exercise-feedback.js'
+  PASS: P1: import contract includes readKey
+  PASS: P1: import contract includes storeKey
+  PASS: P1: import contract includes clearKey
+  PASS: P1: import contract includes providerBaseUrl
+  PASS: P1: import contract includes PROVIDERS
+  PASS: P1: no literal 'fireworks_api_key' anywhere in source
+  PASS: P1: no literal 'anthropic_api_key' anywhere in source
+  PASS: P1: no literal 'byok_provider' anywhere in source
+  PASS: P1: no literal 'bt_feedback_count' anywhere in source
+  PASS: P1: no literal 'api.fireworks.ai' anywhere in source
+  PASS: P1: no literal 'sessionStorage' anywhere in source
+  PASS: P3: classifyValidation present (discriminated result)
+  PASS: P3: validation does NOT reuse listModels (401 must not collapse into []/network)
+  PASS: P5: zero console. calls (key never logged)
+  PASS: P5: zero innerHTML usage (textContent-only rendering)
+  PASS: P5: rendering is textContent-based
+  PASS: P6: password input has type=password
+  PASS: P6: password input has autocomplete=off
+  PASS: P15: buildValidationUrl is an exported pure function
+  PASS: P15: buildValidationUrl body contains no fetch(
+  PASS: P15: buildValidationUrl body contains no localStorage
+  PASS: P15: buildValidationUrl body contains no document.
+  PASS: P15: classifyValidation is an exported pure function
+  PASS: P15: classifyValidation body contains no fetch(
+  PASS: P15: classifyValidation body contains no localStorage
+  PASS: P15: classifyValidation body contains no document.
+  PASS: P15: statusMessage is an exported pure function
+  PASS: P15: statusMessage body contains no fetch(
+  PASS: P15: statusMessage body contains no localStorage
+  PASS: P15: statusMessage body contains no document.
+  PASS: P16: docstring header names WHAT/WHERE/NOT
+  PASS: P16: at most 5 public exports (found 4)
+  PASS: P16: public export buildValidationUrl
+  PASS: P16: public export classifyValidation
+  PASS: P16: public export statusMessage
+  PASS: P16: public export mountKeyPage
+  PASS: P3: 2xx -> {ok:true}
+  PASS: P3: any 2xx is ok
+  PASS: P3: 401 -> invalid-key
+  PASS: P3: 403 -> invalid-key
+  PASS: P3: other non-2xx -> network
+  PASS: P3: thrown fetch -> network
+  PASS: P4: statusMessage(saved) has friendly copy
+  PASS: P4: statusMessage(invalid-key) has friendly copy
+  PASS: P4: statusMessage(network) has friendly copy
+  PASS: P4: statusMessage(empty) has friendly copy
+  PASS: P4: statusMessage(cleared) has friendly copy
+  PASS: P2: validation URL honors localhost ?provider= override
+  PASS: P2: default validation URL ends with /models
+  PASS: P10: no-key mount renders a form
+  PASS: P10: no-key mount renders a password input
+  PASS: P6: input type is password
+  PASS: P6: input autocomplete is off
+  PASS: P10: no-key mount renders the Save button
+  PASS: P10: no-key mount has no Clear button
+  PASS: P13: submit handler calls preventDefault
+  PASS: P7: Save stores key via imported storeKey (AC-1 signature, key first)
+  PASS: P7: readKey round-trips the saved key
+  PASS: P14: input value reset to empty AFTER storeKey
+  PASS: P11: one save issues exactly one fetch
+  PASS: P2: validation fetch targets the host-gated models URL
+  PASS: key rides Authorization header, never the body
+  PASS: P7: save reports saved status on 2xx
+  PASS: P5: key never echoed into any DOM textContent
+  PASS: P5: at least one non-empty textContent after save
+  PASS: P9: empty save does NOT clear the existing key
+  PASS: P9: empty save issues no fetch
+  PASS: P9: empty save reports the empty status
+  PASS: P10: key-set mount shows 'key is set' status
+  PASS: P10: key-set mount shows the Clear button
+  PASS: P10: key-set mount renders NO input — the key is never pre-filled
+  PASS: P8: Clear removes the provider key slot
+  PASS: P8: Clear removes bt_feedback_count (no rate-lock)
+  PASS: P8: readKey returns null after Clear
+  PASS: P10: after Clear, UI returns to the empty input form
+  PASS: P10: post-Clear input starts empty
+  PASS: after Clear, the Clear button is gone
+  PASS: P4: Clear reports the cleared status
+  PASS: P11: double mount does not re-render (same form instance)
+  PASS: P11: double mount does not duplicate the submit listener
+  PASS: P11: double mount -> one save -> exactly one fetch
+  PASS: P11: save still works after double mount
+  PASS: P12: mountKeyPage(null/undefined) no-op without crash
+  PASS: P3: 401 save reports invalid-key (not collapsed into network)
+  PASS: 401 save issued one fetch
+  PASS: advisory: key stored even when validation rejects
+  PASS: P3: thrown fetch reports network
+  PASS: network save issued one fetch
+  PASS: storage-unavailable: ZERO fetches issued when storeKey throws
+  PASS: storage-unavailable: friendly storage status rendered
+  PASS: storage-unavailable: key NOT stored
+  PASS: storage-unavailable: input keeps its value for retry (no silent wipe)
+  PASS: P17: empty save does NOT fire onSaved
+  PASS: P17: empty save still reports the empty status
+  PASS: P17: storage-unavailable save does NOT fire onSaved
+  PASS: P17: storage-unavailable save issues no fetch (onSaved would continue a doomed flow)
+  PASS: P17: successful save fires onSaved EXACTLY once
+  PASS: P17: key stored alongside onSaved (onSaved runs after storeKey)
+  PASS: P17: successful save still issues one validation fetch
+  PASS: Node.js behavioral tests passed (all key-page assertions)
+=== Results: 40 passed, 0 failed ===

--- a/rodney-probes/feedback-probe.js
+++ b/rodney-probes/feedback-probe.js
@@ -394,6 +394,14 @@ function probeP11NoKeyLink() {
 // P5 — cross-page persistence (save via key-page UI → real navigation)
 // ---------------------------------------------------------------------------
 function probeP5CrossPage() {
+  // Precondition: EMPTY storage. P11 ran first in the same rodney session and
+  // stored its inline key (fw_inline_probe_789) — with a key present,
+  // mountKeyPage renders the key-set state (status + Clear) and the key-input
+  // form never appears, which would make the guard below vacuous-fail. Clear
+  // through the page (same origin) so the empty-storage → key-page UI → save
+  // → cross-page flow is deterministic. This is a precondition reset, NOT the
+  // save step — the key must still be entered through the real key-page UI.
+  rodneyJs("(() => { localStorage.clear(); return 'cleared'; })()");
   // Page 1 — save the key through the REAL key-page UI (password input →
   // Save button). NOT eval localStorage.setItem (sneaky-pass).
   navigateTo(KEY_PAGE_URL);

--- a/rodney-probes/feedback-probe.js
+++ b/rodney-probes/feedback-probe.js
@@ -17,9 +17,12 @@
  *              in the stub response renders as literal text (window.__xss
  *              stays undefined). No fetch-spy substitution for this clause:
  *              the verdict must come from the REAL stub round-trip.
- *          P11 no-key link end-to-end — with empty localStorage, the exercise
- *              page renders [data-byok="no-key"] (target=_blank, rel=noopener,
- *              href = keyPageUrl) AND ZERO /chat/completions fetches observed.
+ *          P11 inline key form end-to-end — with empty localStorage, the
+ *              exercise page mounts the key-page form INLINE inside the
+ *              feedback container ([data-byok="key-page-form"], NO
+ *              navigation link); saving through the real form stores the key
+ *              and the save-continuation (issue #186) fires the feedback
+ *              fetch — verdict renders through the stub.
  *
  * P3: NO synthetic-DOM fixture generation — every navigation targets a file
  * under the served demo-book/_output/ root (AC-7 render output; the old
@@ -300,7 +303,8 @@ function waitForFeedbackUi() {
 }
 
 // ---------------------------------------------------------------------------
-// P11 — no-key link end-to-end (empty localStorage → link, ZERO fetches)
+// P11 — inline key form end-to-end (empty localStorage → inline form, save →
+// key stored → feedback fetch fires through the stub → verdict)
 // ---------------------------------------------------------------------------
 function probeP11NoKeyLink() {
   // Empty localStorage precondition: clear through the page (fresh state;
@@ -320,37 +324,70 @@ function probeP11NoKeyLink() {
   rodney(["click", ".bt-exercise:first-of-type .bt-feedback-btn"]);
   sleep(1);
 
-  const noKeyVisible = waitForExpr(
-    "document.querySelector('[data-byok=\"no-key\"]') !== null",
+  const formVisible = waitForExpr(
+    "document.querySelector('[data-byok=\"key-page-form\"]') !== null",
     10,
   );
-  if (noKeyVisible === -1) {
-    record("P11 no-key: link rendered", false, "[data-byok=no-key] not found after click");
+  if (formVisible === -1) {
+    record("P11 no-key: inline key form rendered", false, "[data-byok=key-page-form] not found after click");
     return;
   }
-  record("P11 no-key: link rendered", true, "no-key link appears on click with empty storage");
+  record("P11 no-key: inline key form rendered", true, "inline key form appears on click with empty storage");
 
   assertExpr(
-    "P11 no-key: target=_blank",
-    "document.querySelector('[data-byok=\"no-key\"] a').getAttribute('target') === '_blank'",
+    "P11 no-key: NO navigation link (no data-byok=no-key)",
+    "document.querySelector('[data-byok=\"no-key\"]') === null",
   );
   assertExpr(
-    "P11 no-key: rel=noopener",
-    "document.querySelector('[data-byok=\"no-key\"] a').getAttribute('rel') === 'noopener'",
+    "P11 no-key: NO anchor rendered in the form or feedback area",
+    "document.querySelector('[data-byok=\"key-page-form\"] a') === null && document.querySelector('[data-byok=\"feedback\"] a') === null",
   );
-  const href = rodneyJs("document.querySelector('[data-byok=\"no-key\"] a').getAttribute('href')");
-  const hrefOk = href === "api-key.html";
-  record("P11 no-key: href = keyPageUrl (api-key.html)", hrefOk, `href=${href}`);
 
-  const log = fetchLog();
-  const completions = log.filter((e) => e.url.includes("/chat/completions"));
+  const log0 = fetchLog();
+  const completions0 = log0.filter((e) => e.url.includes("/chat/completions"));
   record(
-    "P11 no-key: ZERO /chat/completions fetches",
-    completions.length === 0,
-    `fetches observed: ${JSON.stringify(log)}`,
+    "P11 no-key: ZERO /chat/completions fetches before save",
+    completions0.length === 0,
+    `fetches observed: ${JSON.stringify(log0)}`,
   );
 
-  screenshot("fb-01-no-key-link", "exercise page with empty storage: no-key link to key page");
+  // Save through the REAL inline form UI: type the key, click Save. The
+  // save-continuation (issue #186) then re-runs the submit flow — the key is
+  // now stored, so the feedback fetch fires and the verdict renders.
+  rodney(["input", '[data-byok="key-input"]', "fw_inline_probe_789"]);
+  rodney(["click", '[data-byok="save"]']);
+
+  const keyStored = waitForExpr(
+    "localStorage.getItem('fireworks_api_key') === 'fw_inline_probe_789'",
+    15,
+  );
+  if (keyStored === -1) {
+    record("P11 save: key stored via inline form", false, "fireworks_api_key not stored after save click");
+    return;
+  }
+  record("P11 save: key stored via inline form", true, `key stored (${keyStored}ms)`);
+
+  const fetchFired = waitForExpr(
+    "JSON.parse(JSON.stringify(window.__fetchLog || [])).filter((e) => String(e.url).includes('/chat/completions')).length >= 1",
+    20,
+  );
+  record(
+    "P11 save-continuation: feedback fetch fires through stub",
+    fetchFired !== -1,
+    fetchFired !== -1 ? `new /chat/completions observed (${fetchFired}ms)` : "no /chat/completions after save",
+  );
+
+  const verdictElapsed = waitForExpr(
+    "document.querySelector('[data-byok=\"verdict\"]') !== null",
+    20,
+  );
+  record(
+    "P11 save-continuation: verdict rendered",
+    verdictElapsed !== -1,
+    verdictElapsed !== -1 ? `verdict rendered (${verdictElapsed}ms)` : "no [data-byok=verdict] after save",
+  );
+
+  screenshot("fb-01-no-key-inline-form", "exercise page with empty storage: inline key form + save-continuation verdict");
 }
 
 // ---------------------------------------------------------------------------
@@ -400,9 +437,10 @@ function probeP5CrossPage() {
   );
 
   // Proceed past the no-key state: with the key present, clicking the
-  // feedback button must NOT render the no-key link (it goes to pending →
-  // verdict through the stub). The rate-limit config comes from the REAL
-  // rendered page: blendtutor.lua build_key_page_config_script now emits
+  // feedback button must NOT render the no-key state (no inline key form —
+  // it goes straight to pending → verdict through the stub). The rate-limit
+  // config comes from the REAL rendered page: blendtutor.lua
+  // build_key_page_config_script now emits
   // window.__btConfig.maxFeedbackPerSession = window.__btConfig.maxFeedbackPerSession ?? 20
   // (issue #179, crates parity) alongside keyPageUrl — so NO manual injection
   // here. A regression to keyPageUrl-only emission would compute

--- a/scripts/tests/test_quarto_feedback.py
+++ b/scripts/tests/test_quarto_feedback.py
@@ -896,34 +896,6 @@ globalThis.window.__btConfig = undefined;
 assert(mod.keyPageUrl() === "api-key.html", "AC-4 arm 3: window.__btConfig undefined → default (never throws)");
 globalThis.window.__btConfig = savedBtConfig;
 
-// --- issue #186: no-key click mounts the INLINE key form (no link) ---
-// The no-key guard now mounts the key-page form INTO the feedback container
-// (key-page.js mountKeyPage) with an onSaved save-continuation. ZERO fetches
-// before the key is saved; saving stores the key and re-runs the submit flow
-// — exactly one /chat/completions fetch + verdict.
-localStorageMap.clear();
-globalThis.window.__btConfig = { maxFeedbackPerSession: 100 };
-installFetchSpy();
-const eNK = makeEntry({ id: "exNK", output: "" });
-mountAndClick(eNK);
-await flush();
-assert(fetchCalls.length === 0, "issue #186 (Node): no key → ZERO fetches (inline form shown, no auto-fire)");
-const nkForm = eNK.feedbackContainer.querySelector('[data-byok="key-page-form"]');
-assert(nkForm !== null, "issue #186 (Node): inline key form mounted inside the feedback container");
-assert(eNK.feedbackContainer.querySelector('[data-byok="key-input"]') !== null, "issue #186 (Node): password input present");
-assert(eNK.feedbackContainer.querySelector('[data-byok="save"]') !== null, "issue #186 (Node): Save button present");
-assert(eNK.feedbackContainer.querySelector('[data-byok="no-key"]') === null, "issue #186 (Node): NO data-byok=no-key anchor");
-assert(eNK.feedbackContainer.querySelector("a") === null, "issue #186 (Node): NO anchor rendered (no navigation link)");
-const nkInput = eNK.feedbackContainer.querySelector('[data-byok="key-input"]');
-nkInput.value = "k-inline-node";
-await nkForm._handlers.submit[0]({ preventDefault: () => {} });
-await flush();
-assert(mod.readKey("fireworks") === "k-inline-node", "issue #186 (Node): save stored the key via shared localStorage");
-const nkCompletions = fetchCalls.filter((c) => String(c.url).includes("/chat/completions"));
-assert(nkCompletions.length === 1, "issue #186 (Node): save-continuation fires EXACTLY ONE /chat/completions fetch");
-assert(eNK.feedbackContainer.querySelector('[data-byok="verdict"]') !== null, "issue #186 (Node): verdict rendered after save-continuation");
-assert(eNK.feedbackContainer.querySelector('[data-byok="error"]') === null, "issue #186 (Node): no error state after save-continuation");
-
 // ===========================================================================
 // AC-5 (issue #166): check-output wiring + pinned model + picker collapse
 // ===========================================================================
@@ -994,6 +966,34 @@ function promptBodyAt(i) {
   if (!call || call.url.indexOf("/chat/completions") === -1) return null;
   return JSON.parse(call.opts.body);
 }
+
+// --- issue #186: no-key click mounts the INLINE key form (no link) ---
+// The no-key guard now mounts the key-page form INTO the feedback container
+// (key-page.js mountKeyPage) with an onSaved save-continuation. ZERO fetches
+// before the key is saved; saving stores the key and re-runs the submit flow
+// — exactly one /chat/completions fetch + verdict.
+localStorageMap.clear();
+globalThis.window.__btConfig = { maxFeedbackPerSession: 100 };
+installFetchSpy();
+const eNK = makeEntry({ id: "exNK", output: "" });
+mountAndClick(eNK);
+await flush();
+assert(fetchCalls.length === 0, "issue #186 (Node): no key → ZERO fetches (inline form shown, no auto-fire)");
+const nkForm = eNK.feedbackContainer.querySelector('[data-byok="key-page-form"]');
+assert(nkForm !== null, "issue #186 (Node): inline key form mounted inside the feedback container");
+assert(eNK.feedbackContainer.querySelector('[data-byok="key-input"]') !== null, "issue #186 (Node): password input present");
+assert(eNK.feedbackContainer.querySelector('[data-byok="save"]') !== null, "issue #186 (Node): Save button present");
+assert(eNK.feedbackContainer.querySelector('[data-byok="no-key"]') === null, "issue #186 (Node): NO data-byok=no-key anchor");
+assert(eNK.feedbackContainer.querySelector("a") === null, "issue #186 (Node): NO anchor rendered (no navigation link)");
+const nkInput = eNK.feedbackContainer.querySelector('[data-byok="key-input"]');
+nkInput.value = "k-inline-node";
+await nkForm._handlers.submit[0]({ preventDefault: () => {} });
+await flush();
+assert(mod.readKey("fireworks") === "k-inline-node", "issue #186 (Node): save stored the key via shared localStorage");
+const nkCompletions = fetchCalls.filter((c) => String(c.url).includes("/chat/completions"));
+assert(nkCompletions.length === 1, "issue #186 (Node): save-continuation fires EXACTLY ONE /chat/completions fetch");
+assert(eNK.feedbackContainer.querySelector('[data-byok="verdict"]') !== null, "issue #186 (Node): verdict rendered after save-continuation");
+assert(eNK.feedbackContainer.querySelector('[data-byok="error"]') === null, "issue #186 (Node): no error state after save-continuation");
 
 // Arm 1: mounting feedback triggers ZERO fetches (no auto-fire).
 localStorageMap.clear();

--- a/scripts/tests/test_quarto_feedback.py
+++ b/scripts/tests/test_quarto_feedback.py
@@ -3,8 +3,8 @@
 
 Verifies the 9-clause predicate from AC-7, the issue #162 localStorage
 migration (P1-P7), the issue #167 Fireworks-only learner UX (C1-C6), the
-issue #165 no-key link (AC-4 arms 1-7), and the issue #166 check-output
-wiring (AC-5 arms 1-13):
+issue #165 no-key link (AC-4 arms 1-7), the issue #166 check-output
+wiring (AC-5 arms 1-13), and the issue #186 inline key form (no-key state):
   1. key entered once — shared localStorage key slot (provider-scoped, not
      exercise-scoped); entered once, reused across exercises.
   2. per-exercise scoping — each exercise has its own feedback container; no
@@ -16,17 +16,18 @@ wiring (AC-5 arms 1-13):
       removes the provider key AND bt_feedback_count; zero sessionStorage tokens
       remain (P4); readKey degrades to null when localStorage is unavailable (P7).
    4. provider switch — PROVIDERS map + storeProvider/readProvider; Fireworks-only
-      learner UX (issue #167): renderKeyPrompt renders NO provider <select>
+      learner UX (issue #167): the no-key state renders NO provider <select>
       (C1 — absent, not hidden), the anthropic backend + ?provider= seam survive
       (C3/C4), both disclosures state localStorage wording (C5), and submit
       stores under fireworks with no dangling provSelect ref (C6).
-   11. no-key link (issue #165) — renderKeyPrompt emits [data-byok="no-key"]
-      with exactly one DOM-built anchor (copy "Enter your API key first") whose
-      href is read LAZILY from window.__btConfig.keyPageUrl at render time
-      (arm 2); defaults to api-key.html (arm 3); javascript:/data: schemes
-      rejected (arm 6); keyPageUrl() exported pure fn (arm 7); inline form
-      tokens (provider-key input, Save key & get feedback, innerHTML) absent
-      (arm 1); no-key guard first in submit flow (arm 4).
+   11. inline key form (issue #186) — the no-key state mounts the key-page
+      form (key-page.js mountKeyPage) INLINE into the feedback container: the
+      mountKeyPage import + inline call with an onSaved save-continuation live
+      FIRST in the submit flow; renderKeyPrompt, the [data-byok="no-key"]
+      anchor, its href/target=_blank link, and the inline-form-negative tokens
+      of AC-4 are GONE; keyPageUrl() stays exported (api-key chapter, arm 7);
+      save stores the key then re-runs the submit flow (exactly one feedback
+      fetch + verdict).
    5. ?provider= override — providerBaseUrl honors a localhost-only override and
       rejects non-local / credentialed overrides.
    6. llm_evaluation_prompt ABSENT — never in the JS source or the qmd fixture.
@@ -44,8 +45,9 @@ wiring (AC-5 arms 1-13):
       fetch-spy suite drives the REAL handleSubmitForExercise through
       mountFeedback clicks and asserts arms 2,4,5,7,8,9,10,11,12,13
       (button sole trigger, no picker, per-exercise output scoping, XSS
-      textContent-only verdict, rate-limit/no-key refusal, error path,
-      concurrent guard, empty-output tolerance).
+      textContent-only verdict, rate-limit refusal, inline no-key form with
+      save-continuation, error path, concurrent guard, empty-output
+      tolerance).
    12. rate-limit default emission (issue #179) — blendtutor.lua's
       build_key_page_config_script emits window.__btConfig.maxFeedbackPerSession
       = window.__btConfig.maxFeedbackPerSession ?? 20 via the C22 merge pattern
@@ -307,63 +309,31 @@ def check_fireworks_only_ux(src: str) -> None:
         ko("C5 (source): one or both disclosures missing localStorage wording")
 
 
-def check_no_key_link(src: str) -> None:
-    """AC-4 (source): the no-key state is a link to the key page, not an
-    inline key-entry form.
+def check_no_key_inline_form(src: str) -> None:
+    """Issue #186 (source): the no-key state mounts the key-page form INLINE
+    in the feedback container with a save-continuation — no navigation link.
 
-    arm 1 (source): renderKeyPrompt emits the no-key marker and the inline
-    form tokens (provider-key input, "Save key & get feedback" button,
-    innerHTML interpolation) are GONE from the asset.
-    arm 2 (source): `const href = keyPageUrl()` lives INSIDE the render body —
-    a module-top cache would freeze the value and fail the eval-injection seam.
+    arm 1 (source): the inline mount — `import { mountKeyPage } from
+    "./key-page.js"` — is present, and handleSubmitForExercise's no-key guard
+    calls mountKeyPage(container, { onSaved: ... }) which re-invokes the
+    submit handler once the key is stored.
+    arm 2 (source): the AC-4 link machinery is GONE — renderKeyPrompt, the
+    [data-byok="no-key"] marker, the href/target=_blank anchor.
+    arm 3 (source): keyPageUrl() stays exported (the api-key chapter still
+    links to it; key-page-url.test.js pins the contract).
     arm 4 (source): the no-key guard stays FIRST in the submit flow.
-    arm 7 (source): keyPageUrl() is exported (Node-testable).
     """
     code = _strip_comments(src)
 
-    # The no-key region: keyPageUrl() definition + renderKeyPrompt body.
-    region_start = src.find("export function keyPageUrl")
-    region_end = src.find("function renderVerdict")
-    if region_start != -1 and region_end != -1 and region_end > region_start:
-        region = src[region_start:region_end]
-        if "keyPageUrl" in region and "__btConfig" in region:
-            ok("AC-4 (source): no-key region reads window.__btConfig via keyPageUrl()")
-        else:
-            ko("AC-4 (source): no-key region missing __btConfig/keyPageUrl read")
-        if "api-key.html" in region:
-            ok("AC-4 (source): default key-page fallback api-key.html present")
-        else:
-            ko("AC-4 (source): default api-key.html fallback missing")
-        if "no-key" in region:
-            ok('AC-4 (source): no-key marker (data-byok="no-key") present')
-        else:
-            ko("AC-4 (source): no-key marker missing")
+    # arm 1 (source): the inline mount import + save-continuation call.
+    import_line = next(
+        (l for l in src.split("\n") if "mountKeyPage" in l and '"./key-page.js"' in l),
+        "",
+    )
+    if import_line and "import" in import_line:
+        ok('issue #186 (source): `import { mountKeyPage } from "./key-page.js"` present')
     else:
-        ko("AC-4 (source): keyPageUrl() export + renderKeyPrompt region not found")
-
-    if "const href = keyPageUrl()" in code:
-        ok("AC-4 (source): lazy read — const href = keyPageUrl() inside render body")
-    else:
-        ko("AC-4 (source): href must be read lazily inside render body (const href = keyPageUrl())")
-
-    if "export function keyPageUrl" in code:
-        ok("AC-4 (source): keyPageUrl() exported (Node-testable pure fn)")
-    else:
-        ko("AC-4 (source): keyPageUrl() not exported")
-
-    # Inline-form tokens must be GONE from the whole asset (arm 1 negative).
-    if 'input[name="provider-key"]' not in code:
-        ok('AC-4 (source): input[name="provider-key"] ABSENT (inline form gone)')
-    else:
-        ko('AC-4 (source): input[name="provider-key"] still present')
-    if "Save key & get feedback" not in code:
-        ok('AC-4 (source): "Save key & get feedback" button ABSENT')
-    else:
-        ko('AC-4 (source): "Save key & get feedback" button still present')
-    if "innerHTML" not in code:
-        ok("AC-4 (source): innerHTML ABSENT (anchor DOM-built, no URL interpolation)")
-    else:
-        ko("AC-4 (source): innerHTML present — anchor must be DOM-built")
+        ko('issue #186 (source): mountKeyPage import from "./key-page.js" missing')
 
     # arm 4 (source): the no-key guard stays FIRST in the submit flow.
     submit_start = src.find("async function handleSubmitForExercise")
@@ -372,14 +342,52 @@ def check_no_key_link(src: str) -> None:
         submit_region = src[submit_start:submit_end]
         if (
             "if (!apiKey)" in submit_region
-            and "renderKeyPrompt(container);" in submit_region
+            and "mountKeyPage(container" in submit_region
+            and "onSaved:" in submit_region
+            and "handleSubmitForExercise(entry)" in submit_region
             and "return;" in submit_region
         ):
-            ok("AC-4 (source): no-key guard `if (!apiKey) { renderKeyPrompt(container); return; }` first in submit flow")
+            ok("issue #186 (source): no-key guard mounts the inline form with save-continuation (`if (!apiKey) { mountKeyPage(container, { onSaved: () => handleSubmitForExercise(entry) }); return; }`) first in submit flow")
         else:
-            ko("AC-4 (source): no-key guard missing or out of place in handleSubmitForExercise")
+            ko("issue #186 (source): no-key guard must mount the inline form with onSaved save-continuation in handleSubmitForExercise")
     else:
-        ko("AC-4 (source): handleSubmitForExercise region not found")
+        ko("issue #186 (source): handleSubmitForExercise region not found")
+
+    # The keyPageUrl region: kept for the api-key chapter, but the link
+    # rendering that consumed it is gone.
+    region_start = src.find("export function keyPageUrl")
+    region_end = src.find("function renderVerdict")
+    if region_start != -1 and region_end != -1 and region_end > region_start:
+        region = src[region_start:region_end]
+        if "keyPageUrl" in region and "__btConfig" in region:
+            ok("issue #186 (source): keyPageUrl region keeps the window.__btConfig read")
+        else:
+            ko("issue #186 (source): keyPageUrl region missing __btConfig read")
+        if "api-key.html" in region:
+            ok("issue #186 (source): default api-key.html fallback present")
+        else:
+            ko("issue #186 (source): default api-key.html fallback missing")
+    else:
+        ko("issue #186 (source): keyPageUrl() export region not found")
+
+    if "export function keyPageUrl" in code:
+        ok("issue #186 (source): keyPageUrl() exported (api-key chapter + key-page-url.test.js)")
+    else:
+        ko("issue #186 (source): keyPageUrl() not exported")
+
+    # arm 2 (source): the link machinery is GONE (negatives).
+    if "renderKeyPrompt" not in code:
+        ok('issue #186 (source): renderKeyPrompt GONE (no link renderer)')
+    else:
+        ko("issue #186 (source): renderKeyPrompt still present")
+    if 'data-byok="no-key"' not in code:
+        ok('issue #186 (source): [data-byok="no-key"] marker ABSENT (no link wrapper)')
+    else:
+        ko('issue #186 (source): data-byok="no-key" marker still present')
+    if "_blank" not in code:
+        ok("issue #186 (source): target=_blank ABSENT (no new-tab navigation)")
+    else:
+        ko("issue #186 (source): target=_blank still present — the link must be gone")
 
 
 def check_concurrent_guard(src: str) -> None:
@@ -888,34 +896,33 @@ globalThis.window.__btConfig = undefined;
 assert(mod.keyPageUrl() === "api-key.html", "AC-4 arm 3: window.__btConfig undefined → default (never throws)");
 globalThis.window.__btConfig = savedBtConfig;
 
-// --- AC-4 arm 1+5: renderKeyPrompt renders the no-key link (inline form GONE) ---
-globalThis.window.__btConfig.keyPageUrl = "/keys.html";
-const nkContainer = mockElement("div");
-mod.renderKeyPrompt(nkContainer);
-const nkWrapper = nkContainer.children[0];
-assert(nkWrapper.dataset.byok === "no-key", "AC-4 arm 1: container carries data-byok=no-key");
-assert(nkContainer.querySelectorAll("a").length === 1, "AC-4 arm 1: exactly one <a> in no-key state");
-const nkLink = nkContainer.querySelector("a");
-assert(nkLink.textContent === "Enter your API key first", "AC-4 arm 1: link copy exact (AC literal)");
-assert(nkLink.href === "/keys.html", "AC-4 arm 1: link href resolved from keyPageUrl()");
-assert(nkLink.target === "_blank", "AC-4 arm 5: link opens in new tab (preserves learner's code)");
-assert(nkLink.rel.includes("noopener"), "AC-4 arm 5: rel includes noopener");
-assert(nkContainer.querySelector('input[name="provider-key"]') === null, "AC-4 arm 1: NO key input in rendered output");
-assert(nkContainer.querySelector("form") === null, "AC-4 arm 1: NO form in rendered output");
-assert(nkContainer.querySelector('button[type="submit"]') === null, "AC-4 arm 1: NO save/submit button in rendered output");
-assert(nkContainer.querySelector('select[data-byok="provider"]') === null, "C1: NO provider <select> (absent, not hidden)");
-assert(nkContainer.querySelectorAll("option").length === 0, "C1: ZERO <option> elements");
-assert(!JSON.stringify(nkContainer).includes("fake-key-123"), "AC-4 arm 5: no key value anywhere in rendered DOM");
-
-// --- AC-4 arm 2: lazy read at render time (post-import config honored) ---
-// keyPageUrl was set AFTER module import; an eager module-init cache would
-// have frozen the value read at import (when __btConfig was {} → default)
-// and would FAIL this assertion.
-globalThis.window.__btConfig.keyPageUrl = "/custom/keys.html";
-const lazyContainer = mockElement("div");
-mod.renderKeyPrompt(lazyContainer);
-const lazyLink = lazyContainer.querySelector("a");
-assert(lazyLink.href === "/custom/keys.html", "AC-4 arm 2: lazy read at render time — post-import eval-set config honored");
+// --- issue #186: no-key click mounts the INLINE key form (no link) ---
+// The no-key guard now mounts the key-page form INTO the feedback container
+// (key-page.js mountKeyPage) with an onSaved save-continuation. ZERO fetches
+// before the key is saved; saving stores the key and re-runs the submit flow
+// — exactly one /chat/completions fetch + verdict.
+localStorageMap.clear();
+globalThis.window.__btConfig = { maxFeedbackPerSession: 100 };
+installFetchSpy();
+const eNK = makeEntry({ id: "exNK", output: "" });
+mountAndClick(eNK);
+await flush();
+assert(fetchCalls.length === 0, "issue #186 (Node): no key → ZERO fetches (inline form shown, no auto-fire)");
+const nkForm = eNK.feedbackContainer.querySelector('[data-byok="key-page-form"]');
+assert(nkForm !== null, "issue #186 (Node): inline key form mounted inside the feedback container");
+assert(eNK.feedbackContainer.querySelector('[data-byok="key-input"]') !== null, "issue #186 (Node): password input present");
+assert(eNK.feedbackContainer.querySelector('[data-byok="save"]') !== null, "issue #186 (Node): Save button present");
+assert(eNK.feedbackContainer.querySelector('[data-byok="no-key"]') === null, "issue #186 (Node): NO data-byok=no-key anchor");
+assert(eNK.feedbackContainer.querySelector("a") === null, "issue #186 (Node): NO anchor rendered (no navigation link)");
+const nkInput = eNK.feedbackContainer.querySelector('[data-byok="key-input"]');
+nkInput.value = "k-inline-node";
+await nkForm._handlers.submit[0]({ preventDefault: () => {} });
+await flush();
+assert(mod.readKey("fireworks") === "k-inline-node", "issue #186 (Node): save stored the key via shared localStorage");
+const nkCompletions = fetchCalls.filter((c) => String(c.url).includes("/chat/completions"));
+assert(nkCompletions.length === 1, "issue #186 (Node): save-continuation fires EXACTLY ONE /chat/completions fetch");
+assert(eNK.feedbackContainer.querySelector('[data-byok="verdict"]') !== null, "issue #186 (Node): verdict rendered after save-continuation");
+assert(eNK.feedbackContainer.querySelector('[data-byok="error"]') === null, "issue #186 (Node): no error state after save-continuation");
 
 // ===========================================================================
 // AC-5 (issue #166): check-output wiring + pinned model + picker collapse
@@ -1072,15 +1079,26 @@ await flush();
 assert(fetchCalls.length === 0, "AC-5 arm 9: counter at cap → ZERO fetches");
 assert(eR.feedbackContainer.querySelector('[data-byok="limit-reached"]') !== null, "AC-5 arm 9: limit-reached message rendered");
 
-// Arm 10: no key → no-key link rendered, ZERO fetches.
+// Arm 10: no key → inline key form rendered, ZERO fetches until save; save
+// → exactly one /chat/completions fetch + verdict (issue #186 continuation).
 localStorageMap.clear();
 globalThis.window.__btConfig = { maxFeedbackPerSession: 3 };
 installFetchSpy();
 const eN = makeEntry({ id: "exN", output: "" });
 mountAndClick(eN);
 await flush();
-assert(fetchCalls.length === 0, "AC-5 arm 10: no key → ZERO fetches");
-assert(eN.feedbackContainer.querySelector('[data-byok="no-key"]') !== null, "AC-5 arm 10: no-key link rendered");
+assert(fetchCalls.length === 0, "AC-5 arm 10: no key → ZERO fetches (inline form shown, no auto-fire)");
+assert(eN.feedbackContainer.querySelector('[data-byok="key-page-form"]') !== null, "AC-5 arm 10: inline key form rendered in feedback container");
+assert(eN.feedbackContainer.querySelector('[data-byok="no-key"]') === null, "AC-5 arm 10: NO no-key link rendered");
+const nkInput10 = eN.feedbackContainer.querySelector('[data-byok="key-input"]');
+const nkForm10 = eN.feedbackContainer.querySelector('[data-byok="key-page-form"]');
+assert(nkInput10 !== null, "AC-5 arm 10: key input present for save");
+nkInput10.value = "k-inline-arm10";
+await nkForm10._handlers.submit[0]({ preventDefault: () => {} });
+await flush();
+const nkComp10 = fetchCalls.filter((c) => String(c.url).includes("/chat/completions"));
+assert(nkComp10.length === 1, "AC-5 arm 10: save → EXACTLY ONE /chat/completions fetch (save-continuation)");
+assert(eN.feedbackContainer.querySelector('[data-byok="verdict"]') !== null, "AC-5 arm 10: verdict rendered after save-continuation");
 
 // Arm 11: failed fetch → error state rendered, counter still incremented.
 localStorageMap.clear();
@@ -1291,7 +1309,7 @@ def main() -> int:
     check_prompt_fences(src)
     check_providers_map(src)
     check_fireworks_only_ux(src)
-    check_no_key_link(src)
+    check_no_key_inline_form(src)
     check_shared_local_storage(src)
     check_zero_session_storage(src)
     check_no_singleton_feedback(src)

--- a/scripts/tests/test_quarto_key_page.py
+++ b/scripts/tests/test_quarto_key_page.py
@@ -34,13 +34,18 @@ Verifies the 16-clause predicate from AC-2 of byok-api-key:
   P15 (pure helpers)     — buildValidationUrl / classifyValidation / statusMessage
                            bodies contain no fetch(, localStorage, document..
   P16 (module discipline)— docstring header (WHAT/WHERE/NOT) + <=5 public exports.
+  P17 (onSaved contract) — mountKeyPage(target, {onSaved}) calls onSaved
+                           EXACTLY once after a successful storeKey (issue
+                           #186 save-continuation); empty save and
+                           storage-unavailable save NEVER fire it.
 
 Negative: key echoed into DOM textContent or console; hardcoded api.fireworks.ai;
 innerHTML of status (XSS); Save writing sessionStorage or old slot names; Clear
 leaving bt_feedback_count; validation silently skipped or 401 collapsed into
 network error (listModels reuse); empty save wiping the stored key; key
 pre-filled into the input on key-set mount; duplicate literal slot names instead
-of the imported contract; fetch issued twice on double-mount.
+of the imported contract; fetch issued twice on double-mount; onSaved fired
+without a key actually stored (empty or storage-unavailable save).
 
 Usage: python3 scripts/tests/test_quarto_key_page.py
        uv run pytest scripts/tests/test_quarto_key_page.py -x -q
@@ -394,6 +399,33 @@ assert(status5.textContent === mod.statusMessage("storage-unavailable"), "storag
 assert(localStorageMap.get("fireworks_api_key") === undefined, "storage-unavailable: key NOT stored");
 assert(input5.value === "KEY-STORE-THROW", "storage-unavailable: input keeps its value for retry (no silent wipe)");
 storageError = null;
+
+// --- P17: onSaved fires EXACTLY once after a successful storeKey; never on
+// empty or storage-unavailable saves (issue #186 save-continuation) ---------
+localStorageMap.clear();
+fetchCalls.length = 0;
+let savedCalls = 0;
+const t6 = freshTarget();
+mod.mountKeyPage(t6, { onSaved: () => { savedCalls++; } });
+const form6 = findByDataset(t6, "byok", "key-page-form");
+const input6 = findByDataset(t6, "byok", "key-input");
+const status6 = findByDataset(t6, "byok", "key-status");
+input6.value = "   ";
+await form6._listeners.submit[0]({ preventDefault: () => {} });
+assert(savedCalls === 0, "P17: empty save does NOT fire onSaved");
+assert(status6.textContent === mod.statusMessage("empty"), "P17: empty save still reports the empty status");
+storageError = "QuotaExceededError: storage unavailable";
+input6.value = "KEY-STORE-THROW";
+await form6._listeners.submit[0]({ preventDefault: () => {} });
+assert(savedCalls === 0, "P17: storage-unavailable save does NOT fire onSaved");
+assert(fetchCalls.length === 0, "P17: storage-unavailable save issues no fetch (onSaved would continue a doomed flow)");
+storageError = null;
+input6.value = "P17-KEY";
+fetchCalls.length = 0;
+await form6._listeners.submit[0]({ preventDefault: () => {} });
+assert(savedCalls === 1, "P17: successful save fires onSaved EXACTLY once");
+assert(localStorageMap.get("fireworks_api_key") === "P17-KEY", "P17: key stored alongside onSaved (onSaved runs after storeKey)");
+assert(fetchCalls.length === 1, "P17: successful save still issues one validation fetch");
 
 process.exit(failures > 0 ? 1 : 0);
 """


### PR DESCRIPTION
## Summary
User-reported fix (issue #186): the deployed demo book had no place to enter the Fireworks API key — the "Enter your API key first" link navigated away to a confusing separate page. The no-key state now mounts the existing key-page form (key-page.js `mountKeyPage`) INLINE in the exercise feedback container, and saving the key auto-proceeds to the feedback fetch — no navigation link.

- `exercise-feedback.js`: `renderKeyPrompt` (the `[data-byok="no-key"]` anchor) removed. `handleSubmitForExercise`'s no-key branch now calls `mountKeyPage(container, { onSaved: () => handleSubmitForExercise(entry) })`. `keyPageUrl()` stays exported (api-key chapter + lua emission untouched). Circular import (key-page.js ↔ exercise-feedback.js) is safe — live bindings only at call time.
- `key-page.js`: `mountKeyPage(target, opts = {})` accepts `opts.onSaved`, fired once after a successful `storeKey` (optimistic contract — key stored = proceed; advisory validation never blocks continuation; empty/storage-unavailable saves never fire it). Backward-compatible (lua bootstrap passes no opts).
- `styles.css` (crates source → sync): dead `[data-byok="no-key"]` link rules removed; `.bt-feedback [data-byok="key-page-form"]` flatten override added so the `:global` card styling doesn't card-in-card inline.
- demo-book vendored copies synced byte-identical; rodney `feedback-probe.js` P11 rewritten for the inline form + save-continuation (rodney execution is builder-vision-probe's domain).

## Issue
Closes #186

## ACs implemented
- Inline key-page form mounted in the exercise feedback no-key state (no navigation link)
- Save → auto-proceed to feedback fetch (save-continuation, exactly one fetch)
- `onSaved` fires exactly once on successful storeKey; never on empty/storage-unavailable save
- Dead no-key link CSS removed; inline form flattened inside `.bt-feedback` (no card-in-card)
- Demo-book vendored assets byte-identical; api-key.qmd chapter + lua `keyPageUrl` emission kept as secondary entry

## Test plan
- [x] `python3 scripts/tests/test_quarto_feedback.py` — 64 passed, 0 failed
- [x] `python3 scripts/tests/test_quarto_key_page.py` — 40 passed, 0 failed (incl. new P17 onSaved contract)
- [x] `bash scripts/tests/test_quarto_bootstrap.sh` — 74 passed, 0 failed
- [x] `bash scripts/tests/test_quarto_asset_deployment.sh` — 68 passed, 0 failed
- [x] `bash scripts/sync-quarto-assets.sh --check` — clean
- [x] `cmp` demo-book vendored JS copies byte-identical
- [x] `quarto render demo-book` — deployed libs byte-identical; inline mount + onSaved present in rendered JS
- [x] Bonus render-path suites: ux 46/46, render 12/12, distribution 91/91, install-render 13/13
- [x] Evidence at `docs/evidence/186/` (test-suite.log, asset-parity.log, rendered-page.log, shell-suites.log)

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested (no anchor/href/target=_blank; ZERO fetches before save; onSaved not fired on refused saves)
- [x] Verification medium satisfied (code + rodney — probe updated, execution delegated to builder-vision-probe)
- [x] Design intent respected
- [x] No scope creep (blendtutor.lua, crates Rust, api-key.qmd untouched)