### PR TITLE
[feat] smevals runner (run.sh) + deterministic polarity checker (check_polarity.sh)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,13 @@ jobs:
       - name: Model alignment
         run: ./scripts/check-model-alignment.sh
 
+      # Issue #196 — smevals runner (run.sh) + deterministic polarity checker
+      # (check_polarity.sh): env→argv wiring, verdict header contract,
+      # transient-only retry with per-call timeout, fail-closed checker.
+      # Stub-based shell BDD; needs only bash + jq + GNU timeout (ubuntu).
+      - name: smevals runner test
+        run: bash scripts/tests/test_smevals_runner.sh
+
   quarto-render:
     name: quarto render
     runs-on: ubuntu-latest

--- a/.opencode/plans/smevals-eval-report/AC-3.md
+++ b/.opencode/plans/smevals-eval-report/AC-3.md
@@ -1,0 +1,84 @@
+---
+ac: 3
+depends_on: AC-1, AC-2
+risk: low
+status: complete
+---
+
+## AC spec: smevals runner script (run.sh) + deterministic polarity checker (check_polarity.sh)
+
+### Executable Spec
+- **predicate:** 17 clauses, all must hold:
+  1. **Env→argv wiring:** stub blendtutor on PATH asserts it receives `eval <lesson> --case N --format json` built from SMEVALS_TASK_LESSON/SMEVALS_TASK_CASE; stub counter file proves the stub was invoked (no canned output).
+  2. **No cargo run:** `grep -c 'cargo run' scripts/smevals/*.sh == 0` — runner resolves blendtutor from PATH.
+  3. **Header contract:** on success, runner stdout line 1 == `verdict: correct|incorrect` (exact, lowercase); lines 2+ == feedback_message byte-exact, multi-line preserved (jq -r '.cases[0].feedback_message').
+  4. **Source-of-truth = .actual, NOT .matched:** inconsistent-JSON stub (.cases[0].actual=="incorrect", .matched==true) MUST produce `verdict: incorrect`.
+  5. **Four polarity combinations:** expected x actual in {correct, incorrect}² → checker exit 0 on the two matches, non-zero on the two mismatches.
+  6. **Line-1-only parsing:** output file with `verdict: ` on line 2+ MUST NOT confuse the checker — parse head -1 / read -r line 1 only, no grep.
+  7. **Fail-closed on malformed header:** `verdict: maybe`, `verdict:` (empty), `verdict:correct` (no space), 0-byte output → checker non-zero.
+  8. **Case-sensitive token:** `verdict: Correct` → checker fails closed.
+  9. **Bounded retry, transient only:** retry (max 3 attempts, sleep 2 backoff) on blendtutor exit-1, empty stdout, or malformed JSON; NO retry on well-formed mismatch verdict — stub counter shows exactly 1 call on valid JSON with mismatched verdict.
+  10. **Backoff wall-time:** retry-then-fail scenario (stub always exits 1) takes >= 4s wall-clock.
+  11. **Per-call timeout:** invocation wrapped in `timeout "${SMEVALS_TIMEOUT:-120}"`; exit 124 treated as transient → retry. Test overrides SMEVALS_TIMEOUT=2 with a sleep 5 stub (proves timeout path in ~10s, not 2-min waits).
+  12. **Missing env → usage error:** unset SMEVALS_TASK_LESSON/SMEVALS_TASK_CASE → non-zero exit naming the missing variable on stderr.
+  13. **FIREWORKS_API_KEY propagation:** no env -i / env scrubbing in runner — stub asserts the var is visible in its environment when set by the caller.
+  14. **Empty feedback_message:** valid JSON with feedback_message: "" → header line emitted, zero following lines, runner exit 0.
+  15. **command -v jq guard:** jq absent from PATH → runner exits non-zero naming jq.
+  16. **Hygiene:** both scripts start with `set -euo pipefail`.
+  17. **required:true path contract:** the checker path recorded in the AC-2-generated graders/default.yaml template == the actual checker script path (cross-file assert: grep -F of the literal path against the generator source and the real file).
+- **probe:** `bash scripts/tests/test_smevals_runner.sh` (shell BDD, stub-on-PATH + counter-file pattern per scripts/tests/eval-course.sh:83-137; ok/ko/assert_eq helpers; mktemp -d + trap rm -rf; cd "$(git rev-parse --show-toplevel)"; set -euo pipefail). CI: step added to `.github/workflows/ci.yml` (`run: bash scripts/tests/test_smevals_runner.sh`).
+- **negative:** Stub emitting inconsistent JSON (.actual=incorrect, .matched=true) with message body containing `verdict: correct` on line 3 — a sneaky-pass runner reading .matched or grep-scanning for verdict: produces the wrong polarity and the checker wrongly exits 0. Correct: verdict = incorrect from line-1 header derived from .actual; checker compares against SMEVALS_TASK_EXPECTED exactly.
+- **verification:** code · shell BDD test with stub-on-PATH pattern
+- **fixture status:** NEW — scripts/smevals/run.sh (runner), scripts/smevals/check_polarity.sh (checker), scripts/tests/test_smevals_runner.sh (test). Conventions anchor: scripts/tests/eval-course.sh:83-137 (existing). NOTE: script names pinned run.sh + check_polarity.sh — AC-2's generator template (configs/default.yaml runner path + graders/default.yaml checker path) emits these exact relative paths.
+- **rubric anchor:** §2 (pure polarity-checker logic shell-testable; effectful LLM call isolated in runner), §5 (single-responsibility scripts)
+
+### Design Intent
+- **Types (§1):** verdict channel is a two-token contract — line-1 header `verdict: correct|incorrect`, body verbatim; malformed header unrepresentable to checker (fail-closed).
+- **Pure / effectful (§2):** checker = pure comparator (output.txt x SMEVALS_TASK_EXPECTED → exit code); runner = thin effectful shell (blendtutor invocation + retry loop + timeout).
+- **Boundary cuts (§3):** scripts/smevals/ owns the smevals-facing boundary; core eval logic stays in Rust; jq is the only JSON boundary tool.
+- **Module responsibility (§4):** runner: env→argv, timeout, retry-on-transient, header emission. Checker: line-1 parse, exact case-sensitive comparison, required:true.
+- **Function discipline (§5):** one concern per script; the runner's retry loop and the checker's line-1 parse are each directly stub-testable.
+
+### Technical Context
+- **Files touched:**
+  - `scripts/smevals/run.sh` — NEW. Reads the smevals task contract env (verified against real smevals 0.2.0: SMEVALS_MODEL, SMEVALS_PROMPT, SMEVALS_TASK_LESSON, SMEVALS_TASK_CASE, SMEVALS_TASK_EXPECTED all set; SMEVALS_RUN_DIR set for checker), invokes `blendtutor eval <lesson> --case N --format json` under `timeout "${SMEVALS_TIMEOUT:-120}"`, parses `.cases[0].actual` (source of truth) + `.cases[0].feedback_message` via jq, emits `verdict: <actual>` + verbatim message. Retries only exit-1 / 124 / empty-stdout / malformed-JSON, 3 attempts, 2s backoff. Requires all five task env vars fail-closed (missing → named on stderr). jq guard first.
+  - `scripts/smevals/check_polarity.sh` — NEW. Reads output file (argv 1, else `${SMEVALS_RUN_DIR:-}/output.txt`), takes line 1 ONLY, matches the full-line grammar `verdict: correct|incorrect` exactly (anything else fails closed), compares against SMEVALS_TASK_EXPECTED, emits `{"score": 1.0|0.0, "notes": ...}` and exits 0/1 (smevals grader contract, `required: true` in graders/default.yaml).
+  - `scripts/tests/test_smevals_runner.sh` — NEW shell BDD test. Stub blendtutor (asserts argv contract + counter file) + GNU-compatible `timeout` shim on PATH (macOS lacks coreutils timeout; CI ubuntu has real one — shim shadows it deterministically in tests).
+  - `.github/workflows/ci.yml` — add `smevals runner test` step to the `check` job (bash + jq + GNU timeout on ubuntu-latest; the test needs no quarto).
+  - `.opencode/plans/smevals-eval-report/AC-3.md` — this plan.
+  - `docs/evidence/196/` — E2E evidence.
+- **Env contract provenance:** real-smevals probe (AC-2 eval dir + env-dumping stub runner) confirmed smevals 0.2.0 sets SMEVALS_MODEL / SMEVALS_PROMPT / SMEVALS_TASK_LESSON / SMEVALS_TASK_CASE / SMEVALS_TASK_EXPECTED / SMEVALS_RUN_DIR (absolute), and passes FIREWORKS_API_KEY through unchanged.
+- **JSON shape:** `blendtutor eval <lesson> --case N --format json` → `{"cases":[{"expected","actual","matched","feedback_message"}],"accuracy"}` (crates/core/src/eval.rs:240-258; actual = lowercase token via ExpectedVerdict::token()). matched is derived via score_case, never independently set.
+- **Test migration:** 0 files — new scripts + new test; no existing symbol changed.
+
+### Dependencies
+- **Depends on:** AC-1 (#194 — `eval --case N --format json` + feedback_message + .actual token), AC-2 (#195 — generated .smevals/ layout, graders/default.yaml + configs/default.yaml templates with exact script paths).
+- **Blocks:** LLM-judge (AC-4, slots into same graders/default.yaml), eval-report (AC-5).
+- **Conflict set:** scripts/smevals/, scripts/tests/test_smevals_runner.sh, AC-2's graders/configs templates (path contract — read-only for AC-3).
+- **Risk level:** low — shell-only, no Rust changes; cross-AC path contract is pinned by predicate 17 and AC-2's own integration tests.
+
+### Progress
+- [x] spec written (Director) — 2026-08-08
+- [x] red test (test_smevals_runner.sh — runner missing → 127) — 2026-08-08
+- [x] green: run.sh + check_polarity.sh — 48/48 assertions — 2026-08-08
+- [x] CI step added to .github/workflows/ci.yml (check job) — 2026-08-08
+- [x] E2E evidence docs/evidence/196/ (test-suite.log + real-smevals probe) — 2026-08-08
+- [x] full workspace cargo test green (no crates/ changes) — 2026-08-08
+
+### Decision Log
+- 2026-08-08 — required env set: all five task-contract vars (LESSON/CASE/MODEL/PROMPT/EXPECTED) required fail-closed, first missing named on stderr. Predicate 12 pins LESSON/CASE naming; the rest are the full "reads" contract from the issue summary, and the real-smevals probe proved all five are always set.
+- 2026-08-08 — MODEL/PROMPT/EXPECTED validated but not consumed: blendtutor eval derives the model from the provider default (single-sourced to the same value as configs/default.yaml) and the submission from the eval suite file — no drift possible, so forwarding them into argv would be wrong.
+- 2026-08-08 — timeout shim: local macOS lacks GNU `timeout`; the test ships a GNU-compatible shim (SIGTERM after N s → exit 124) on PATH FIRST so behavior is deterministic on both macOS and CI ubuntu (which shadows with the real coreutils timeout).
+- 2026-08-08 — checker output-file resolution: argv 1 if given, else `${SMEVALS_RUN_DIR:-}/output.txt` — argv keeps tests hermetic; SMEVALS_RUN_DIR is the real-smevals contract (proven by the AC-2 smoke).
+
+### Surprises & Discoveries
+- 2026-08-08 — Local macOS has NO GNU `timeout` (CI ubuntu does), yet the binding decision wraps blendtutor in `timeout "${SMEVALS_TIMEOUT:-120}"`. The test ships a GNU-compatible `timeout` shim on PATH FIRST so the timeout path is deterministic on both platforms. First shim draft HUNG the suite: `kill $pid` on the stub orphans its inner `sleep 5` (bash doesn't exec), and the orphan keeps the runner's command-substitution stdout pipe open → each attempt cost ~5s instead of ~2s (19s observed vs 10s expected). Fix: `set -m` + process-group kill `kill -TERM -$pid` takes the whole tree down together; the killer subshell also redirects its fds so it can never hold the pipe.
+- 2026-08-08 — The smevals 0.2.0 env contract is now empirically pinned, not assumed: an env-dumping stub runner under real `uvx smevals==0.2.0 run` showed SMEVALS_MODEL / SMEVALS_PROMPT / SMEVALS_TASK_LESSON / SMEVALS_TASK_CASE / SMEVALS_TASK_EXPECTED / SMEVALS_RUN_DIR (absolute) all set, and FIREWORKS_API_KEY passed through unscrubbed. This de-risked requiring all five in the runner (fail-closed, first-missing named).
+- 2026-08-08 — `grep -c` exits 1 on zero matches. With `set -o pipefail` in the test, the predicate-2 count assertion silently killed the whole test script (no FAIL line — just a dying `$(...)`). Fixed with `{ grep ... || true; } | awk`; naive `| ... || echo 0` double-prints and failed the assert with a stray newline.
+- 2026-08-08 — Predicate-2 self-trap: the runner's own docstring contained the literal string "cargo run" ("…resolving blendtutor from PATH (never cargo run)") — the spec's `grep -c 'cargo run' scripts/smevals/*.sh == 0` matched it. Reworded to "never an in-tree build invocation".
+- 2026-08-08 — `smevals run -g <path>`: `-g` consumes the next arg as its grader value, so the eval path MUST precede `-g` (`smevals run <path> -g`). Harmless CLI quirk that cost a probe cycle.
+- 2026-08-08 — The AC-2 smoke temp dir (`/var/folders/.../smevals-e2e-76934/repo`) survived and was reused for the real-tool E2E probe: real smevals 0.2.0 + AC-2-generated templates + MY real run.sh/check_polarity.sh, with only the blendtutor LLM call stubbed. Run A (match) → 3/3 pass exit 0; Run B (mismatch) → 3/3 fail exit 1, `grade.yaml` shows `ok: false / notes: polarity mismatch` — the `required: true` halt proven end-to-end. Worth noting the generator's `lesson:` value is the slug (`demo_lesson`), which the runner forwards verbatim as the eval arg.
+
+### Idempotence & Recovery
+- Safe retry: re-run `bash scripts/tests/test_smevals_runner.sh` — hermetic (mktemp + trap, stub-on-PATH). Idempotent.
+- Rollback: delete scripts/smevals/run.sh + check_polarity.sh + test + CI step.

--- a/docs/evidence/196/README.md
+++ b/docs/evidence/196/README.md
@@ -1,0 +1,70 @@
+# Issue #196 — E2E Evidence
+
+AC-3: shared smevals runner script (`scripts/smevals/run.sh`) + deterministic
+polarity checker (`scripts/smevals/check_polarity.sh`) wired into the
+AC-2-generated `graders/default.yaml` template (`required: true`). Verification:
+code — stub-based shell BDD + real-tool E2E.
+
+## What changed
+
+1. **`scripts/smevals/run.sh`** — the smevals runner. Reads the smevals task
+   contract env (all five vars verified set by real smevals 0.2.0:
+   `SMEVALS_MODEL`, `SMEVALS_PROMPT`, `SMEVALS_TASK_LESSON`,
+   `SMEVALS_TASK_CASE`, `SMEVALS_TASK_EXPECTED`), invokes
+   `blendtutor eval <lesson> --case N --format json` (AC-1) under a per-call
+   `timeout "${SMEVALS_TIMEOUT:-120}"`, and emits the verdict header + verbatim
+   feedback to stdout (smevals saves it as `output.txt`). Verdict comes from the
+   JSON `.cases[0].actual` token — the source of truth, never `.matched`.
+   Bounded transient-only retry: 3 attempts, 2s backoff, retrying exit-1,
+   timeout-124, empty stdout, and malformed JSON; a well-formed run never
+   retries. No env scrubbing (FIREWORKS_API_KEY reaches blendtutor). jq guard.
+2. **`scripts/smevals/check_polarity.sh`** — the polarity checker. Reads the
+   output file (argv 1, else `${SMEVALS_RUN_DIR}/output.txt`), takes line 1
+   ONLY (never a grep scan), matches the full-line grammar
+   `verdict: correct|incorrect` exactly (anything else fails closed), compares
+   against `SMEVALS_TASK_EXPECTED` exactly, emits the smevals grader JSON
+   contract and exits 0/1. Wired `required: true` in `graders/default.yaml` by
+   AC-2's template — a mismatch halts grading.
+3. **`scripts/tests/test_smevals_runner.sh`** — stub-based shell BDD test
+   (48 assertions, all 17 predicates + the sneaky-pass negative). Stub
+   blendtutor asserts the argv contract and records calls to a counter file; a
+   GNU-compatible `timeout` shim on PATH keeps the timeout path deterministic
+   on macOS (no coreutils) and CI ubuntu alike.
+4. **`.github/workflows/ci.yml`** — `smevals runner test` step added to the
+   `check` job (`run: bash scripts/tests/test_smevals_runner.sh`).
+
+## Evidence
+
+| File | Proves |
+|------|--------|
+| `test-suite.log` | 48/48 shell BDD assertions green: env→argv wiring (stub counter proves invocation), header contract (line-1 `verdict: correct\|incorrect` + byte-exact multi-line message), `.actual` source-of-truth (inconsistent JSON `.actual=incorrect .matched=true` → `verdict: incorrect`), four polarity combos, line-1-only parsing, fail-closed malformed headers, case-sensitivity, transient-only retry (3 attempts / no-retry-on-valid-mismatch / ≥4s backoff / timeout-124 retry), missing-env naming, FIREWORKS_API_KEY propagation, empty-message header-only, jq guard, `set -euo pipefail` hygiene, generator-template↔script path contract |
+| `probe-real-smevals.log` | **Real-tool round trip**: `uvx smevals==0.2.0 run -g` against the AC-2-generated eval dir consuming **my real run.sh + check_polarity.sh** (only the LLM call stubbed). Run A (polarities match): 3/3 `grade: pass`, run exit 0, observed argv `eval demo_lesson --case N --format json`. Run B (deliberate mismatch): 3/3 `grade: fail`, run exit 1 — the `required: true` checker halts grading; `grade.yaml` shows `ok: false / score: 0.0 / notes: polarity mismatch` with the pinned checker path `../../../../scripts/smevals/check_polarity.sh` |
+
+## Why unit tests alone were insufficient
+
+The runner/checker contract is an external one — smevals 0.2.0 sets the
+`SMEVALS_*` env and captures stdout as `output.txt`, and the AC-2 generator
+emits the `runner:`/`checker:` paths. The real-tool probe proves the env wiring,
+the stdout→output.txt capture, the line-1 header parse, and the
+`required: true` grader halt all work against the actual tool, not just the
+stub harness. The stub harness alone proves the runner/checker logic;
+the probe proves the tool boundary.
+
+## Notes
+
+- **GNU `timeout` dependency**: the binding decision wraps the blendtutor call
+  in `timeout "${SMEVALS_TIMEOUT:-120}"`. macOS without coreutils lacks
+  `timeout`; CI ubuntu ships it. The test ships a GNU-compatible `timeout` shim
+  on PATH so the timeout path is exercised deterministically everywhere; macOS
+  users running smevals need GNU coreutils (or a `timeout` shim on PATH).
+- The runner requires all five task-contract env vars fail-closed (first
+  missing named on stderr); `SMEVALS_MODEL`/`SMEVALS_PROMPT`/
+  `SMEVALS_TASK_EXPECTED` are validated but not consumed — `blendtutor eval`
+  derives the model from the provider default (single-sourced to the same value
+  `configs/default.yaml` names) and the submission from the eval suite file.
+
+## Status
+
+All probes pass. `bash scripts/tests/test_smevals_runner.sh` → 48 passed,
+0 failed. Rust suite untouched (no `crates/` changes) — `cargo test` re-run to
+confirm zero regressions.

--- a/docs/evidence/196/probe-real-smevals.log
+++ b/docs/evidence/196/probe-real-smevals.log
@@ -1,0 +1,83 @@
+# Real-tool E2E probe: uvx smevals==0.2.0 run -g consuming scripts/smevals/run.sh + check_polarity.sh
+# (AC-2-generated eval dir + real smevals 0.2.0; only the blendtutor LLM call is stubbed)
+
+## Generated templates (AC-2, consumed as-is)
+
+### configs/default.yaml
+name: default
+runner: ../../../../scripts/smevals/run.sh
+model: accounts/fireworks/models/deepseek-v4-flash-0731
+
+### graders/default.yaml
+name: default
+checks:
+  - checker: ../../../../scripts/smevals/check_polarity.sh
+    required: true
+scoring:
+  pass_threshold: 0.8
+
+### tasks (env contract source)
+--- case-1.yaml ---
+name: case-1
+lesson: demo_lesson
+case: 1
+prompt: "cat(\"alpha\\n\")"
+expected: correct
+--- case-2.yaml ---
+name: case-2
+lesson: demo_lesson
+case: 2
+prompt: "cat(\"beta\\n\")"
+expected: incorrect
+--- case-3.yaml ---
+name: case-3
+lesson: demo_lesson
+case: 3
+prompt: "cat(\"gamma\\n\")"
+expected: correct
+
+## Run A: stub emits actual == SMEVALS_TASK_EXPECTED (all match)
+case-1 / default / accounts/fireworks/models/deepseek-v4-flash-0731 ... ok (0.0s) -> examples/write-less-code-r/.smevals/runs/case-1/default/accounts-fireworks-models-deepseek-v4-flash-0731/2026-08-08T06-31-42Z
+    grade: pass score=1.0
+case-2 / default / accounts/fireworks/models/deepseek-v4-flash-0731 ... ok (0.0s) -> examples/write-less-code-r/.smevals/runs/case-2/default/accounts-fireworks-models-deepseek-v4-flash-0731/2026-08-08T06-31-42Z
+    grade: pass score=1.0
+case-3 / default / accounts/fireworks/models/deepseek-v4-flash-0731 ... ok (0.0s) -> examples/write-less-code-r/.smevals/runs/case-3/default/accounts-fireworks-models-deepseek-v4-flash-0731/2026-08-08T06-31-42Z
+    grade: pass score=1.0
+run-exit: 0
+
+## Run B: stub emits the OPPOSITE polarity (all mismatch)
+case-1 / default / accounts/fireworks/models/deepseek-v4-flash-0731 ... ok (0.0s) -> examples/write-less-code-r/.smevals/runs/case-1/default/accounts-fireworks-models-deepseek-v4-flash-0731/2026-08-08T06-31-42Z
+    grade: fail score=0.0
+case-2 / default / accounts/fireworks/models/deepseek-v4-flash-0731 ... ok (0.0s) -> examples/write-less-code-r/.smevals/runs/case-2/default/accounts-fireworks-models-deepseek-v4-flash-0731/2026-08-08T06-31-42Z
+    grade: fail score=0.0
+case-3 / default / accounts/fireworks/models/deepseek-v4-flash-0731 ... ok (0.0s) -> examples/write-less-code-r/.smevals/runs/case-3/default/accounts-fireworks-models-deepseek-v4-flash-0731/2026-08-08T06-31-42Z
+    grade: fail score=0.0
+Error: 3 run(s) graded as fail
+run-exit: 1
+
+## Run B case-1 artifacts
+### output.txt (run.sh stdout captured by smevals)
+verdict: incorrect
+probe: deliberate mismatch
+
+### grades/default/grade.yaml (check_polarity.sh verdict)
+grader: default
+graded: '2026-08-08T06:31:42.756460+00:00'
+outcome: fail
+score: 0.0
+tags: []
+checks:
+- checker: ../../../../scripts/smevals/check_polarity.sh
+  ok: false
+  score: 0.0
+  notes: polarity mismatch
+
+## blendtutor argv observed by the stub (both runs)
+### Run A
+blendtutor eval demo_lesson --case 1 --format json
+blendtutor eval demo_lesson --case 2 --format json
+blendtutor eval demo_lesson --case 3 --format json
+### Run B
+blendtutor eval demo_lesson --case 1 --format json
+blendtutor eval demo_lesson --case 2 --format json
+blendtutor eval demo_lesson --case 3 --format json

--- a/docs/evidence/196/test-suite.log
+++ b/docs/evidence/196/test-suite.log
@@ -1,0 +1,69 @@
+== Predicate 1 + 3: env→argv wiring + header contract ==
+  PASS: runner exits 0 (got: 0)
+  PASS: stub invoked exactly once (got: 1)
+  PASS: argv = eval <lesson> --case N --format json (got: eval lessons/alpha.yaml --case 2 --format json)
+  PASS: line 1 = verdict: correct (got: verdict: correct)
+  PASS: message byte-exact, multi-line preserved (got: all good
+second line)
+== Predicate 2: no cargo run ==
+  PASS: grep -c 'cargo run' scripts/smevals/*.sh == 0 (got: 0)
+== Predicate 4 + negative: .actual source of truth, fail-closed ==
+  PASS: runner exits 0 on well-formed JSON (got: 0)
+  PASS: verdict from .actual (incorrect), not .matched (got: verdict: incorrect)
+  PASS: negative: checker fails closed on inconsistent-JSON output
+== Predicate 5: four polarity combinations ==
+  PASS: correct×correct → exit 0 (got: 0)
+  PASS: incorrect×incorrect → exit 0 (got: 0)
+  PASS: correct×incorrect → non-zero
+  PASS: incorrect×correct → non-zero
+== Predicate 6: line-1-only parsing ==
+  PASS: line 1 wins over body mention (got: 0)
+  PASS: body-only verdict: ignored (a grep scanner would pass here)
+== Predicate 7: fail-closed on malformed headers ==
+  PASS: malformed (p7-maybe) fails closed
+  PASS: malformed (p7-empty) fails closed
+  PASS: malformed (p7-nospace) fails closed
+  PASS: malformed (p7-zero) fails closed
+== Predicate 8: case-sensitive token ==
+  PASS: verdict: Correct fails closed
+== Predicate 9 + 10: bounded transient-only retry + backoff ==
+  PASS: fail: exactly 3 attempts (max) (got: 3)
+  PASS: fail: runner exits non-zero after retries
+  PASS: fail: backoff wall-time >= 4s (4s)
+  PASS: empty: exactly 3 attempts (max) (got: 3)
+  PASS: empty: runner exits non-zero after retries
+  PASS: empty: backoff wall-time >= 4s (4s)
+  PASS: garbage: exactly 3 attempts (max) (got: 3)
+  PASS: garbage: runner exits non-zero after retries
+  PASS: garbage: backoff wall-time >= 4s (4s)
+  PASS: well-formed mismatch: exit 0 (got: 0)
+  PASS: well-formed mismatch: exactly 1 call (no retry) (got: 1)
+== Predicate 11: per-call timeout ==
+  PASS: timeout (124) treated as transient → 3 attempts (got: 3)
+  PASS: runner exits non-zero after timeout retries
+  PASS: timeout actually killed the sleeps (10s < 15s)
+== Predicate 12: missing env naming the variable ==
+  PASS: missing SMEVALS_TASK_LESSON named on stderr
+  PASS: missing SMEVALS_TASK_CASE named on stderr
+== Predicate 13: FIREWORKS_API_KEY propagation ==
+  PASS: stub saw the key → runner exit 0 (no env scrubbing) (got: 0)
+== Predicate 14: empty feedback_message ==
+  PASS: runner exits 0 (got: 0)
+  PASS: header line emitted (got: verdict: correct)
+  PASS: zero following lines (got: 1)
+== Predicate 15: jq absent → non-zero naming jq ==
+  PASS: jq guard names jq
+== Predicate 16: set -euo pipefail hygiene ==
+  PASS: run.sh starts with set -euo pipefail (got: set -euo pipefail)
+  PASS: check_polarity.sh starts with set -euo pipefail (got: set -euo pipefail)
+== Predicate 17: generator template path == actual script path ==
+  PASS: generator records scripts/smevals/run.sh
+  PASS: runner exists at pinned path
+  PASS: generator records scripts/smevals/check_polarity.sh
+  PASS: checker exists at pinned path
+  PASS: graders template pins required: true
+
+=========================================
+  Results: 48 passed, 0 failed
+=========================================
+All tests passed.

--- a/scripts/smevals/check_polarity.sh
+++ b/scripts/smevals/check_polarity.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# scripts/smevals/check_polarity.sh — smevals polarity checker.
+#
+# Contract (AC-3):
+#   - Reads the runner's output.txt: the output file is argv 1 when given
+#     (test-hermetic), else `${SMEVALS_RUN_DIR}/output.txt` (the real smevals
+#     contract — smevals sets SMEVALS_RUN_DIR per run).
+#   - Takes the verdict from line 1 ONLY (head -1 / read -r line 1 — never a
+#     grep scan, so a `verdict: ` mention in the feedback body cannot confuse
+#     it) and matches the full-line grammar `verdict: correct|incorrect`
+#     exactly. Any other line-1 content — `verdict: maybe`, an empty value,
+#     a missing space, wrong case, a 0-byte file — fails closed.
+#   - Compares the actual polarity against SMEVALS_TASK_EXPECTED EXACTLY
+#     (case-sensitive) and emits the smevals grader JSON contract on stdout:
+#     `{"score": 1.0, "notes": "polarity match"}` + exit 0 on match, or
+#     `{"score": 0.0, ...}` + exit 1 on mismatch. graders/default.yaml wires
+#     this entry `required: true`, so a mismatch halts grading before any
+#     later (AC-4 judge) check runs.
+
+: "${SMEVALS_TASK_EXPECTED:?SMEVALS_TASK_EXPECTED is required}"
+
+output_file="${1:-}"
+if [ -z "$output_file" ]; then
+  if [ -n "${SMEVALS_RUN_DIR:-}" ]; then
+    output_file="$SMEVALS_RUN_DIR/output.txt"
+  else
+    echo "check_polarity.sh: no output file (pass as argv 1 or set SMEVALS_RUN_DIR)" >&2
+    exit 1
+  fi
+fi
+
+if [ ! -r "$output_file" ]; then
+  echo "check_polarity.sh: output file not readable: $output_file" >&2
+  exit 1
+fi
+
+line1="$(head -n 1 "$output_file")"
+
+actual=""
+case "$line1" in
+  "verdict: correct") actual="correct" ;;
+  "verdict: incorrect") actual="incorrect" ;;
+esac
+
+if [ "$actual" = "$SMEVALS_TASK_EXPECTED" ]; then
+  printf '{"score": 1.0, "notes": "polarity match"}\n'
+  exit 0
+fi
+printf '{"score": 0.0, "notes": "polarity mismatch"}\n'
+exit 1

--- a/scripts/smevals/run.sh
+++ b/scripts/smevals/run.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# scripts/smevals/run.sh — smevals runner: invoke `blendtutor eval` for one
+# task case and emit the verdict + feedback to stdout.
+#
+# Contract (AC-3):
+#   - Reads the smevals task env (SMEVALS_TASK_LESSON/SMEVALS_TASK_CASE build
+#     the argv; SMEVALS_MODEL/SMEVALS_PROMPT/SMEVALS_TASK_EXPECTED are
+#     validated fail-closed so a misconfigured eval dir fails loudly, but are
+#     not consumed — blendtutor eval derives the model from the provider
+#     default, single-sourced to the same value configs/default.yaml names,
+#     and the submission from the eval suite file).
+#   - Invokes `blendtutor eval <lesson> --case N --format json` (AC-1) under a
+#     per-call timeout, resolving blendtutor from PATH (never an in-tree build
+#     invocation).
+#   - Emits `verdict: correct|incorrect` (line 1, from the JSON `.cases[0]`.
+#     `actual` token — the source of truth, never `.matched`) followed by the
+#     byte-exact feedback_message (lines 2+, raw via jq so multi-line content
+#     and trailing whitespace survive). smevals captures stdout as output.txt;
+#     check_polarity.sh parses line 1 only.
+#   - Bounded transient-only retry (3 attempts, 2s backoff): blendtutor
+#     exit-1, timeout (124), empty stdout, and malformed JSON retry; a
+#     well-formed run never retries — the polarity checker decides mismatches.
+#   - No env scrubbing: FIREWORKS_API_KEY and friends reach blendtutor.
+#
+# Per-call timeout default 120s (typical LLM latency 5-30s); override via
+# SMEVALS_TIMEOUT so tests can exercise the timeout path in seconds.
+
+command -v jq >/dev/null 2>&1 || {
+  echo "run.sh: jq not found in PATH — required to parse blendtutor eval JSON" >&2
+  exit 1
+}
+
+: "${SMEVALS_TASK_LESSON:?SMEVALS_TASK_LESSON is required}"
+: "${SMEVALS_TASK_CASE:?SMEVALS_TASK_CASE is required}"
+: "${SMEVALS_MODEL:?SMEVALS_MODEL is required}"
+: "${SMEVALS_PROMPT:?SMEVALS_PROMPT is required}"
+: "${SMEVALS_TASK_EXPECTED:?SMEVALS_TASK_EXPECTED is required}"
+
+MAX_ATTEMPTS=3
+BACKOFF_SECONDS=2
+
+attempt=0
+while [ "$attempt" -lt "$MAX_ATTEMPTS" ]; do
+  attempt=$((attempt + 1))
+  exit_status=0
+  json=""
+  json="$(timeout "${SMEVALS_TIMEOUT:-120}" blendtutor eval \
+    "$SMEVALS_TASK_LESSON" --case "$SMEVALS_TASK_CASE" --format json)" \
+    || exit_status=$?
+
+  if [ "$exit_status" -eq 0 ] \
+      && [ -n "$json" ] \
+      && jq -e '.cases[0].actual' >/dev/null 2>&1 <<<"$json"; then
+    # Well-formed run: emit the header from .actual, then the verbatim
+    # message (skipped entirely when empty — header line only).
+    printf 'verdict: %s\n' "$(jq -r '.cases[0].actual' <<<"$json")"
+    if jq -e '.cases[0].feedback_message != ""' >/dev/null 2>&1 <<<"$json"; then
+      jq -r '.cases[0].feedback_message' <<<"$json"
+    fi
+    exit 0
+  fi
+
+  # Transient only: exit-1 (pipeline hiccup), timeout-124, and exit-0 with
+  # empty or malformed stdout (the jq check above failed). Anything else —
+  # usage error, missing binary — is permanent and fails immediately.
+  retryable=false
+  case "$exit_status" in
+    0|1|124) retryable=true ;;
+  esac
+  if [ "$retryable" = false ]; then
+    echo "run.sh: blendtutor eval failed permanently (exit $exit_status)" >&2
+    exit 1
+  fi
+
+  if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+    sleep "$BACKOFF_SECONDS"
+  fi
+done
+
+echo "run.sh: blendtutor eval failed after $MAX_ATTEMPTS attempts" >&2
+exit 1

--- a/scripts/tests/test_smevals_runner.sh
+++ b/scripts/tests/test_smevals_runner.sh
@@ -1,0 +1,504 @@
+#!/usr/bin/env bash
+# Stub-based integration test for scripts/smevals/run.sh + check_polarity.sh.
+#
+# Verifies the 17-point compound predicate from AC-3:
+#   1. Env→argv wiring: stub blendtutor asserts `eval <lesson> --case N --format
+#      json` built from SMEVALS_TASK_LESSON/SMEVALS_TASK_CASE; counter file
+#      proves invocation (no canned output).
+#   2. No `cargo run` anywhere in scripts/smevals/*.sh — blendtutor from PATH.
+#   3. Header contract: line 1 == `verdict: correct|incorrect` (exact,
+#      lowercase); lines 2+ == feedback_message byte-exact, multi-line kept.
+#   4. Source-of-truth = .actual token, NOT .matched (inconsistent-JSON stub).
+#   5. Four polarity combos → checker exit 0 on matches, non-zero on mismatches.
+#   6. Line-1-only parsing: `verdict: ` in the body must not confuse the checker.
+#   7. Fail-closed on malformed headers (maybe / empty / no-space / 0-byte).
+#   8. Case-sensitive token: `verdict: Correct` fails closed.
+#   9. Bounded transient-only retry: exit-1, empty stdout, malformed JSON all
+#      retry (max 3, sleep 2); well-formed mismatch verdict does NOT retry.
+#  10. Backoff wall-time >= 4s for a retry-then-fail run.
+#  11. Per-call timeout: SMEVALS_TIMEOUT=2 + sleep-5 stub → 124 → transient retry.
+#  12. Missing SMEVALS_TASK_LESSON/SMEVALS_TASK_CASE → non-zero naming the var.
+#  13. FIREWORKS_API_KEY propagation (no env scrubbing in the runner).
+#  14. Empty feedback_message → header only, zero following lines, exit 0.
+#  15. jq absent from PATH → runner exits non-zero naming jq.
+#  16. Both scripts start with `set -euo pipefail`.
+#  17. Generator template checker path == real checker script path (cross-file).
+#
+# Also catches the negative cheat: inconsistent JSON (.actual=incorrect,
+# .matched=true) whose message body contains `verdict: correct` on line 3 — a
+# sneaky-pass runner reading .matched or grep-scanning for verdict: yields the
+# wrong polarity and the checker wrongly exits 0.
+#
+# The stub-on-PATH + counter-file pattern follows scripts/tests/eval-course.sh
+# (stub at :83-137). macOS lacks GNU coreutils `timeout`, so the test also puts
+# a GNU-compatible `timeout` shim on PATH FIRST — deterministic on macOS and on
+# CI ubuntu (which would otherwise use the real coreutils timeout).
+#
+# Usage: bash scripts/tests/test_smevals_runner.sh
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+RUNNER="scripts/smevals/run.sh"
+CHECKER="scripts/smevals/check_polarity.sh"
+PASS=0
+FAIL=0
+
+ok() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+ko() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    ok "$label (got: $actual)"
+  else
+    ko "$label — expected [$expected], got [$actual]"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Setup: temp dir + stub blendtutor + GNU-compatible timeout shim on PATH.
+# ---------------------------------------------------------------------------
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+STUB_DIR="$TMPDIR/bin"
+mkdir -p "$STUB_DIR"
+
+# Counter file — proves the stub was invoked (predicate 1: no canned output).
+COUNTER="$TMPDIR/calls.txt"
+: > "$COUNTER"
+
+cat > "$STUB_DIR/blendtutor" <<'STUB'
+#!/usr/bin/env bash
+# Stub blendtutor eval — asserts the AC-3 argv contract, records each call,
+# and emits canned JSON selected by STUB_MODE.
+set -euo pipefail
+
+COUNTER="${SMEVALS_RUNNER_COUNTER:-/dev/null}"
+MODE="${STUB_MODE:-correct}"
+
+# Predicate 13 — FIREWORKS_API_KEY must reach the subprocess unscrubbed.
+if [ "${STUB_ASSERT_API_KEY:-0}" = "1" ] && [ -z "${FIREWORKS_API_KEY:-}" ]; then
+  echo "stub: FIREWORKS_API_KEY not visible in environment" >&2
+  exit 1
+fi
+
+# Argv contract (predicate 1): eval <lesson> --case N --format json.
+if [ "$1" != "eval" ] || [ "$3" != "--case" ] || [ "$5" != "--format" ] || [ "$6" != "json" ]; then
+  echo "stub: unexpected argv: $*" >&2
+  exit 1
+fi
+if [ "$2" != "$SMEVALS_TASK_LESSON" ] || [ "$4" != "$SMEVALS_TASK_CASE" ]; then
+  echo "stub: argv lesson/case do not match env: $2 / $4" >&2
+  exit 1
+fi
+
+echo "eval $2 --case $4 --format json" >> "$COUNTER"
+
+case "$MODE" in
+  correct)
+    echo '{"cases":[{"expected":"correct","actual":"correct","matched":true,"feedback_message":"all good\nsecond line"}],"accuracy":1.0}'
+    ;;
+  incorrect)
+    echo '{"cases":[{"expected":"correct","actual":"incorrect","matched":false,"feedback_message":"try again"}],"accuracy":0.0}'
+    ;;
+  inconsistent)
+    # Negative cheat: .actual=incorrect but .matched=true, and the message body
+    # contains `verdict: correct` on its second line (= output line 3).
+    echo '{"cases":[{"expected":"correct","actual":"incorrect","matched":true,"feedback_message":"feedback one\nverdict: correct\ntail"}],"accuracy":0.0}'
+    ;;
+  empty-msg)
+    echo '{"cases":[{"expected":"correct","actual":"correct","matched":true,"feedback_message":""}],"accuracy":1.0}'
+    ;;
+  fail)
+    echo "stub: simulated eval failure" >&2
+    exit 1
+    ;;
+  empty)
+    # Exit 0 with no stdout — transient (empty output).
+    exit 0
+    ;;
+  garbage)
+    echo "this is not json at all"
+    ;;
+  slow)
+    sleep 5
+    echo '{"cases":[{"expected":"correct","actual":"correct","matched":true,"feedback_message":"slow"}],"accuracy":1.0}'
+    ;;
+  *)
+    echo "stub: unknown mode: $MODE" >&2
+    exit 1
+    ;;
+esac
+STUB
+chmod +x "$STUB_DIR/blendtutor"
+
+cat > "$STUB_DIR/timeout" <<'STUB'
+#!/usr/bin/env bash
+# Minimal GNU-timeout-compatible shim (CI uses real coreutils; local macOS
+# often lacks GNU timeout). Runs "$@" with SIGTERM to its process group after
+# $1 seconds; exits 124 on timeout (GNU contract), else the command's own exit
+# status. `set -m` puts the command in its own group so the group-kill takes
+# the command AND its children down together — killing only the parent would
+# orphan a child holding the caller's stdout pipe open.
+set -euo pipefail
+set -m
+limit="$1"
+shift
+"$@" &
+pid=$!
+# The killer must not inherit the caller's stdout pipe: if it is orphaned, a
+# held pipe would block the runner's command substitution until it expires.
+( sleep "$limit"; kill -TERM -"$pid" 2>/dev/null || true ) >/dev/null 2>&1 &
+killer=$!
+status=0
+wait "$pid" || status=$?
+kill "$killer" 2>/dev/null || true
+if [ "$status" -eq 143 ]; then
+  exit 124
+fi
+exit "$status"
+STUB
+chmod +x "$STUB_DIR/timeout"
+
+export PATH="$STUB_DIR:$PATH"
+export SMEVALS_RUNNER_COUNTER="$COUNTER"
+
+# ---------------------------------------------------------------------------
+# Helpers: run the runner / checker with the standard smevals task env.
+# ---------------------------------------------------------------------------
+
+# run_runner_status <out> <err> [VAR=val overrides...] — sets RUNNER_STATUS.
+run_runner_status() {
+  local out="$1" err="$2"
+  shift 2
+  RUNNER_STATUS=0
+  env STUB_MODE="${STUB_MODE:-correct}" \
+      SMEVALS_MODEL="accounts/fireworks/models/deepseek-v4-flash-0731" \
+      SMEVALS_PROMPT="prompt-placeholder" \
+      SMEVALS_TASK_LESSON="lessons/alpha.yaml" \
+      SMEVALS_TASK_CASE="2" \
+      SMEVALS_TASK_EXPECTED="correct" \
+      "$@" "$RUNNER" >"$out" 2>"$err" || RUNNER_STATUS=$?
+}
+
+# checker_status <expected> <output-file> — sets CHECKER_STATUS.
+checker_status() {
+  local expected="$1" file="$2"
+  CHECKER_STATUS=0
+  SMEVALS_TASK_EXPECTED="$expected" "$CHECKER" "$file" >/dev/null 2>&1 \
+    || CHECKER_STATUS=$?
+}
+
+OUT="$TMPDIR/out.txt"
+ERR="$TMPDIR/err.txt"
+
+# ---------------------------------------------------------------------------
+# Predicate 1 + 3 — env→argv wiring, counter proof, header contract.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 1 + 3: env→argv wiring + header contract =="
+
+: > "$COUNTER"
+run_runner_status "$OUT" "$ERR"
+assert_eq "runner exits 0" "0" "$RUNNER_STATUS"
+assert_eq "stub invoked exactly once" "1" "$(wc -l < "$COUNTER" | tr -d ' ')"
+assert_eq "argv = eval <lesson> --case N --format json" \
+  "eval lessons/alpha.yaml --case 2 --format json" "$(cat "$COUNTER")"
+assert_eq "line 1 = verdict: correct" "verdict: correct" "$(sed -n '1p' "$OUT")"
+assert_eq "message byte-exact, multi-line preserved" "all good
+second line" "$(tail -n +2 "$OUT")"
+
+# ---------------------------------------------------------------------------
+# Predicate 2 — no `cargo run` in the smevals scripts.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 2: no cargo run =="
+
+# grep -c exits 1 on zero matches — the group's `|| true` keeps the pipeline
+# status 0 (pipefail would otherwise kill the test) without double-printing.
+COUNT=$({ grep -c 'cargo run' scripts/smevals/run.sh scripts/smevals/check_polarity.sh \
+  2>/dev/null || true; } | awk -F: '{s += $2} END {print s+0}')
+assert_eq "grep -c 'cargo run' scripts/smevals/*.sh == 0" "0" "$COUNT"
+
+# ---------------------------------------------------------------------------
+# Predicate 4 + negative — .actual is the source of truth, not .matched.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 4 + negative: .actual source of truth, fail-closed =="
+
+: > "$COUNTER"
+STUB_MODE=inconsistent run_runner_status "$OUT" "$ERR"
+assert_eq "runner exits 0 on well-formed JSON" "0" "$RUNNER_STATUS"
+assert_eq "verdict from .actual (incorrect), not .matched" \
+  "verdict: incorrect" "$(sed -n '1p' "$OUT")"
+
+# Negative: expected=correct vs the sneaky-pass output → checker must fail.
+checker_status "correct" "$OUT"
+if [ "$CHECKER_STATUS" -ne 0 ]; then
+  ok "negative: checker fails closed on inconsistent-JSON output"
+else
+  ko "negative: checker fails closed on inconsistent-JSON output — sneaky-pass!"
+fi
+
+# ---------------------------------------------------------------------------
+# Predicate 5 — all four polarity combinations.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 5: four polarity combinations =="
+
+printf 'verdict: correct\n' > "$TMPDIR/p5-correct.txt"
+printf 'verdict: incorrect\n' > "$TMPDIR/p5-incorrect.txt"
+
+checker_status "correct" "$TMPDIR/p5-correct.txt"
+assert_eq "correct×correct → exit 0" "0" "$CHECKER_STATUS"
+checker_status "incorrect" "$TMPDIR/p5-incorrect.txt"
+assert_eq "incorrect×incorrect → exit 0" "0" "$CHECKER_STATUS"
+checker_status "correct" "$TMPDIR/p5-incorrect.txt"
+if [ "$CHECKER_STATUS" -ne 0 ]; then
+  ok "correct×incorrect → non-zero"
+else
+  ko "correct×incorrect → non-zero"
+fi
+checker_status "incorrect" "$TMPDIR/p5-correct.txt"
+if [ "$CHECKER_STATUS" -ne 0 ]; then
+  ok "incorrect×correct → non-zero"
+else
+  ko "incorrect×correct → non-zero"
+fi
+
+# ---------------------------------------------------------------------------
+# Predicate 6 — line-1-only parsing (a body `verdict:` must not confuse).
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 6: line-1-only parsing =="
+
+printf 'verdict: incorrect\nbody mentions verdict: correct\n' > "$TMPDIR/p6a.txt"
+checker_status "incorrect" "$TMPDIR/p6a.txt"
+assert_eq "line 1 wins over body mention" "0" "$CHECKER_STATUS"
+
+printf 'plain body\nverdict: correct\n' > "$TMPDIR/p6b.txt"
+checker_status "correct" "$TMPDIR/p6b.txt"
+if [ "$CHECKER_STATUS" -ne 0 ]; then
+  ok "body-only verdict: ignored (a grep scanner would pass here)"
+else
+  ko "body-only verdict: ignored (a grep scanner would pass here)"
+fi
+
+# ---------------------------------------------------------------------------
+# Predicate 7 — fail-closed on malformed headers.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 7: fail-closed on malformed headers =="
+
+printf 'verdict: maybe\n' > "$TMPDIR/p7-maybe.txt"
+printf 'verdict:\n' > "$TMPDIR/p7-empty.txt"
+printf 'verdict:correct\n' > "$TMPDIR/p7-nospace.txt"
+: > "$TMPDIR/p7-zero.txt"
+
+for name in p7-maybe p7-empty p7-nospace p7-zero; do
+  checker_status "correct" "$TMPDIR/$name.txt"
+  if [ "$CHECKER_STATUS" -ne 0 ]; then
+    ok "malformed ($name) fails closed"
+  else
+    ko "malformed ($name) fails closed"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Predicate 8 — case-sensitive token.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 8: case-sensitive token =="
+
+printf 'verdict: Correct\n' > "$TMPDIR/p8.txt"
+checker_status "correct" "$TMPDIR/p8.txt"
+if [ "$CHECKER_STATUS" -ne 0 ]; then
+  ok "verdict: Correct fails closed"
+else
+  ko "verdict: Correct fails closed"
+fi
+
+# ---------------------------------------------------------------------------
+# Predicate 9 + 10 — bounded transient-only retry + backoff wall-time.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 9 + 10: bounded transient-only retry + backoff =="
+
+for mode in fail empty garbage; do
+  : > "$COUNTER"
+  START=$(date +%s)
+  STUB_MODE="$mode" run_runner_status "$OUT" "$ERR"
+  ELAPSED=$(( $(date +%s) - START ))
+  assert_eq "$mode: exactly 3 attempts (max)" "3" "$(wc -l < "$COUNTER" | tr -d ' ')"
+  if [ "$RUNNER_STATUS" -ne 0 ]; then
+    ok "$mode: runner exits non-zero after retries"
+  else
+    ko "$mode: runner exits non-zero after retries"
+  fi
+  if [ "$ELAPSED" -ge 4 ]; then
+    ok "$mode: backoff wall-time >= 4s (${ELAPSED}s)"
+  else
+    ko "$mode: backoff wall-time >= 4s (${ELAPSED}s)"
+  fi
+done
+
+# No-retry arm: a well-formed (mismatched) verdict must NOT be retried.
+: > "$COUNTER"
+STUB_MODE=incorrect run_runner_status "$OUT" "$ERR"
+assert_eq "well-formed mismatch: exit 0" "0" "$RUNNER_STATUS"
+assert_eq "well-formed mismatch: exactly 1 call (no retry)" \
+  "1" "$(wc -l < "$COUNTER" | tr -d ' ')"
+
+# ---------------------------------------------------------------------------
+# Predicate 11 — per-call timeout (SMEVALS_TIMEOUT), exit 124 → transient.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 11: per-call timeout =="
+
+: > "$COUNTER"
+START=$(date +%s)
+STUB_MODE=slow SMEVALS_TIMEOUT=2 run_runner_status "$OUT" "$ERR"
+ELAPSED=$(( $(date +%s) - START ))
+assert_eq "timeout (124) treated as transient → 3 attempts" \
+  "3" "$(wc -l < "$COUNTER" | tr -d ' ')"
+if [ "$RUNNER_STATUS" -ne 0 ]; then
+  ok "runner exits non-zero after timeout retries"
+else
+  ko "runner exits non-zero after timeout retries"
+fi
+if [ "$ELAPSED" -lt 15 ]; then
+  ok "timeout actually killed the sleeps (${ELAPSED}s < 15s)"
+else
+  ko "timeout actually killed the sleeps (${ELAPSED}s >= 15s)"
+fi
+
+# ---------------------------------------------------------------------------
+# Predicate 12 — missing env → usage error naming the variable.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 12: missing env naming the variable =="
+
+if env SMEVALS_MODEL=m SMEVALS_PROMPT=p SMEVALS_TASK_EXPECTED=correct \
+    "$RUNNER" >/dev/null 2>"$ERR"; then
+  ko "missing SMEVALS_TASK_LESSON exits non-zero"
+else
+  if grep -q 'SMEVALS_TASK_LESSON' "$ERR"; then
+    ok "missing SMEVALS_TASK_LESSON named on stderr"
+  else
+    ko "missing SMEVALS_TASK_LESSON named on stderr — got: $(cat "$ERR")"
+  fi
+fi
+
+if env SMEVALS_MODEL=m SMEVALS_PROMPT=p SMEVALS_TASK_EXPECTED=correct \
+    SMEVALS_TASK_LESSON=lessons/x.yaml "$RUNNER" >/dev/null 2>"$ERR"; then
+  ko "missing SMEVALS_TASK_CASE exits non-zero"
+else
+  if grep -q 'SMEVALS_TASK_CASE' "$ERR"; then
+    ok "missing SMEVALS_TASK_CASE named on stderr"
+  else
+    ko "missing SMEVALS_TASK_CASE named on stderr — got: $(cat "$ERR")"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Predicate 13 — FIREWORKS_API_KEY reaches the subprocess unscrubbed.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 13: FIREWORKS_API_KEY propagation =="
+
+: > "$COUNTER"
+STUB_ASSERT_API_KEY=1 FIREWORKS_API_KEY=fw_dummy-key run_runner_status "$OUT" "$ERR"
+assert_eq "stub saw the key → runner exit 0 (no env scrubbing)" "0" "$RUNNER_STATUS"
+
+# ---------------------------------------------------------------------------
+# Predicate 14 — empty feedback_message.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 14: empty feedback_message =="
+
+: > "$COUNTER"
+STUB_MODE=empty-msg run_runner_status "$OUT" "$ERR"
+assert_eq "runner exits 0" "0" "$RUNNER_STATUS"
+assert_eq "header line emitted" "verdict: correct" "$(sed -n '1p' "$OUT")"
+assert_eq "zero following lines" "1" "$(wc -l < "$OUT" | tr -d ' ')"
+
+# ---------------------------------------------------------------------------
+# Predicate 15 — jq guard.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 15: jq absent → non-zero naming jq =="
+
+NOJQ="$TMPDIR/nojq"
+mkdir -p "$NOJQ"
+ln -s "$(command -v bash)" "$NOJQ/bash"
+
+if env PATH="$NOJQ" "$RUNNER" >/dev/null 2>"$ERR"; then
+  ko "jq-absent runner exits non-zero"
+else
+  if grep -qi 'jq' "$ERR"; then
+    ok "jq guard names jq"
+  else
+    ko "jq guard names jq — got: $(cat "$ERR")"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Predicate 16 — both scripts start with set -euo pipefail.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 16: set -euo pipefail hygiene =="
+
+for script in "$RUNNER" "$CHECKER"; do
+  assert_eq "$(basename "$script") starts with set -euo pipefail" \
+    "set -euo pipefail" "$(sed -n '2p' "$script")"
+done
+
+# ---------------------------------------------------------------------------
+# Predicate 17 — grader-template checker path == real checker script path.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 17: generator template path == actual script path =="
+
+if grep -qF 'scripts/smevals/run.sh' crates/core/src/smevals_gen.rs; then
+  ok "generator records scripts/smevals/run.sh"
+else
+  ko "generator records scripts/smevals/run.sh"
+fi
+if [ -f scripts/smevals/run.sh ]; then
+  ok "runner exists at pinned path"
+else
+  ko "runner exists at pinned path"
+fi
+if grep -qF 'scripts/smevals/check_polarity.sh' crates/core/src/smevals_gen.rs; then
+  ok "generator records scripts/smevals/check_polarity.sh"
+else
+  ko "generator records scripts/smevals/check_polarity.sh"
+fi
+if [ -f scripts/smevals/check_polarity.sh ]; then
+  ok "checker exists at pinned path"
+else
+  ko "checker exists at pinned path"
+fi
+if grep -qF 'required: true' crates/core/src/smevals_gen.rs; then
+  ok "graders template pins required: true"
+else
+  ko "graders template pins required: true"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "========================================="
+echo "  Results: $PASS passed, $FAIL failed"
+echo "========================================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+
+echo "All tests passed."


### PR DESCRIPTION
## Summary
Adds the shared smevals Runner and deterministic polarity checker for the smevals eval pipeline (AC-3):

- **`scripts/smevals/run.sh`** — reads the smevals task env (all five vars verified against real smevals 0.2.0), invokes `blendtutor eval <lesson> --case N --format json` (AC-1) under `timeout "${SMEVALS_TIMEOUT:-120}"`, emits `verdict: correct|incorrect` (from `.cases[0].actual` — the source of truth, never `.matched`) + the verbatim `feedback_message` to stdout (smevals captures as output.txt). Bounded transient-only retry (3 attempts, 2s backoff; retries exit-1/timeout-124/empty-stdout/malformed-JSON; never retries a well-formed run). No env scrubbing — FIREWORKS_API_KEY reaches blendtutor.
- **`scripts/smevals/check_polarity.sh`** — parses output.txt line 1 ONLY (full-line grammar `verdict: correct|incorrect`, fail-closed on anything else), compares against `SMEVALS_TASK_EXPECTED` exactly, emits the smevals grader JSON contract (exit 0 match / 1 mismatch). Wired `required: true` in AC-2's `graders/default.yaml` template — path contract asserted cross-file.
- **`scripts/tests/test_smevals_runner.sh`** — stub-based shell BDD (48 assertions, all 17 predicates + the sneaky-pass negative: `.actual=incorrect .matched=true` with `verdict: correct` in the body). GNU-compatible `timeout` shim on PATH keeps the timeout path deterministic on macOS + CI.
- **`.github/workflows/ci.yml`** — `smevals runner test` step in the `check` job.

## Issue
Closes #196

## ACs implemented
- [x] `scripts/smevals/run.sh` reads SMEVALS_TASK_LESSON/CASE env, shells `blendtutor eval <lesson> --case N --format json`, prints `verdict: correct|incorrect` header + feedback_message verbatim, retries transient failures (3 attempts, backoff, per-call timeout)
- [x] `scripts/smevals/check_polarity.sh` compares output.txt line 1 vs SMEVALS_TASK_EXPECTED exactly (fail-closed)
- [x] wired required: true in graders/default.yaml (template path contract asserted)

## Test plan
- [x] `bash scripts/tests/test_smevals_runner.sh` → 48 passed, 0 failed (evidence: docs/evidence/196/test-suite.log)
- [x] Real-tool E2E: `uvx smevals==0.2.0 run -g` on the AC-2-generated eval dir with the real scripts (LLM call stubbed) — Run A 3/3 pass (exit 0), Run B 3/3 fail (exit 1, `grade.yaml ok: false / notes: polarity mismatch`) — the required:true halt proven end-to-end (evidence: docs/evidence/196/probe-real-smevals.log)
- [x] `cargo test --workspace` green (no crates/ changes)

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested
- [x] Verification medium satisfied (code — shell BDD + real-tool probe)
- [x] Design intent respected
- [x] No scope creep (no crates/ changes; AC-4 judge + AC-5 report untouched)