### PR TITLE
[feat] docs.yml assembles committed docs/evals/ into Pages artifact at /evals/

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -110,6 +110,24 @@ jobs:
           cp -R demo-standalone/index_files docs/book/book/demo/
           cp demo-standalone/coi-serviceworker.js docs/book/book/demo/
 
+      # AC-6 (#199) — assemble committed docs/evals/ into the Pages artifact at
+      # /evals/, mirroring the /api + /examples/{r,python} + /demo-book/ +
+      # /demo/ nesting. Guarded: before AC-5 (#198) lands there is no
+      # docs/evals/, and the if/then/fi guard keeps the job green (Actions runs
+      # steps under `bash -eo pipefail` — an `&&` shorthand would exit 1 on a
+      # missing dir). mkdir INSIDE the guard: no empty /evals/ nest published
+      # pre-AC-5. rm before mkdir (api precedent docs.yml:67): docs/evals is
+      # committed source; lesson deletion is a committed deletion; cp-only never
+      # removes stale reports. DOT-COPY (trailing /.): a bare cp -R docs/evals
+      # would double-nest to /evals/evals/<lesson>/ → 404.
+      - name: Assemble evals into artifact (/evals/)
+        run: |
+          if [ -d docs/evals ]; then
+            rm -rf docs/book/book/evals
+            mkdir -p docs/book/book/evals
+            cp -R docs/evals/. docs/book/book/evals/
+          fi
+
       - name: Add .nojekyll at artifact root
         run: touch docs/book/book/.nojekyll
 

--- a/docs/evidence/199/README.md
+++ b/docs/evidence/199/README.md
@@ -7,7 +7,7 @@ quarto-render job (ci.yml:140 runs `bash scripts/tests/test_docs_pages_artifact.
 ## Artifacts
 
 - `test-suite.log` — full probe output: `bash scripts/tests/test_docs_pages_artifact.sh`
-  → **21 passed, 0 failed** (exit 0).
+  → **23 passed, 0 failed** (exit 0).
 - `check-docs-secondary.log` — secondary probe: `bash scripts/check-docs.sh`
   (local mirror) → exit 0, "docs: OK — merged site … evals at /evals/".
 
@@ -31,13 +31,17 @@ Phase 1 (structural pins on `.github/workflows/docs.yml` build block):
   double-nest assert)
 
 Phase 3 (functional fixture sub-phase, clause 8):
-- temp fixture `docs/evals/evals-fixture/index.html`; guarded assemble snippet
-  under `bash -euo pipefail` against scratch book_out → fixture HTML lands at
-  `<scratch>/evals/evals-fixture/index.html` byte-identical, and
-  `! [ -e <scratch>/evals/evals ]` (no double-nest — bare cp would nest to
-  `/evals/evals/<lesson>/` → 404)
-- fixture removed → same snippet under `bash -e` exits 0 and creates no `evals/`
-  dir (CI stays green pre-AC-5); fixture + scratch cleaned up via trap
+- temp fixture `docs/evals/evals-fixture/index.html` inside the (real or
+  simulated) committed docs/evals; guarded assemble snippet under
+  `bash -euo pipefail` against scratch book_out → fixture HTML lands at
+  `<scratch>/evals/evals-fixture/index.html` byte-identical, committed lesson
+  nests alongside, and `! [ -e <scratch>/evals/evals ]` (no double-nest — bare
+  cp would nest to `/evals/evals/<lesson>/` → 404)
+- docs/evals absent → same snippet under `bash -e` exits 0 and creates no
+  `evals/` dir (CI stays green pre-AC-5); fixture + scratch cleaned up via trap
+- **committed docs/evals preservation pin**: the sub-phase moves pre-existing
+  docs/evals aside (post-AC-5 it is committed source) and restores it
+  byte-identical — a `rm -rf docs/evals` cleanup would delete real reports
 
 ## Negative cases exercised
 

--- a/docs/evidence/199/README.md
+++ b/docs/evidence/199/README.md
@@ -1,0 +1,60 @@
+# Issue #199 — docs.yml assembles committed docs/evals/ into Pages artifact at /evals/
+
+E2E evidence for AC-6 (smevals-eval-report). `verification: code` — shell tests
+(structural pins + functional fixture sub-phase), CI-enforced via the
+quarto-render job (ci.yml:140 runs `bash scripts/tests/test_docs_pages_artifact.sh`).
+
+## Artifacts
+
+- `test-suite.log` — full probe output: `bash scripts/tests/test_docs_pages_artifact.sh`
+  → **21 passed, 0 failed** (exit 0).
+- `check-docs-secondary.log` — secondary probe: `bash scripts/check-docs.sh`
+  (local mirror) → exit 0, "docs: OK — merged site … evals at /evals/".
+
+## What the probe asserts (predicate clauses)
+
+Phase 1 (structural pins on `.github/workflows/docs.yml` build block):
+- guard form `if [ -d docs/evals ]` present (clause 1)
+- `[ -d docs/evals ] &&` shorthand ABSENT anywhere in the workflow (clause 1 —
+  Actions runs steps under `bash -eo pipefail`; a trailing `&&` would exit 1
+  when docs/evals is missing, reddening CI before AC-5 lands)
+- within-step order guard < `rm -rf docs/book/book/evals` < `mkdir -p …` <
+  dot-copy `cp -R docs/evals/. docs/book/book/evals/` (clause 2 — mkdir inside
+  guard, no empty /evals/ nest pre-AC-5)
+- step ordering demo-standalone assemble < evals guard < `.nojekyll` <
+  `actions/upload-pages-artifact@v5` (clause 3 — evals lands before upload;
+  all current paths preserved)
+- no `|| true` / `continue-on-error: true` on build steps or the evals step
+  (clause 4)
+- deploy job block free of `evals` needles (clause 5 — deploy has no checkout)
+- check-docs.sh mirror contract 11/11 needles (clause 6/7 — guard, dot-copy,
+  double-nest assert)
+
+Phase 3 (functional fixture sub-phase, clause 8):
+- temp fixture `docs/evals/evals-fixture/index.html`; guarded assemble snippet
+  under `bash -euo pipefail` against scratch book_out → fixture HTML lands at
+  `<scratch>/evals/evals-fixture/index.html` byte-identical, and
+  `! [ -e <scratch>/evals/evals ]` (no double-nest — bare cp would nest to
+  `/evals/evals/<lesson>/` → 404)
+- fixture removed → same snippet under `bash -e` exits 0 and creates no `evals/`
+  dir (CI stays green pre-AC-5); fixture + scratch cleaned up via trap
+
+## Negative cases exercised
+
+- (a) docs/evals absent → guard exits 0, no evals nest (Phase 3 clause 8b)
+- (b) `&&` shorthand → structural absence pin fails (Phase 1)
+- (c) `|| true` on step → clause 4 pin fails
+- (d) bare `cp -R docs/evals …` (no `/.`) → functional double-nest assert fails
+  (Phase 3 clause 8a)
+- (e) evals after .nojekyll/upload → ordering chain fails (Phase 1)
+- (f) check-docs.sh not mirrored → MIRROR_OK 11-count fails (Phase 1)
+- (g) `evals` needle in deploy block → deploy-leak assert fails (Phase 1)
+- (h) mkdir outside guard → within-step order pin fails (Phase 1 clause 2)
+
+## Regressions
+
+- Phase 2 (`check-docs.sh` end-to-end local render + assemble + assert) passes —
+  existing mdBook/rustdoc/examples/demo-book/demo artifact survives; no
+  `rm -rf docs/book/book/*` clobber introduced (clause 9).
+
+Generated 2026-08-07 on branch `199-evals-pages`.

--- a/docs/evidence/199/check-docs-secondary.log
+++ b/docs/evidence/199/check-docs-secondary.log
@@ -1,0 +1,45 @@
+docs: building API reference (rustdoc, -D warnings) …
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.38s
+   Generated /Users/carbonite/Documents/coding/portfolio/worktree-issue-199/target/doc/blendtutor/index.html and 1 other file
+docs: building narrative site (mdBook) …
+ INFO Book building has started
+ INFO Running the html backend
+ INFO HTML book written to `/Users/carbonite/Documents/coding/portfolio/worktree-issue-199/docs/book/book`
+docs: assembling merged site (docs/book/book + /api) …
+docs: building example sites (webr + pyodide) …
+    Finished `release` profile [optimized] target(s) in 0.27s
+     Running `target/release/blendtutor build examples/write-less-code-r --target webr -o docs/book/book/examples/r`
+built 5 lesson(s) for webr into docs/book/book/examples/r
+    Finished `release` profile [optimized] target(s) in 0.17s
+     Running `target/release/blendtutor build examples/write-less-code-python --target pyodide -o docs/book/book/examples/python`
+built 5 lesson(s) for pyodide into docs/book/book/examples/python
+docs: rendering demos (quarto) and assembling /demo-book/ + /demo/ …
+[1m[34m[1/4] index.qmd[39m[22m
+[1m[34m[2/4] api-key.qmd[39m[22m
+[1m[34m[3/4] r-exercises.qmd[39m[22m
+[1m[34m[4/4] python-exercises.qmd[39m[22m
+
+Output created: _output/index.html
+
+[1mpandoc [22m
+  to: html
+  output-file: index.html
+  standalone: true
+  section-divs: true
+  html-math-method: mathjax
+  wrap: none
+  default-image-extension: png
+  
+[1mmetadata[22m
+  document-css: false
+  link-citations: true
+  date-format: long
+  lang: en
+  title: Blendtutor Interactive Demo
+  coi: true
+  
+Output created: index.html
+
+fixed COI scope for demo-standalone: src -> ./coi-serviceworker.js, shim -> demo-standalone/coi-serviceworker.js
+docs: verifying failure propagation (missing course path) …
+docs: OK — merged site at docs/book/book (book at /, API at /api, examples at /examples/{r,python}, demos at /demo-book/ + /demo/, evals at /evals/)

--- a/docs/evidence/199/check-docs-secondary.log
+++ b/docs/evidence/199/check-docs-secondary.log
@@ -1,5 +1,5 @@
 docs: building API reference (rustdoc, -D warnings) …
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.22s
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.09s
    Generated /Users/carbonite/Documents/coding/portfolio/worktree-issue-199/target/doc/blendtutor/index.html and 1 other file
 docs: building narrative site (mdBook) …
  INFO Book building has started
@@ -7,10 +7,10 @@ docs: building narrative site (mdBook) …
  INFO HTML book written to `/Users/carbonite/Documents/coding/portfolio/worktree-issue-199/docs/book/book`
 docs: assembling merged site (docs/book/book + /api) …
 docs: building example sites (webr + pyodide) …
-    Finished `release` profile [optimized] target(s) in 0.14s
+    Finished `release` profile [optimized] target(s) in 0.09s
      Running `target/release/blendtutor build examples/write-less-code-r --target webr -o docs/book/book/examples/r`
 built 5 lesson(s) for webr into docs/book/book/examples/r
-    Finished `release` profile [optimized] target(s) in 0.13s
+    Finished `release` profile [optimized] target(s) in 0.08s
      Running `target/release/blendtutor build examples/write-less-code-python --target pyodide -o docs/book/book/examples/python`
 built 5 lesson(s) for pyodide into docs/book/book/examples/python
 docs: rendering demos (quarto) and assembling /demo-book/ + /demo/ …

--- a/docs/evidence/199/check-docs-secondary.log
+++ b/docs/evidence/199/check-docs-secondary.log
@@ -1,5 +1,5 @@
 docs: building API reference (rustdoc, -D warnings) …
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.38s
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.22s
    Generated /Users/carbonite/Documents/coding/portfolio/worktree-issue-199/target/doc/blendtutor/index.html and 1 other file
 docs: building narrative site (mdBook) …
  INFO Book building has started
@@ -7,10 +7,10 @@ docs: building narrative site (mdBook) …
  INFO HTML book written to `/Users/carbonite/Documents/coding/portfolio/worktree-issue-199/docs/book/book`
 docs: assembling merged site (docs/book/book + /api) …
 docs: building example sites (webr + pyodide) …
-    Finished `release` profile [optimized] target(s) in 0.27s
+    Finished `release` profile [optimized] target(s) in 0.14s
      Running `target/release/blendtutor build examples/write-less-code-r --target webr -o docs/book/book/examples/r`
 built 5 lesson(s) for webr into docs/book/book/examples/r
-    Finished `release` profile [optimized] target(s) in 0.17s
+    Finished `release` profile [optimized] target(s) in 0.13s
      Running `target/release/blendtutor build examples/write-less-code-python --target pyodide -o docs/book/book/examples/python`
 built 5 lesson(s) for pyodide into docs/book/book/examples/python
 docs: rendering demos (quarto) and assembling /demo-book/ + /demo/ …

--- a/docs/evidence/199/test-suite.log
+++ b/docs/evidence/199/test-suite.log
@@ -20,7 +20,7 @@
   PASS: check-docs.sh mirrors the build steps incl. guarded evals assemble (11/11 commands found)
 == Phase 2: local render + assemble + assert (check-docs.sh) ==
 docs: building API reference (rustdoc, -D warnings) …
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.38s
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.16s
    Generated /Users/carbonite/Documents/coding/portfolio/worktree-issue-199/target/doc/blendtutor/index.html and 1 other file
 docs: building narrative site (mdBook) …
  INFO Book building has started
@@ -28,10 +28,10 @@ docs: building narrative site (mdBook) …
  INFO HTML book written to `/Users/carbonite/Documents/coding/portfolio/worktree-issue-199/docs/book/book`
 docs: assembling merged site (docs/book/book + /api) …
 docs: building example sites (webr + pyodide) …
-    Finished `release` profile [optimized] target(s) in 0.21s
+    Finished `release` profile [optimized] target(s) in 0.14s
      Running `target/release/blendtutor build examples/write-less-code-r --target webr -o docs/book/book/examples/r`
 built 5 lesson(s) for webr into docs/book/book/examples/r
-    Finished `release` profile [optimized] target(s) in 0.14s
+    Finished `release` profile [optimized] target(s) in 0.09s
      Running `target/release/blendtutor build examples/write-less-code-python --target pyodide -o docs/book/book/examples/python`
 built 5 lesson(s) for pyodide into docs/book/book/examples/python
 docs: rendering demos (quarto) and assembling /demo-book/ + /demo/ …

--- a/docs/evidence/199/test-suite.log
+++ b/docs/evidence/199/test-suite.log
@@ -20,7 +20,7 @@
   PASS: check-docs.sh mirrors the build steps incl. guarded evals assemble (11/11 commands found)
 == Phase 2: local render + assemble + assert (check-docs.sh) ==
 docs: building API reference (rustdoc, -D warnings) …
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.27s
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.38s
    Generated /Users/carbonite/Documents/coding/portfolio/worktree-issue-199/target/doc/blendtutor/index.html and 1 other file
 docs: building narrative site (mdBook) …
  INFO Book building has started
@@ -28,10 +28,10 @@ docs: building narrative site (mdBook) …
  INFO HTML book written to `/Users/carbonite/Documents/coding/portfolio/worktree-issue-199/docs/book/book`
 docs: assembling merged site (docs/book/book + /api) …
 docs: building example sites (webr + pyodide) …
-    Finished `release` profile [optimized] target(s) in 0.16s
+    Finished `release` profile [optimized] target(s) in 0.21s
      Running `target/release/blendtutor build examples/write-less-code-r --target webr -o docs/book/book/examples/r`
 built 5 lesson(s) for webr into docs/book/book/examples/r
-    Finished `release` profile [optimized] target(s) in 0.11s
+    Finished `release` profile [optimized] target(s) in 0.14s
      Running `target/release/blendtutor build examples/write-less-code-python --target pyodide -o docs/book/book/examples/python`
 built 5 lesson(s) for pyodide into docs/book/book/examples/python
 docs: rendering demos (quarto) and assembling /demo-book/ + /demo/ …
@@ -67,10 +67,12 @@ docs: OK — merged site at docs/book/book (book at /, API at /api, examples at 
   PASS: check-docs.sh renders + assembles + asserts the artifact layout (clauses 9-10)
 == Phase 3: functional evals fixture sub-phase ==
   PASS: fixture HTML lands at <scratch>/evals/evals-fixture/index.html, byte-identical (dot-copy)
+  PASS: committed lesson nests alongside fixture (<scratch>/evals/committed-lesson/report.html)
   PASS: no double-nest — <scratch>/evals/evals absent
   PASS: guard exits 0 with docs/evals absent; no evals/ nest created (CI green pre-AC-5)
+  PASS: committed docs/evals preserved byte-identical after fixture sub-phase
 
 =========================================
-  Results: 21 passed, 0 failed
+  Results: 23 passed, 0 failed
 =========================================
 All tests passed.

--- a/docs/evidence/199/test-suite.log
+++ b/docs/evidence/199/test-suite.log
@@ -1,0 +1,76 @@
+== Phase 1: structural pins (docs.yml build job) ==
+  PASS: quarto setup in build job (quarto-dev/quarto-actions/setup@v2)
+  PASS: build job renders demo-book (quarto render demo-book --to html)
+  PASS: build job renders demo-standalone (quarto render demo-standalone --to html)
+  PASS: COI post-process present (scripts/fix-demo-coi-scope.sh demo-standalone)
+  PASS: demo-book DOT-COPY literal (cp -R demo-book/_output/. — no _output/ layer)
+  PASS: selective demo copy (index.html + index_files/ + coi-serviceworker.js → /demo/)
+  PASS: .nojekyll step at artifact root (touch docs/book/book/.nojekyll)
+  PASS: ordering: setup → renders → fix-coi → copies → evals guard → .nojekyll all BEFORE upload (clauses 4, 8)
+  PASS: no '|| true' on build steps
+  PASS: no 'continue-on-error: true' on build steps
+  PASS: evals guard present (if [ -d docs/evals ])
+  PASS: no '&&' shorthand guard (if/then/fi only — CI green before AC-5)
+  PASS: evals step order: guard < rm < mkdir < dot-copy (clause 2, mkdir inside guard)
+  PASS: no '|| true' on evals step
+  PASS: no render/copy steps in deploy job block
+== Phase 1: structural pins (ci.yml quarto-render job) ==
+  PASS: CI quarto-render job runs test_docs_pages_artifact.sh
+== Phase 1: structural pins (check-docs.sh mirror contract) ==
+  PASS: check-docs.sh mirrors the build steps incl. guarded evals assemble (11/11 commands found)
+== Phase 2: local render + assemble + assert (check-docs.sh) ==
+docs: building API reference (rustdoc, -D warnings) …
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.27s
+   Generated /Users/carbonite/Documents/coding/portfolio/worktree-issue-199/target/doc/blendtutor/index.html and 1 other file
+docs: building narrative site (mdBook) …
+ INFO Book building has started
+ INFO Running the html backend
+ INFO HTML book written to `/Users/carbonite/Documents/coding/portfolio/worktree-issue-199/docs/book/book`
+docs: assembling merged site (docs/book/book + /api) …
+docs: building example sites (webr + pyodide) …
+    Finished `release` profile [optimized] target(s) in 0.16s
+     Running `target/release/blendtutor build examples/write-less-code-r --target webr -o docs/book/book/examples/r`
+built 5 lesson(s) for webr into docs/book/book/examples/r
+    Finished `release` profile [optimized] target(s) in 0.11s
+     Running `target/release/blendtutor build examples/write-less-code-python --target pyodide -o docs/book/book/examples/python`
+built 5 lesson(s) for pyodide into docs/book/book/examples/python
+docs: rendering demos (quarto) and assembling /demo-book/ + /demo/ …
+[1m[34m[1/4] index.qmd[39m[22m
+[1m[34m[2/4] api-key.qmd[39m[22m
+[1m[34m[3/4] r-exercises.qmd[39m[22m
+[1m[34m[4/4] python-exercises.qmd[39m[22m
+
+Output created: _output/index.html
+
+[1mpandoc [22m
+  to: html
+  output-file: index.html
+  standalone: true
+  section-divs: true
+  html-math-method: mathjax
+  wrap: none
+  default-image-extension: png
+  
+[1mmetadata[22m
+  document-css: false
+  link-citations: true
+  date-format: long
+  lang: en
+  title: Blendtutor Interactive Demo
+  coi: true
+  
+Output created: index.html
+
+fixed COI scope for demo-standalone: src -> ./coi-serviceworker.js, shim -> demo-standalone/coi-serviceworker.js
+docs: verifying failure propagation (missing course path) …
+docs: OK — merged site at docs/book/book (book at /, API at /api, examples at /examples/{r,python}, demos at /demo-book/ + /demo/, evals at /evals/)
+  PASS: check-docs.sh renders + assembles + asserts the artifact layout (clauses 9-10)
+== Phase 3: functional evals fixture sub-phase ==
+  PASS: fixture HTML lands at <scratch>/evals/evals-fixture/index.html, byte-identical (dot-copy)
+  PASS: no double-nest — <scratch>/evals/evals absent
+  PASS: guard exits 0 with docs/evals absent; no evals/ nest created (CI green pre-AC-5)
+
+=========================================
+  Results: 21 passed, 0 failed
+=========================================
+All tests passed.

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Build the combined documentation site locally and assert it satisfies the
-# docs slice (#3) and the example-sites slice (#76): mdBook narrative + rustdoc
-# API + example course sites (webr + pyodide) merged into one Pages artifact.
+# docs slice (#3), the example-sites slice (#76), and the evals-pages slice
+# (#199): mdBook narrative + rustdoc API + example course sites (webr + pyodide)
+# + committed docs/evals/ (when present) merged into one Pages artifact.
 #
 # This is the slice's executable spec — the same predicates CI enforces,
 # runnable by hand:
@@ -82,6 +83,22 @@ mkdir -p "$book_out/demo"
 cp demo-standalone/index.html "$book_out/demo/"
 cp -R demo-standalone/index_files "$book_out/demo/"
 cp demo-standalone/coi-serviceworker.js "$book_out/demo/"
+
+# AC-6 (#199) — assemble committed docs/evals/ into the artifact at /evals/,
+# mirroring the /api + /examples/{r,python} + /demo-book/ + /demo/ nesting.
+# Guarded: before AC-5 (#198) lands there is no docs/evals/, and the if/then/fi
+# guard keeps the local check (and CI, via docs.yml's identical guard) green.
+# mkdir INSIDE the guard: no empty /evals/ nest pre-AC-5. rm before mkdir (api
+# precedent): docs/evals is committed source; cp-only never removes stale
+# reports. DOT-COPY (trailing /.): a bare cp would double-nest to
+# /evals/evals/<lesson>/ → 404 — asserted inside the guard.
+if [ -d docs/evals ]; then
+  rm -rf "$book_out/evals"
+  mkdir -p "$book_out/evals"
+  cp -R docs/evals/. "$book_out/evals/"
+  ! [ -e "$book_out/evals/evals" ] \
+    || { echo "docs: evals double-nested ($book_out/evals/evals — bare cp, not dot-copy)" >&2; exit 1; }
+fi
 touch "$book_out/.nojekyll"
 
 # AC-2 — assert the assembled layout (clause 9):
@@ -218,4 +235,4 @@ grep -q 'examples/r/' "$book_out/examples.html" \
 grep -q 'examples/python/' "$book_out/examples.html" \
   || { echo "docs: built mdBook examples.html missing rendered link to examples/python/" >&2; exit 1; }
 
-echo "docs: OK — merged site at $book_out (book at /, API at /api, examples at /examples/{r,python}, demos at /demo-book/ + /demo/)"
+echo "docs: OK — merged site at $book_out (book at /, API at /api, examples at /examples/{r,python}, demos at /demo-book/ + /demo/, evals at /evals/)"

--- a/scripts/tests/test_docs_pages_artifact.sh
+++ b/scripts/tests/test_docs_pages_artifact.sh
@@ -338,14 +338,54 @@ fi
 
 echo "== Phase 3: functional evals fixture sub-phase =="
 
-# Runtime temp fixture: docs/evals/ is the committed AC-5 source dir; the
-# fixture simulates a report tree so the assemble semantics (dot-copy, guard
-# exit-0-when-absent) are exercised against a scratch book_out.
-FIXTURE_DIR="docs/evals/evals-fixture"
+# Once AC-5 (#198) lands, docs/evals/ is COMMITTED SOURCE — this sub-phase must
+# never destroy it (a `rm -rf docs/evals` cleanup would delete real reports
+# from the working tree). If docs/evals pre-exists, its content is snapshotted
+# and moved aside; the fixture sub-phase then runs against a fresh fixture tree
+# and the pre-existing content is restored + verified byte-identical. If it does
+# not pre-exist, a simulated committed report tree is created so the same
+# safety path is always exercised (and cleaned up on exit).
 SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/bt-evals-scratch.XXXXXX")"
-cleanup_evals() { rm -rf docs/evals "$SCRATCH"; }
+EVALS_PREEXISTING=0
+EVALS_BACKUP=""
+cleanup_evals() {
+  # Restore pre-existing (committed) docs/evals if it was moved aside.
+  if [ -n "$EVALS_BACKUP" ] && [ -d "$EVALS_BACKUP" ]; then
+    rm -rf docs/evals
+    mv "$EVALS_BACKUP" docs/evals
+  fi
+  # Simulated fixture tree (created by this sub-phase) must not linger.
+  if [ "$EVALS_PREEXISTING" -eq 0 ]; then
+    rm -rf docs/evals
+  fi
+  rm -rf "$SCRATCH"
+}
 trap cleanup_evals EXIT
 
+if [ -d docs/evals ]; then
+  EVALS_PREEXISTING=1
+else
+  # Simulate the post-AC-5 committed tree so the backup/restore path is always
+  # exercised and the preservation pin is live even before AC-5 lands.
+  mkdir -p docs/evals/committed-lesson
+  printf '<!doctype html><html><body>committed report</body></html>\n' \
+    > docs/evals/committed-lesson/report.html
+fi
+
+# The committed content file (real pre-existing or simulated), relative to the
+# repo root — used to assert it nests alongside the fixture in clause 8a
+# without hardcoding the simulated dir name (real AC-5 lessons vary).
+COMMITTED_FILE="$(find docs/evals -type f | head -1 || true)"
+COMMITTED_NESTED="${COMMITTED_FILE#docs/evals/}"
+
+# Snapshot the committed tree's content BEFORE the temp fixture is added, so
+# the preservation pin proves the committed content survived the sub-phase
+# independent of the fixture (byte-identical compare, fixture excluded).
+find docs/evals -type f -exec cksum {} \; | sort > "$SCRATCH/docs-evals-before.cksum"
+
+# Temp fixture — simulates a report tree inside the (real or simulated)
+# committed docs/evals, exactly the post-AC-5 shape (lessons + new report).
+FIXTURE_DIR="docs/evals/evals-fixture"
 mkdir -p "$FIXTURE_DIR"
 printf '<!doctype html><html><body>evals-fixture</body></html>\n' \
   > "$FIXTURE_DIR/index.html"
@@ -363,13 +403,19 @@ evals_assemble() {
 }
 
 # Clause 8a — fixture present: HTML lands at <scratch>/evals/evals-fixture/
-# index.html byte-identical, and no double-nest (<scratch>/evals/evals absent).
+# index.html byte-identical, committed lesson also nests, and no double-nest
+# (<scratch>/evals/evals absent).
 if evals_assemble; then
   if [ -f "$SCRATCH/evals/evals-fixture/index.html" ] \
       && cmp -s "$FIXTURE_DIR/index.html" "$SCRATCH/evals/evals-fixture/index.html"; then
     ok "fixture HTML lands at <scratch>/evals/evals-fixture/index.html, byte-identical (dot-copy)"
   else
     ko "fixture HTML not byte-identical at <scratch>/evals/evals-fixture/index.html"
+  fi
+  if [ -n "$COMMITTED_NESTED" ] && [ -f "$SCRATCH/evals/$COMMITTED_NESTED" ]; then
+    ok "committed lesson nests alongside fixture (<scratch>/evals/$COMMITTED_NESTED)"
+  else
+    ko "committed lesson missing from assembled evals nest (expected <scratch>/evals/$COMMITTED_NESTED)"
   fi
   if [ ! -e "$SCRATCH/evals/evals" ]; then
     ok "no double-nest — <scratch>/evals/evals absent"
@@ -380,11 +426,13 @@ else
   ko "guarded assemble exits non-zero with fixture present"
 fi
 
-# Clause 8b — fixture removed (docs/evals entirely absent, as pre-AC-5): same
-# snippet under bash -e exits 0 and creates no evals/ dir (CI stays green).
-# Scratch evals/ from 8a is cleared first so "creates no evals dir" is a true
-# negative.
-rm -rf docs/evals "$SCRATCH/evals"
+# Clause 8b — docs/evals absent (as pre-AC-5): same snippet under bash -e
+# exits 0 and creates no evals/ dir (CI stays green). The committed tree is
+# moved aside first (restored below); scratch evals/ from 8a is cleared so
+# "creates no evals dir" is a true negative.
+mv docs/evals "$SCRATCH/docs-evals-real"
+EVALS_BACKUP="$SCRATCH/docs-evals-real"
+rm -rf "$SCRATCH/evals"
 if bash -e -c '
   if [ -d docs/evals ]; then
     rm -rf "$1/evals"
@@ -399,6 +447,22 @@ if bash -e -c '
   fi
 else
   ko "guard exits non-zero with docs/evals absent (would redden CI pre-AC-5)"
+fi
+
+# Restore the (real or simulated) committed tree and pin byte-identical
+# preservation — a regression here deletes committed AC-5 reports. The temp
+# fixture (which travelled inside docs/evals to the backup) is removed from the
+# restored tree; the before-snapshot never contained it, so the pin compares
+# committed content only.
+rm -rf docs/evals
+mv "$EVALS_BACKUP" docs/evals
+EVALS_BACKUP=""
+rm -rf "$FIXTURE_DIR"
+if find docs/evals -type f -exec cksum {} \; | sort \
+    | diff -q "$SCRATCH/docs-evals-before.cksum" - >/dev/null; then
+  ok "committed docs/evals preserved byte-identical after fixture sub-phase"
+else
+  ko "committed docs/evals NOT preserved (content changed or deleted)"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_docs_pages_artifact.sh
+++ b/scripts/tests/test_docs_pages_artifact.sh
@@ -28,6 +28,22 @@
 #      rm -rf docs/book/book/* clobber (asserted by check-docs.sh Phase 2)
 #  11. ci.yml quarto-render job runs this test (awk job-block pin, not file-wide)
 #
+# AC-6 of smevals-eval-report (#199) adds a 12th concern — evals publishing:
+#  12. build job gains a guarded evals assemble step: if/then/fi guard with the
+#      literal `if [ -d docs/evals ]` AND the `&&` shorthand `[ -d docs/evals ]
+#      &&` ABSENT anywhere in the workflow (Actions runs steps under
+#      bash -eo pipefail — a trailing && chain exits 1 when the dir is missing,
+#      reddening CI before AC-5 commits any report)
+#  13. within the step, line order is guard < `rm -rf docs/book/book/evals` <
+#      `mkdir -p docs/book/book/evals` < literal DOT-COPY `cp -R docs/evals/.
+#      docs/book/book/evals/` (trailing /. — a bare cp double-nests to
+#      /evals/evals/<lesson>/ → 404); mkdir INSIDE the guard (no empty /evals/
+#      nest published pre-AC-5); step before .nojekyll and before upload
+#  14. deploy job block free of `evals`/`docs/evals` needles (deploy has no
+#      checkout); check-docs.sh mirrors the guarded assemble + double-nest
+#      assert against $book_out; fixture sub-phase (Phase 3) proves the cp
+#      semantics (no double-nest) + the guard exits 0 when docs/evals absent
+#
 # Negative cases (from the spec):
 #   - quarto setup step missing → render fails on clean runner → clause 1
 #   - || true / continue-on-error: true → silent-failure deploy of a broken
@@ -103,6 +119,10 @@ L_COPY_BOOK="$(block_line "$BUILD_BLOCK" 'demo-book/_output/.')"
 L_COPY_DEMO="$(block_line "$BUILD_BLOCK" 'cp demo-standalone/index.html')"
 L_NOJEKYLL="$(block_line "$BUILD_BLOCK" 'docs/book/book/.nojekyll')"
 L_UPLOAD="$(block_line "$BUILD_BLOCK" 'actions/upload-pages-artifact@v5')"
+L_EVALS_GUARD="$(block_line "$BUILD_BLOCK" 'if [ -d docs/evals ]')"
+L_EVALS_RM="$(block_line "$BUILD_BLOCK" 'rm -rf docs/book/book/evals')"
+L_EVALS_MKDIR="$(block_line "$BUILD_BLOCK" 'mkdir -p docs/book/book/evals')"
+L_EVALS_CP="$(block_line "$BUILD_BLOCK" 'cp -R docs/evals/. docs/book/book/evals/')"
 
 # Clause 1 — quarto setup in the build job block (absent today: a clean
 # runner has no quarto and the render steps would fail).
@@ -166,7 +186,7 @@ fi
 # fix-coi → dot-copy demo-book → selective demo copy → .nojekyll → upload.
 ORDER_OK=1
 for ln in "$L_SETUP" "$L_RENDER_BOOK" "$L_RENDER_SA" "$L_FIX" "$L_COPY_BOOK" \
-          "$L_COPY_DEMO" "$L_NOJEKYLL" "$L_UPLOAD"; do
+          "$L_COPY_DEMO" "$L_EVALS_GUARD" "$L_NOJEKYLL" "$L_UPLOAD"; do
   [ -n "$ln" ] || ORDER_OK=0
 done
 if [ "$ORDER_OK" -eq 1 ] \
@@ -175,11 +195,12 @@ if [ "$ORDER_OK" -eq 1 ] \
     && [ "$L_RENDER_SA" -lt "$L_FIX" ] \
     && [ "$L_FIX" -lt "$L_COPY_BOOK" ] \
     && [ "$L_COPY_BOOK" -lt "$L_COPY_DEMO" ] \
-    && [ "$L_COPY_DEMO" -lt "$L_NOJEKYLL" ] \
+    && [ "$L_COPY_DEMO" -lt "$L_EVALS_GUARD" ] \
+    && [ "$L_EVALS_GUARD" -lt "$L_NOJEKYLL" ] \
     && [ "$L_NOJEKYLL" -lt "$L_UPLOAD" ]; then
-  ok "ordering: setup → renders → fix-coi → copies → .nojekyll all BEFORE upload (clauses 4, 8)"
+  ok "ordering: setup → renders → fix-coi → copies → evals guard → .nojekyll all BEFORE upload (clauses 4, 8)"
 else
-  ko "ordering: all new steps BEFORE upload with fix-coi after render, before copy — setup=$L_SETUP render_book=$L_RENDER_BOOK render_sa=$L_RENDER_SA fix=$L_FIX copy_book=$L_COPY_BOOK copy_demo=$L_COPY_DEMO nojekyll=$L_NOJEKYLL upload=$L_UPLOAD"
+  ko "ordering: all new steps BEFORE upload with fix-coi after render, before copy — setup=$L_SETUP render_book=$L_RENDER_BOOK render_sa=$L_RENDER_SA fix=$L_FIX copy_book=$L_COPY_BOOK copy_demo=$L_COPY_DEMO evals=$L_EVALS_GUARD nojekyll=$L_NOJEKYLL upload=$L_UPLOAD"
 fi
 
 # Clause 8 — refusal arms: no || true, no continue-on-error on any step.
@@ -195,9 +216,51 @@ else
   ok "no 'continue-on-error: true' on build steps"
 fi
 
+# AC-6 (#199) — clause 1: evals guard present in if/then/fi form, and the
+# `[ -d docs/evals ] &&` shorthand ABSENT anywhere in the workflow. Actions
+# runs steps under `bash -eo pipefail`, so a trailing && chain would exit 1
+# (and redden CI) whenever docs/evals does not exist — before AC-5 has
+# committed any report. Grep the whole file, not just the build block.
+if [ -n "$L_EVALS_GUARD" ]; then
+  ok "evals guard present (if [ -d docs/evals ])"
+else
+  ko "evals guard present (if [ -d docs/evals ]) — missing"
+fi
+
+if grep -qF '[ -d docs/evals ] &&' "$DOCS_FILE"; then
+  ko "no '&&' shorthand guard (trailing && exits 1 under bash -eo pipefail when docs/evals missing)"
+else
+  ok "no '&&' shorthand guard (if/then/fi only — CI green before AC-5)"
+fi
+
+# AC-6 (#199) — clause 2: within-step line order guard < rm < mkdir < dot-copy.
+# mkdir INSIDE the guard: no empty /evals/ nest published pre-AC-5. The
+# trailing /. on the copy is the double-nest trap (bare cp → /evals/evals/).
+EVALS_ORDER_OK=1
+for ln in "$L_EVALS_GUARD" "$L_EVALS_RM" "$L_EVALS_MKDIR" "$L_EVALS_CP"; do
+  [ -n "$ln" ] || EVALS_ORDER_OK=0
+done
+if [ "$EVALS_ORDER_OK" -eq 1 ] \
+    && [ "$L_EVALS_GUARD" -lt "$L_EVALS_RM" ] \
+    && [ "$L_EVALS_RM" -lt "$L_EVALS_MKDIR" ] \
+    && [ "$L_EVALS_MKDIR" -lt "$L_EVALS_CP" ]; then
+  ok "evals step order: guard < rm < mkdir < dot-copy (clause 2, mkdir inside guard)"
+else
+  ko "evals step order: guard < rm < mkdir < dot-copy — guard=$L_EVALS_GUARD rm=$L_EVALS_RM mkdir=$L_EVALS_MKDIR cp=$L_EVALS_CP"
+fi
+
+# AC-6 (#199) — clause 4: no || true on the evals step.
+if [ -z "$L_EVALS_GUARD" ] || [ -z "$L_EVALS_CP" ]; then
+  ko "no '|| true' on evals step — evals step missing (clause 1 already fails)"
+elif grep -qE '\|\|\s*true' <<< "$(sed -n "$L_EVALS_GUARD,$((L_EVALS_CP + 2))p" <<< "$BUILD_BLOCK")"; then
+  ko "no '|| true' on evals step (silent-failure trap)"
+else
+  ok "no '|| true' on evals step"
+fi
+
 # Clause 8 — build-job-block scoping: no render/copy steps leak into deploy.
 DEPLOY_LEAK=""
-for needle in 'quarto render' 'fix-demo-coi-scope' 'demo-book' 'demo-standalone' '.nojekyll'; do
+for needle in 'quarto render' 'fix-demo-coi-scope' 'demo-book' 'demo-standalone' '.nojekyll' 'evals'; do
   if grep -qF "$needle" <<< "$DEPLOY_BLOCK"; then
     DEPLOY_LEAK="$DEPLOY_LEAK $needle"
   fi
@@ -221,7 +284,8 @@ fi
 echo "== Phase 1: structural pins (check-docs.sh mirror contract) =="
 
 # Clause 9 (structural half) — check-docs.sh mirrors the new build steps so
-# the local mirror cannot silently diverge from CI.
+# the local mirror cannot silently diverge from CI. AC-6 (#199) adds the three
+# evals needles (guard, dot-copy, double-nest assert) → 8 → 11.
 MIRROR_OK=0
 for needle in \
   'quarto render demo-book' \
@@ -231,13 +295,16 @@ for needle in \
   'cp demo-standalone/index.html' \
   'cp -R demo-standalone/index_files' \
   'cp demo-standalone/coi-serviceworker.js' \
-  '.nojekyll'; do
+  '.nojekyll' \
+  'if [ -d docs/evals ]' \
+  'cp -R docs/evals/. "$book_out/evals/"' \
+  '"$book_out/evals/evals"'; do
   grep -qF "$needle" "$CHECK_DOCS" && MIRROR_OK=$((MIRROR_OK + 1))
 done
-if [ "$MIRROR_OK" -eq 8 ]; then
-  ok "check-docs.sh mirrors the new build steps (8/8 commands found)"
+if [ "$MIRROR_OK" -eq 11 ]; then
+  ok "check-docs.sh mirrors the build steps incl. guarded evals assemble (11/11 commands found)"
 else
-  ko "check-docs.sh mirrors the new build steps — only $MIRROR_OK/8 commands found"
+  ko "check-docs.sh mirrors the build steps — only $MIRROR_OK/11 commands found"
 fi
 
 # ---------------------------------------------------------------------------
@@ -263,6 +330,75 @@ else
   else
     ko "check-docs.sh renders + assembles + asserts the artifact layout (clauses 9-10)"
   fi
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 3 — functional evals fixture sub-phase (AC-6, #199, clause 8)
+# ---------------------------------------------------------------------------
+
+echo "== Phase 3: functional evals fixture sub-phase =="
+
+# Runtime temp fixture: docs/evals/ is the committed AC-5 source dir; the
+# fixture simulates a report tree so the assemble semantics (dot-copy, guard
+# exit-0-when-absent) are exercised against a scratch book_out.
+FIXTURE_DIR="docs/evals/evals-fixture"
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/bt-evals-scratch.XXXXXX")"
+cleanup_evals() { rm -rf docs/evals "$SCRATCH"; }
+trap cleanup_evals EXIT
+
+mkdir -p "$FIXTURE_DIR"
+printf '<!doctype html><html><body>evals-fixture</body></html>\n' \
+  > "$FIXTURE_DIR/index.html"
+
+# The guarded assemble snippet — the docs.yml step body with docs/book/book
+# replaced by the scratch dir, run under bash -euo pipefail.
+evals_assemble() {
+  bash -euo pipefail -c '
+    if [ -d docs/evals ]; then
+      rm -rf "$1/evals"
+      mkdir -p "$1/evals"
+      cp -R docs/evals/. "$1/evals/"
+    fi
+  ' _ "$SCRATCH"
+}
+
+# Clause 8a — fixture present: HTML lands at <scratch>/evals/evals-fixture/
+# index.html byte-identical, and no double-nest (<scratch>/evals/evals absent).
+if evals_assemble; then
+  if [ -f "$SCRATCH/evals/evals-fixture/index.html" ] \
+      && cmp -s "$FIXTURE_DIR/index.html" "$SCRATCH/evals/evals-fixture/index.html"; then
+    ok "fixture HTML lands at <scratch>/evals/evals-fixture/index.html, byte-identical (dot-copy)"
+  else
+    ko "fixture HTML not byte-identical at <scratch>/evals/evals-fixture/index.html"
+  fi
+  if [ ! -e "$SCRATCH/evals/evals" ]; then
+    ok "no double-nest — <scratch>/evals/evals absent"
+  else
+    ko "double-nest — <scratch>/evals/evals present (bare cp, not dot-copy)"
+  fi
+else
+  ko "guarded assemble exits non-zero with fixture present"
+fi
+
+# Clause 8b — fixture removed (docs/evals entirely absent, as pre-AC-5): same
+# snippet under bash -e exits 0 and creates no evals/ dir (CI stays green).
+# Scratch evals/ from 8a is cleared first so "creates no evals dir" is a true
+# negative.
+rm -rf docs/evals "$SCRATCH/evals"
+if bash -e -c '
+  if [ -d docs/evals ]; then
+    rm -rf "$1/evals"
+    mkdir -p "$1/evals"
+    cp -R docs/evals/. "$1/evals/"
+  fi
+' _ "$SCRATCH"; then
+  if [ ! -e "$SCRATCH/evals" ]; then
+    ok "guard exits 0 with docs/evals absent; no evals/ nest created (CI green pre-AC-5)"
+  else
+    ko "evals/ nest created despite docs/evals absent (mkdir outside guard)"
+  fi
+else
+  ko "guard exits non-zero with docs/evals absent (would redden CI pre-AC-5)"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_docs_pages_artifact.sh
+++ b/scripts/tests/test_docs_pages_artifact.sh
@@ -348,13 +348,17 @@ echo "== Phase 3: functional evals fixture sub-phase =="
 SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/bt-evals-scratch.XXXXXX")"
 EVALS_PREEXISTING=0
 EVALS_BACKUP=""
+FIXTURE_DIR="docs/evals/evals-fixture"
 cleanup_evals() {
   # Restore pre-existing (committed) docs/evals if it was moved aside.
   if [ -n "$EVALS_BACKUP" ] && [ -d "$EVALS_BACKUP" ]; then
     rm -rf docs/evals
     mv "$EVALS_BACKUP" docs/evals
   fi
-  # Simulated fixture tree (created by this sub-phase) must not linger.
+  # Temp fixture — inside the restored real tree (pre-existing case) OR the
+  # simulated tree (non-pre-existing) — must not linger in either case.
+  rm -rf "$FIXTURE_DIR"
+  # Simulated committed tree (created by this sub-phase) must not linger.
   if [ "$EVALS_PREEXISTING" -eq 0 ]; then
     rm -rf docs/evals
   fi
@@ -385,7 +389,6 @@ find docs/evals -type f -exec cksum {} \; | sort > "$SCRATCH/docs-evals-before.c
 
 # Temp fixture — simulates a report tree inside the (real or simulated)
 # committed docs/evals, exactly the post-AC-5 shape (lessons + new report).
-FIXTURE_DIR="docs/evals/evals-fixture"
 mkdir -p "$FIXTURE_DIR"
 printf '<!doctype html><html><body>evals-fixture</body></html>\n' \
   > "$FIXTURE_DIR/index.html"
@@ -453,16 +456,19 @@ fi
 # preservation — a regression here deletes committed AC-5 reports. The temp
 # fixture (which travelled inside docs/evals to the backup) is removed from the
 # restored tree; the before-snapshot never contained it, so the pin compares
-# committed content only.
-rm -rf docs/evals
-mv "$EVALS_BACKUP" docs/evals
-EVALS_BACKUP=""
-rm -rf "$FIXTURE_DIR"
-if find docs/evals -type f -exec cksum {} \; | sort \
-    | diff -q "$SCRATCH/docs-evals-before.cksum" - >/dev/null; then
-  ok "committed docs/evals preserved byte-identical after fixture sub-phase"
-else
-  ko "committed docs/evals NOT preserved (content changed or deleted)"
+# committed content only. Guarded: if 8b never moved docs/evals aside (hard
+# failure before it), there is nothing to restore.
+if [ -n "$EVALS_BACKUP" ] && [ -d "$EVALS_BACKUP" ]; then
+  rm -rf docs/evals
+  mv "$EVALS_BACKUP" docs/evals
+  EVALS_BACKUP=""
+  rm -rf "$FIXTURE_DIR"
+  if find docs/evals -type f -exec cksum {} \; | sort \
+      | diff -q "$SCRATCH/docs-evals-before.cksum" - >/dev/null; then
+    ok "committed docs/evals preserved byte-identical after fixture sub-phase"
+  else
+    ko "committed docs/evals NOT preserved (content changed or deleted)"
+  fi
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Extend `.github/workflows/docs.yml` to assemble committed `docs/evals/` into the GitHub Pages artifact at `/evals/` via the existing cp-into-`docs/book/book` pattern, **guarded** (`if [ -d docs/evals ]; then … fi`) so the job stays green before any report exists (AC-5 #198 not yet landed). `scripts/check-docs.sh` mirrors the guarded assemble + double-nest assert; `scripts/tests/test_docs_pages_artifact.sh` asserts structural pins + a functional fixture sub-phase. All current Pages paths preserved; ci.yml untouched.

Key semantics:
- **Guard form if/then/fi only** — Actions runs steps under `bash -eo pipefail`; an `&&` shorthand would exit 1 when docs/evals is missing → CI red pre-AC-5. Pinned absent by the test.
- **mkdir inside guard** — no empty `/evals/` nest published pre-AC-5.
- **rm before mkdir** (api precedent) — docs/evals is committed source; cp-only never removes stale reports.
- **Dot-copy `cp -R docs/evals/. docs/book/book/evals/`** — bare cp double-nests to `/evals/evals/<lesson>/` → 404. Pinned structurally + functionally.

## Issue
Closes #199

## ACs implemented
- [x] docs.yml build job gains guarded evals assemble step (if/then/fi guard, rm + mkdir + dot-copy into docs/book/book/evals/ before upload); scripts/check-docs.sh mirrors it; scripts/tests/test_docs_pages_artifact.sh asserts structural pins + functional cp semantics (nest preserved, no double-nest); all current Pages paths preserved.

## Test plan
- [x] `bash scripts/tests/test_docs_pages_artifact.sh` → **21 passed, 0 failed** (Phase 1 structural pins + Phase 2 full check-docs.sh render/assemble/assert + Phase 3 functional fixture sub-phase)
- [x] `bash scripts/check-docs.sh` → exit 0 (secondary probe; if-guard skips evals when docs/evals absent)
- [x] Negative cases (a)-(h) from spec exercised: absent-dir green, `&&` shorthand, `|| true`, bare cp double-nest, ordering, mirror, deploy-leak, mkdir-outside-guard
- [x] E2E evidence at `docs/evidence/199/` (test-suite.log, check-docs-secondary.log, README.md)

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested
- [x] Verification medium satisfied (code — shell tests, CI-enforced via quarto-render job)
- [x] Design intent respected
- [x] No scope creep (3 files + evidence; ci.yml untouched)

Commits: 116fbf7 test(red) · 5f4ad51 feat · 2b088e5 docs(evidence)