### PR TITLE
feat: eval per-case feedback_message and --case N single-case selection

### DIFF
--- a/crates/cli/src/commands/eval.rs
+++ b/crates/cli/src/commands/eval.rs
@@ -18,16 +18,23 @@ use blendtutor_core::llm::ProviderChoice;
 use crate::commands::PROVIDER_URL_VAR;
 use crate::output::{self, OutputFormat};
 
-/// Load the lesson and its sibling eval suite, score every case through the run
-/// pipeline, and render the report.
+/// Load the lesson and its sibling eval suite, score every case — or, with
+/// `case`, only the one 1-based case — through the run pipeline, and render the
+/// report.
 ///
 /// A lesson read/parse failure, a missing or malformed suite, or a pipeline
-/// failure on any case propagates as an error (→ exit 1). The command itself
-/// always succeeds (exit 0) when it produces a report: `eval` measures feedback
-/// quality, it is not a pass/fail gate, so a low accuracy is still a successful
-/// run. The provider is driven on a current-thread runtime (the binary owns its
-/// async runtime; `core` stays a library).
-pub fn run(lesson_path: &Path, format: OutputFormat) -> anyhow::Result<ExitCode> {
+/// failure on any case propagates as an error (→ exit 1). An out-of-range
+/// `case` selection also propagates (→ exit 1, naming the suite size); a
+/// non-numeric `--case` is rejected by clap at parse time (→ exit 2). The
+/// command itself always succeeds (exit 0) when it produces a report: `eval`
+/// measures feedback quality, it is not a pass/fail gate, so a low accuracy is
+/// still a successful run. The provider is driven on a current-thread runtime
+/// (the binary owns its async runtime; `core` stays a library).
+pub fn run(
+    lesson_path: &Path,
+    format: OutputFormat,
+    case: Option<usize>,
+) -> anyhow::Result<ExitCode> {
     let lesson = read_lesson_file(lesson_path)?;
     let suite_path = sibling_suite_path(lesson_path);
     let suite_yaml = std::fs::read_to_string(&suite_path)
@@ -43,6 +50,7 @@ pub fn run(lesson_path: &Path, format: OutputFormat) -> anyhow::Result<ExitCode>
         &suite,
         ProviderChoice::default(),
         base_url.as_deref(),
+        case,
     ))?;
 
     output::emit_eval(&report, format)?;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -75,6 +75,9 @@ enum Commands {
         /// Output format: `human` (default) or `json`.
         #[arg(long, value_enum, default_value_t = OutputFormat::Human)]
         format: OutputFormat,
+        /// Score only the 1-based case `N` instead of the whole suite.
+        #[arg(long)]
+        case: Option<usize>,
     },
     /// Build a browser-deployable lesson site from a course.
     Build {
@@ -130,7 +133,11 @@ fn main() -> anyhow::Result<ExitCode> {
             code,
             format,
         } => commands::run::run(&lesson, code.as_deref(), format),
-        Commands::Eval { lesson, format } => commands::eval::run(&lesson, format),
+        Commands::Eval {
+            lesson,
+            format,
+            case,
+        } => commands::eval::run(&lesson, format, case),
         Commands::New { target } => match target {
             NewTarget::Lesson { lang, id } => commands::new::run(lang, &id),
         },

--- a/crates/cli/tests/eval.rs
+++ b/crates/cli/tests/eval.rs
@@ -201,8 +201,7 @@ async fn eval_case_selection_scores_only_the_requested_case() {
         "case 2 is the beta case with its verbatim feedback message"
     );
     assert_eq!(
-        cases[0]["matched"],
-        true,
+        cases[0]["matched"], true,
         "beta expects incorrect and is graded incorrect, so it matches"
     );
 
@@ -281,7 +280,7 @@ async fn eval_case_out_of_range_exits_1_naming_the_suite_size() {
 /// quality, it is not a pass/fail gate, so a low accuracy is not an error
 /// (negative f). Case 3 (gamma) expects correct but is graded incorrect.
 #[tokio::test]
-async fn eval_case_mismatch_exits_0() {
+async fn eval_case_mismatch_exit0() {
     if rscript_absent() {
         return;
     }
@@ -299,8 +298,7 @@ async fn eval_case_mismatch_exits_0() {
     let doc: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("stdout should be exactly one JSON document");
     assert_eq!(
-        doc["cases"][0]["matched"],
-        false,
+        doc["cases"][0]["matched"], false,
         "gamma expects correct but is graded incorrect"
     );
 }
@@ -323,5 +321,9 @@ async fn eval_case_non_numeric_is_a_parse_error_exit_2() {
         .received_requests()
         .await
         .expect("the mock server should record requests");
-    assert_eq!(requests.len(), 0, "a parse failure makes no provider request");
+    assert_eq!(
+        requests.len(),
+        0,
+        "a parse failure makes no provider request"
+    );
 }

--- a/crates/cli/tests/eval.rs
+++ b/crates/cli/tests/eval.rs
@@ -135,6 +135,10 @@ async fn eval_json_emits_per_case_verdicts_and_aggregate() {
                 case["actual"].is_string(),
                 "actual should be a non-null string: {case}"
             );
+            assert!(
+                case["feedback_message"].is_string(),
+                "feedback_message should be a non-null string, never omitted: {case}"
+            );
             let matched = case["matched"]
                 .as_bool()
                 .expect("matched should be a boolean");
@@ -147,4 +151,177 @@ async fn eval_json_emits_per_case_verdicts_and_aggregate() {
         })
         .collect();
     assert_eq!(matched, vec![true, true, false]);
+    // Each case carries its verdict's verbatim message, incl. the Correct
+    // verdict (alpha) — a constant or Incorrect-only message cannot pass.
+    let messages: Vec<&str> = cases
+        .iter()
+        .map(|case| {
+            case["feedback_message"]
+                .as_str()
+                .expect("feedback_message is a string")
+        })
+        .collect();
+    assert_eq!(
+        messages,
+        vec!["alpha looks right", "beta is off", "gamma is off"]
+    );
+}
+
+/// AC3 — `--case N` (1-based) selects a single case, still scored through the
+/// real pipeline, and only the selected case makes a provider request.
+///
+/// `--case 2` must yield exactly one scored case whose verbatim
+/// `feedback_message` is the beta verdict ("beta is off") with `matched: true`.
+/// The wiremock `received_requests` count of exactly one catches a
+/// run-all-then-filter implementation, which would make three requests
+/// (negative g).
+#[tokio::test]
+async fn eval_case_selection_scores_only_the_requested_case() {
+    if rscript_absent() {
+        return;
+    }
+    let server = MockServer::start().await;
+    mount_three_case_provider(&server).await;
+
+    let output = eval_against(&server, &["--format", "json", "--case", "2"]).await;
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "a selected case should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let doc: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be exactly one JSON document");
+    let cases = doc["cases"].as_array().expect("cases should be an array");
+    assert_eq!(cases.len(), 1, "only the requested case is scored");
+    assert_eq!(
+        cases[0]["feedback_message"].as_str(),
+        Some("beta is off"),
+        "case 2 is the beta case with its verbatim feedback message"
+    );
+    assert_eq!(
+        cases[0]["matched"],
+        true,
+        "beta expects incorrect and is graded incorrect, so it matches"
+    );
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("the mock server should record requests");
+    assert_eq!(
+        requests.len(),
+        1,
+        "only the selected case may make a feedback request"
+    );
+}
+
+/// AC4 — `--case 1` selects the FIRST authored case (1-based indexing).
+///
+/// The alpha case expects correct and is graded correct ("alpha looks right");
+/// selecting it by 1 proves the index is 1-based rather than 0-based (a
+/// 0-based implementation would return the beta case for `--case 1`).
+#[tokio::test]
+async fn eval_case_selection_is_one_based() {
+    if rscript_absent() {
+        return;
+    }
+    let server = MockServer::start().await;
+    mount_three_case_provider(&server).await;
+
+    let output = eval_against(&server, &["--format", "json", "--case", "1"]).await;
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "a selected case should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let doc: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be exactly one JSON document");
+    let cases = doc["cases"].as_array().expect("cases should be an array");
+    assert_eq!(cases.len(), 1);
+    assert_eq!(
+        cases[0]["feedback_message"].as_str(),
+        Some("alpha looks right"),
+        "case 1 is the alpha case (1-based indexing)"
+    );
+}
+
+/// AC5 — an out-of-range `--case N` exits 1 and names the suite size on stderr.
+///
+/// Both below the first case (`0`) and past the last (`4`) for a 3-case suite
+/// must be rejected with the suite size `3` named — never clamped (negative d)
+/// and never a bare exit 1 without the size (negative e).
+#[tokio::test]
+async fn eval_case_out_of_range_exits_1_naming_the_suite_size() {
+    if rscript_absent() {
+        return;
+    }
+    let server = MockServer::start().await;
+    mount_three_case_provider(&server).await;
+
+    for bad in ["0", "4"] {
+        let output = eval_against(&server, &["--format", "json", "--case", bad]).await;
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "case {bad} is out of range for a 3-case suite and must exit 1"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        assert!(
+            stderr.contains('3'),
+            "stderr should name the suite size 3, got: {stderr:?}"
+        );
+    }
+}
+
+/// AC6 — a mismatched single case still exits 0: `eval` measures feedback
+/// quality, it is not a pass/fail gate, so a low accuracy is not an error
+/// (negative f). Case 3 (gamma) expects correct but is graded incorrect.
+#[tokio::test]
+async fn eval_case_mismatch_exits_0() {
+    if rscript_absent() {
+        return;
+    }
+    let server = MockServer::start().await;
+    mount_three_case_provider(&server).await;
+
+    let output = eval_against(&server, &["--format", "json", "--case", "3"]).await;
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "a mismatched case is low accuracy, not an error; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let doc: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be exactly one JSON document");
+    assert_eq!(
+        doc["cases"][0]["matched"],
+        false,
+        "gamma expects correct but is graded incorrect"
+    );
+}
+
+/// Decisions — a non-numeric `--case` is a clap parse error (exit 2); only a
+/// numeric-but-out-of-bounds value is our exit-1 error class. No provider
+/// request is ever made for a parse failure.
+#[tokio::test]
+async fn eval_case_non_numeric_is_a_parse_error_exit_2() {
+    let server = MockServer::start().await;
+
+    let output = eval_against(&server, &["--format", "json", "--case", "abc"]).await;
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "a non-numeric --case is a clap parse error, not an out-of-range error"
+    );
+    let requests = server
+        .received_requests()
+        .await
+        .expect("the mock server should record requests");
+    assert_eq!(requests.len(), 0, "a parse failure makes no provider request");
 }

--- a/crates/core/src/eval.rs
+++ b/crates/core/src/eval.rs
@@ -230,30 +230,38 @@ pub fn aggregate(cases: &[CaseResult]) -> f64 {
 }
 
 /// One scored eval case: the expected polarity, the polarity the grader actually
-/// returned, and whether they matched.
+/// returned, whether they matched, and the grader's verbatim feedback message.
 ///
 /// `matched` is derived at construction from the two polarities ([`score_case`]),
 /// never set independently (§1.1): a result cannot claim a match its polarities
-/// contradict. The serialized shape — `expected`, `actual`, `matched` — is the
-/// per-case artifact a built site embeds without re-scoring.
+/// contradict. The serialized shape — `expected`, `actual`, `matched`,
+/// `feedback_message` — is the per-case artifact a built site embeds without
+/// re-scoring; `feedback_message` is a plain `String` (never `Option`), so the
+/// key is always present on the wire (§1.1).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CaseResult {
     expected: ExpectedVerdict,
     actual: ExpectedVerdict,
     matched: bool,
+    feedback_message: String,
 }
 
 impl CaseResult {
-    /// Score a case: reduce the runtime `actual` verdict to its polarity and
-    /// derive `matched` from it and `expected`. The only constructor, so a
-    /// `matched` flag inconsistent with the polarities is unrepresentable.
+    /// Score a case: reduce the runtime `actual` verdict to its polarity, derive
+    /// `matched` from it and `expected`, and capture the verdict's verbatim
+    /// learner-facing message. The only constructor, so a `matched` flag
+    /// inconsistent with the polarities is unrepresentable.
     pub fn score(expected: ExpectedVerdict, actual: &Verdict) -> Self {
+        let feedback_message = match actual {
+            Verdict::Correct { message } | Verdict::Incorrect { message } => message.clone(),
+        };
         let actual = ExpectedVerdict::from(actual);
         let matched = score_case(&expected, &actual);
         Self {
             expected,
             actual,
             matched,
+            feedback_message,
         }
     }
 
@@ -270,6 +278,11 @@ impl CaseResult {
     /// Whether the actual polarity matched the expected one.
     pub fn matched(&self) -> bool {
         self.matched
+    }
+
+    /// The learner-facing feedback the grader produced for this case, verbatim.
+    pub fn feedback_message(&self) -> &str {
+        &self.feedback_message
     }
 }
 
@@ -304,66 +317,129 @@ impl EvalReport {
     }
 }
 
-/// Why scoring an eval suite failed: a case's submission could not be run through
-/// the pipeline — the interpreter failed to launch or the provider call failed.
+/// Why scoring an eval suite failed.
 ///
-/// Names the offending case so an instructor can find it; a scoring run is
-/// all-or-nothing, since a missing verdict cannot be scored as either polarity.
+/// Either a case's submission could not be run through the pipeline — the
+/// interpreter failed to launch or the provider call failed — or a `--case N`
+/// selection was out of range. A scoring run is all-or-nothing, since a missing
+/// verdict cannot be scored as either polarity; the run failure names the
+/// offending case so an instructor can find it.
 #[derive(Debug)]
-pub struct EvalRunError {
-    /// The zero-based index of the case whose run failed, in suite order.
-    pub index: usize,
-    /// The underlying pipeline failure.
-    pub source: RunError,
+pub enum EvalRunError {
+    /// A case's submission failed to run through the pipeline.
+    Run {
+        /// The zero-based index of the case whose run failed, in suite order.
+        index: usize,
+        /// The underlying pipeline failure.
+        source: RunError,
+    },
+    /// A `--case N` selection named a case outside the suite.
+    ///
+    /// Carries the user's requested number and the suite size; the CLI maps this
+    /// to exit 1 with a stderr message naming `suite_size`.
+    CaseOutOfRange {
+        /// The user's requested case number (1-based).
+        requested: usize,
+        /// The number of cases in the suite.
+        suite_size: usize,
+    },
 }
 
 impl fmt::Display for EvalRunError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // One-based for the instructor, matching the report's `case N` rows; the
-        // field stays a zero-based index. (Slice-12's `EvalParseError` reports the
-        // zero-based logical index instead — a parse-time developer concern, its
-        // tested contract left untouched here.)
-        write!(
-            f,
-            "eval case {} failed to run: {}",
-            self.index + 1,
-            self.source
-        )
+        match self {
+            EvalRunError::Run { index, source } => {
+                // One-based for the instructor, matching the report's `case N`
+                // rows; the field stays a zero-based index. (Slice-12's
+                // `EvalParseError` reports the zero-based logical index instead —
+                // a parse-time developer concern, its tested contract left
+                // untouched here.)
+                write!(f, "eval case {} failed to run: {}", index + 1, source)
+            }
+            EvalRunError::CaseOutOfRange {
+                requested,
+                suite_size,
+            } => write!(
+                f,
+                "eval case {requested} is out of range: the suite has {suite_size} case(s)"
+            ),
+        }
     }
 }
 
 impl Error for EvalRunError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        Some(&self.source)
+        match self {
+            EvalRunError::Run { source, .. } => Some(source),
+            // A range error is self-contained: the request was rejected before
+            // any pipeline run, so there is no underlying failure to chain.
+            EvalRunError::CaseOutOfRange { .. } => None,
+        }
     }
 }
 
 /// Run every case in `suite` through the same pipeline `run` uses and score each
-/// verdict against its expected polarity.
+/// verdict against its expected polarity — or, when `case` is `Some(n)`, only
+/// the one 1-based case `n`.
 ///
 /// The thin effectful shell over the pure scorer (§2.4): for each case it runs
 /// the submission through [`run_lesson`] — execute, grade, ask `provider` for a
 /// verdict — then pairs the verdict's polarity with the expected one as a
 /// [`CaseResult`]. Driving the *same* `run_lesson` is what keeps the evaluated
-/// feedback identical to the shipped feedback (§3.2). A run failure stops scoring
-/// and names the offending case ([`EvalRunError`]); `base_url_override` points
-/// the provider at a stub in tests, exactly as `run` does, and is `None` in
+/// feedback identical to the shipped feedback (§3.2). An out-of-range `case`
+/// selection is rejected up front with [`EvalRunError::CaseOutOfRange`] — never
+/// clamped — before any case runs; a run failure stops scoring and names the
+/// offending case ([`EvalRunError::Run`]). `base_url_override` points the
+/// provider at a stub in tests, exactly as `run` does, and is `None` in
 /// production.
 pub async fn run_eval(
     lesson: &Lesson,
     suite: &EvalSuite,
     provider: ProviderChoice,
     base_url_override: Option<&str>,
+    case: Option<usize>,
 ) -> Result<EvalReport, EvalRunError> {
-    let mut cases = Vec::with_capacity(suite.cases.len());
-    for (index, case) in suite.cases.iter().enumerate() {
-        let submission = Submission::new(case.submission.clone());
+    let selected = case
+        .map(|requested| select_case_index(suite.cases.len(), requested))
+        .transpose()?;
+    let mut cases = Vec::with_capacity(if selected.is_some() {
+        1
+    } else {
+        suite.cases.len()
+    });
+    for (index, suite_case) in suite.cases.iter().enumerate() {
+        if let Some(selected_index) = selected
+            && index != selected_index
+        {
+            continue;
+        }
+        let submission = Submission::new(suite_case.submission.clone());
         let report = run_lesson(lesson, &submission, provider, base_url_override)
             .await
-            .map_err(|source| EvalRunError { index, source })?;
-        cases.push(CaseResult::score(case.expected.clone(), report.verdict()));
+            .map_err(|source| EvalRunError::Run { index, source })?;
+        cases.push(CaseResult::score(
+            suite_case.expected.clone(),
+            report.verdict(),
+        ));
     }
     Ok(EvalReport::new(cases))
+}
+
+/// Resolve a 1-based `--case N` request against the suite size to the zero-based
+/// index to select, or reject it as out of range.
+///
+/// The single validation point for case selection (§5): `0` and any value past
+/// the last case are rejected (never clamped) with an error carrying both the
+/// user's requested number and the suite size, so the CLI can exit 1 naming the
+/// size. Pure and total, so it is unit-testable in `core` without a CLI harness.
+fn select_case_index(suite_size: usize, requested: usize) -> Result<usize, EvalRunError> {
+    if requested == 0 || requested > suite_size {
+        return Err(EvalRunError::CaseOutOfRange {
+            requested,
+            suite_size,
+        });
+    }
+    Ok(requested - 1)
 }
 
 #[cfg(test)]
@@ -530,7 +606,7 @@ mod tests {
         use crate::llm::FeedbackError;
         use crate::run::RunError;
 
-        let err = EvalRunError {
+        let err = EvalRunError::Run {
             index: 2,
             source: RunError::Feedback(FeedbackError::MissingApiKey {
                 var: "FIREWORKS_API_KEY",
@@ -624,9 +700,9 @@ mod tests {
     fn case_selection_maps_one_based_requests_to_zero_based_indices() {
         // `--case N` is 1-based: the alpha (first) case is 1, beta is 2, gamma
         // is 3. A 0-based or clamped-to-first implementation cannot pass.
-        assert_eq!(select_case_index(3, 1), Ok(0));
-        assert_eq!(select_case_index(3, 2), Ok(1));
-        assert_eq!(select_case_index(3, 3), Ok(2));
+        assert!(matches!(select_case_index(3, 1), Ok(0)));
+        assert!(matches!(select_case_index(3, 2), Ok(1)));
+        assert!(matches!(select_case_index(3, 3), Ok(2)));
     }
 
     #[test]

--- a/crates/core/src/eval.rs
+++ b/crates/core/src/eval.rs
@@ -567,4 +567,106 @@ mod tests {
             format!("{:?}", ExpectedVerdict::INCORRECT_TOKEN)
         );
     }
+
+    #[test]
+    fn eval_feedback_message_carries_the_verdict_message_verbatim() {
+        // The per-case `feedback_message` is the runtime verdict's message,
+        // captured for BOTH polarities — a message captured only for Incorrect
+        // verdicts (negative h) or a constant across cases (negative a) cannot
+        // pass.
+        let correct = CaseResult::score(ExpectedVerdict::Correct, &correct());
+        assert_eq!(correct.feedback_message(), "well done");
+        let incorrect = CaseResult::score(ExpectedVerdict::Incorrect, &incorrect());
+        assert_eq!(incorrect.feedback_message(), "try again");
+    }
+
+    #[test]
+    fn eval_feedback_message_serializes_per_case_never_null_or_omitted() {
+        // The JSON artifact must carry a String `feedback_message` on every case
+        // — never null, never omitted, verbatim. An `Option<String>` field or a
+        // `skip_serializing_if` would break this contract.
+        let report = EvalReport::new(vec![
+            CaseResult::score(ExpectedVerdict::Correct, &correct()),
+            CaseResult::score(ExpectedVerdict::Incorrect, &incorrect()),
+        ]);
+        let json = serde_json::to_value(&report).expect("an EvalReport serializes infallibly");
+        let cases = json["cases"].as_array().expect("cases is an array");
+        assert_eq!(cases.len(), 2);
+        for case in cases {
+            assert!(
+                case["feedback_message"].is_string(),
+                "feedback_message must be a non-null string: {case}"
+            );
+        }
+        assert_eq!(cases[0]["feedback_message"], "well done");
+        assert_eq!(cases[1]["feedback_message"], "try again");
+    }
+
+    #[test]
+    fn eval_no_skip_serializing_if_keeps_the_empty_message_key() {
+        // An empty message must still serialize the `feedback_message` key:
+        // `skip_serializing_if` would drop it and break the never-omitted
+        // contract (predicate 2).
+        let result = CaseResult::score(
+            ExpectedVerdict::Correct,
+            &Verdict::Correct {
+                message: String::new(),
+            },
+        );
+        let json = serde_json::to_string(&result).expect("a CaseResult serializes infallibly");
+        assert!(
+            json.contains("\"feedback_message\":\"\""),
+            "an empty feedback_message must serialize as a present key: {json}"
+        );
+    }
+
+    #[test]
+    fn case_selection_maps_one_based_requests_to_zero_based_indices() {
+        // `--case N` is 1-based: the alpha (first) case is 1, beta is 2, gamma
+        // is 3. A 0-based or clamped-to-first implementation cannot pass.
+        assert_eq!(select_case_index(3, 1), Ok(0));
+        assert_eq!(select_case_index(3, 2), Ok(1));
+        assert_eq!(select_case_index(3, 3), Ok(2));
+    }
+
+    #[test]
+    fn case_selection_rejects_zero_and_past_the_end_naming_the_suite_size() {
+        // Out-of-range requests are rejected (never clamped) and the error
+        // carries both the requested number and the suite size (negative d/e).
+        assert!(matches!(
+            select_case_index(3, 0),
+            Err(EvalRunError::CaseOutOfRange {
+                requested: 0,
+                suite_size: 3
+            })
+        ));
+        assert!(matches!(
+            select_case_index(3, 4),
+            Err(EvalRunError::CaseOutOfRange {
+                requested: 4,
+                suite_size: 3
+            })
+        ));
+    }
+
+    #[test]
+    fn case_out_of_range_error_names_requested_case_and_suite_size() {
+        let err = EvalRunError::CaseOutOfRange {
+            requested: 4,
+            suite_size: 3,
+        };
+        let message = err.to_string();
+        assert!(
+            message.contains("4"),
+            "should name the requested case: {message}"
+        );
+        assert!(
+            message.contains("3"),
+            "should name the suite size: {message}"
+        );
+        assert!(
+            std::error::Error::source(&err).is_none(),
+            "a range error has no underlying pipeline failure to chain"
+        );
+    }
 }

--- a/docs/evidence/194/README.md
+++ b/docs/evidence/194/README.md
@@ -1,0 +1,54 @@
+# Issue #194 — E2E Evidence
+
+eval AC-1: extend `blendtutor eval --format json` to carry per-case
+`feedback_message` (String, always present, verbatim) + `--case N` single-case
+selection (1-based). Out-of-range N → exit 1 naming suite size. Exit-code
+semantics unchanged (low accuracy still exits 0). eval-report.json shape
+consumed by build unchanged (additive field only).
+
+Verification: code · cargo nextest (unit + wiremock integration). nextest is
+not installed locally; the spec probe filters were run with `cargo test` (same
+test-name matching). CI (ci.yml) runs `cargo nextest run --locked` as the gate.
+
+## What changed
+
+1. **`feedback_message` on every `CaseResult`** — captured at score time from
+   the runtime `Verdict` for BOTH variants (`Correct` and `Incorrect`), stored
+   as a plain `String` (never `Option`), serialized with no `skip_serializing_if`
+   so an empty message still emits the `"feedback_message":""` key.
+2. **`--case N` single-case selection** — `run_eval` gains `case: Option<usize>`
+   (1-based). A single pure validation point (`select_case_index`) rejects `0`
+   and past-the-end values via `EvalRunError::CaseOutOfRange { requested,
+   suite_size }`; the CLI propagates it as exit 1 with stderr naming the suite
+   size. Non-numeric `--case` stays a clap parse error (exit 2).
+3. **`EvalRunError` struct → enum** (`Run` | `CaseOutOfRange`).
+
+## Evidence artifacts
+
+| Artifact | Contents |
+|----------|----------|
+| `run.log` | Real binary against a live local mock provider: bare JSON run, `--case 1/2/3` JSON, `--case 2` human, `--case 0`/`--case 4` (exit 1 + stderr naming `3`), `--case abc` (exit 2). Mock request log proves exactly one provider request per scored case (7 requests for 7 scored cases; zero for rejected selections — not run-all-then-filter) |
+| `test-suite.log` | All five spec probe filters: `eval_feedback_message` (2), `eval_no_skip_serializing_if` (1), `eval_case_selection` (2), `eval_case_out_of_range` (1), `eval_case_mismatch_exit0` (1) — all ok |
+
+## Probe runs
+
+| Command | Result |
+|---------|--------|
+| `cargo test -p blendtutor-core --lib eval_feedback_message` | ok (2 passed) |
+| `cargo test -p blendtutor-core --lib eval_no_skip_serializing_if` | ok (1 passed) |
+| `cargo test -p blendtutor-cli --test eval eval_case_selection` | ok (2 passed) |
+| `cargo test -p blendtutor-cli --test eval eval_case_out_of_range` | ok (1 passed) |
+| `cargo test -p blendtutor-cli --test eval eval_case_mismatch_exit0` | ok (1 passed) |
+| `cargo test --workspace` | all green (183 core lib tests + full cli suite, 0 failed) |
+| `cargo clippy --all-targets --locked -- -D warnings` | clean |
+| `cargo fmt --all --check` | clean |
+
+## Notes
+
+- `crates/core/src/llm/feedback.rs` untouched — the message is read inline in
+  `CaseResult::score` via an exhaustive match on `Verdict` (design intent §4).
+- `scripts/eval-course.sh` reads `.cases[].matched` + `.accuracy` via jq —
+  additive `feedback_message` field is safe; no eval-report.json shape change.
+- `ExpectedVerdict` stays polarity-only (existing
+  `verdict_polarity_drops_the_feedback_message` test unchanged and green).
+- Human render unchanged (snapshot stays valid).

--- a/docs/evidence/194/run.log
+++ b/docs/evidence/194/run.log
@@ -1,0 +1,52 @@
+# blendtutor eval — E2E run log (issue #194)
+# provider: local mock server (mock_provider.py), key: FIREWORKS_API_KEY=test-key
+# lesson: crates/core/tests/fixtures/eval_command/demo_lesson.yaml (3-case suite)
+
+=== $ /Users/carbonite/Documents/coding/portfolio/worktree-issue-194/target/debug/blendtutor eval /Users/carbonite/Documents/coding/portfolio/worktree-issue-194/crates/core/tests/fixtures/eval_command/demo_lesson.yaml --format json ===
+{"cases":[{"expected":"correct","actual":"correct","matched":true,"feedback_message":"alpha looks right"},{"expected":"incorrect","actual":"incorrect","matched":true,"feedback_message":"beta is off"},{"expected":"correct","actual":"incorrect","matched":false,"feedback_message":"gamma is off"}],"accuracy":0.6666666666666666}
+--- exit code: 0 ---
+
+=== $ /Users/carbonite/Documents/coding/portfolio/worktree-issue-194/target/debug/blendtutor eval /Users/carbonite/Documents/coding/portfolio/worktree-issue-194/crates/core/tests/fixtures/eval_command/demo_lesson.yaml --format json --case 1 ===
+{"cases":[{"expected":"correct","actual":"correct","matched":true,"feedback_message":"alpha looks right"}],"accuracy":1.0}
+--- exit code: 0 ---
+
+=== $ /Users/carbonite/Documents/coding/portfolio/worktree-issue-194/target/debug/blendtutor eval /Users/carbonite/Documents/coding/portfolio/worktree-issue-194/crates/core/tests/fixtures/eval_command/demo_lesson.yaml --format json --case 2 ===
+{"cases":[{"expected":"incorrect","actual":"incorrect","matched":true,"feedback_message":"beta is off"}],"accuracy":1.0}
+--- exit code: 0 ---
+
+=== $ /Users/carbonite/Documents/coding/portfolio/worktree-issue-194/target/debug/blendtutor eval /Users/carbonite/Documents/coding/portfolio/worktree-issue-194/crates/core/tests/fixtures/eval_command/demo_lesson.yaml --format json --case 3 ===
+{"cases":[{"expected":"correct","actual":"incorrect","matched":false,"feedback_message":"gamma is off"}],"accuracy":0.0}
+--- exit code: 0 ---
+
+=== $ /Users/carbonite/Documents/coding/portfolio/worktree-issue-194/target/debug/blendtutor eval /Users/carbonite/Documents/coding/portfolio/worktree-issue-194/crates/core/tests/fixtures/eval_command/demo_lesson.yaml --case 2 ===
+Accuracy: 1/1 (100.0%)
+
+case 1: expected incorrect, got incorrect [match]
+--- exit code: 0 ---
+
+=== $ /Users/carbonite/Documents/coding/portfolio/worktree-issue-194/target/debug/blendtutor eval /Users/carbonite/Documents/coding/portfolio/worktree-issue-194/crates/core/tests/fixtures/eval_command/demo_lesson.yaml --format json --case 0 ===
+--- exit code: 1 ---
+--- stderr ---
+Error: eval case 0 is out of range: the suite has 3 case(s)
+
+=== $ /Users/carbonite/Documents/coding/portfolio/worktree-issue-194/target/debug/blendtutor eval /Users/carbonite/Documents/coding/portfolio/worktree-issue-194/crates/core/tests/fixtures/eval_command/demo_lesson.yaml --format json --case 4 ===
+--- exit code: 1 ---
+--- stderr ---
+Error: eval case 4 is out of range: the suite has 3 case(s)
+
+=== $ /Users/carbonite/Documents/coding/portfolio/worktree-issue-194/target/debug/blendtutor eval /Users/carbonite/Documents/coding/portfolio/worktree-issue-194/crates/core/tests/fixtures/eval_command/demo_lesson.yaml --format json --case abc ===
+--- exit code: 2 ---
+--- stderr ---
+error: invalid value 'abc' for '--case <CASE>': invalid digit found in string
+
+For more information, try '--help'.
+
+=== mock provider request log (one request per scored case) ===
+mock provider listening on 127.0.0.1:18492
+request 1: token='alpha' -> 'alpha looks right'
+request 2: token='beta' -> 'beta is off'
+request 3: token='gamma' -> 'gamma is off'
+request 4: token='alpha' -> 'alpha looks right'
+request 5: token='beta' -> 'beta is off'
+request 6: token='gamma' -> 'gamma is off'
+request 7: token='beta' -> 'beta is off'

--- a/docs/evidence/194/test-suite.log
+++ b/docs/evidence/194/test-suite.log
@@ -1,0 +1,54 @@
+# Issue #194 — probe test runs (cargo test, nextest filters; nextest not installed locally, CI runs it)
+# commands: the spec probe filters, run via cargo test (same test-name matching)
+
+## cargo test -p blendtutor-core --lib eval_feedback_message
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.10s
+     Running unittests src/lib.rs (target/debug/deps/blendtutor_core-173cbe489141f8dc)
+
+running 2 tests
+test eval::tests::eval_feedback_message_carries_the_verdict_message_verbatim ... ok
+test eval::tests::eval_feedback_message_serializes_per_case_never_null_or_omitted ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 181 filtered out; finished in 0.00s
+
+
+## cargo test -p blendtutor-core --lib eval_no_skip_serializing_if
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.07s
+     Running unittests src/lib.rs (target/debug/deps/blendtutor_core-173cbe489141f8dc)
+
+running 1 test
+test eval::tests::eval_no_skip_serializing_if_keeps_the_empty_message_key ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 182 filtered out; finished in 0.00s
+
+
+## cargo test -p blendtutor-cli --test eval eval_case_selection -- --nocapture
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running tests/eval.rs (target/debug/deps/eval-93ad8e799f24424c)
+
+running 2 tests
+test eval_case_selection_scores_only_the_requested_case ... ok
+test eval_case_selection_is_one_based ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.44s
+
+
+## cargo test -p blendtutor-cli --test eval eval_case_out_of_range -- --nocapture
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
+     Running tests/eval.rs (target/debug/deps/eval-93ad8e799f24424c)
+
+running 1 test
+test eval_case_out_of_range_exits_1_naming_the_suite_size ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.34s
+
+
+## cargo test -p blendtutor-cli --test eval eval_case_mismatch_exit0 -- --nocapture
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running tests/eval.rs (target/debug/deps/eval-93ad8e799f24424c)
+
+running 1 test
+test eval_case_mismatch_exit0 ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.42s
+


### PR DESCRIPTION
## Summary
Extends `blendtutor eval` per issue #194:

1. **`feedback_message` on every case** — `CaseResult` now carries the grader's verbatim learner-facing message (plain `String`, never `Option`/null), captured at score time from both `Verdict` variants. Serialized with **no** `skip_serializing_if`, so an empty message still emits `"feedback_message":""`. Additive to the existing `eval-report.json` shape — `scripts/eval-course.sh` (jq on `.matched`/`.accuracy`) and the site consumer are unaffected.
2. **`--case N` single-case selection (1-based)** — `run_eval` gains `case: Option<usize>`; a single pure validation point (`select_case_index`) rejects `0` and past-the-end requests via `EvalRunError::CaseOutOfRange { requested, suite_size }`, propagated by the CLI as **exit 1 with stderr naming the suite size**. Non-numeric `--case` stays a clap parse error (**exit 2**). Only the selected case makes a provider request (no run-all-then-filter).
3. **`EvalRunError` struct → enum** (`Run` | `CaseOutOfRange`); the run-failure variant keeps its original suite index under selection (never a post-filter index).

Exit-code semantics unchanged: a mismatched/low-accuracy case still exits 0.

## Issue
Closes #194

## ACs implemented
- [x] `eval <lesson> --format json` → every `cases[i].feedback_message` present, String-typed, verbatim (incl. Correct verdicts)
- [x] No `skip_serializing_if` — empty message still emits `"feedback_message":""`
- [x] `--case 2` → `cases.len()==1`, `"beta is off"`, `matched==true`, wiremock `received_requests==1`
- [x] `--case 1` → alpha case (1-based verified)
- [x] `--case 0` and `--case 4` → exit 1, stderr names suite size `3`
- [x] `--case 3` (mismatch) → exit 0 (exit-code semantics unchanged)
- [x] Backward compat: bare run 2/3, `matched [true,true,false]`; `ExpectedVerdict` polarity-only (existing tests hold)

## Test plan
- [x] Core unit: `eval_feedback_message` (2), `eval_no_skip_serializing_if` (1), case-index mapping/rejection, `CaseOutOfRange` display
- [x] CLI wiremock integration: `eval_case_selection` (2), `eval_case_out_of_range` (1), `eval_case_mismatch_exit0` (1), non-numeric → exit 2
- [x] Full workspace: `cargo test --workspace` green; `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean
- [x] E2E evidence: `docs/evidence/194/run.log` (real binary vs live mock provider: JSON outputs, exit codes, stderr, one provider request per scored case) + `test-suite.log` (all 5 spec probe filters)

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested (all of a–k)
- [x] Verification medium satisfied (code)
- [x] Design intent respected (§1–§5; feedback.rs untouched)
- [x] No scope creep