### PR TITLE
[docs] Document the eval-report flow — creating-lessons Step 9, README, agent-notes, readme.rs pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ evaluation prompt. `blendtutor` handles the rest:
 
 - **Instructors** scaffold a course, add lessons, validate them, dry-run the
   grading against sample submissions, score the grading prompt against known
-  cases, and build a deployable browser site.
+  cases, generate an eval report with `blendtutor eval-report` (committed to
+  `docs/evals/<lesson>/` and published to `/evals/<lesson>/` on Pages), and
+  build a deployable browser site.
 - **Learners** run a lesson, submit code, and get an AI verdict — in the
   terminal locally, or in a browser via [webR](https://docs.r-wasm.org/webr/) /
   [Pyodide](https://pyodide.org/) with no install.
@@ -53,7 +55,7 @@ and `eval` call the provider.
 
 ## Authoring workflow
 
-The instructor loop is **`init → new → validate → run → eval → build`**.
+The instructor loop is **`init → new → validate → run → eval → eval-report → build`**.
 
 ### `blendtutor init` — scaffold a course
 

--- a/crates/cli/tests/readme.rs
+++ b/crates/cli/tests/readme.rs
@@ -2,13 +2,14 @@
 //!
 //! The repo's top-level README is the "what this is" surface (§4.1). After the
 //! R-package → Rust-CLI cutover it must document the binary install and the full
-//! `init → new → validate → run → eval → build` authoring/run/eval/deploy
-//! workflow, including the GitHub Pages + COOP/COEP cross-origin-isolation note a
-//! built webR/Pyodide site needs (see `docs/agent-notes/site-build.md`). This
-//! pins each required token so a README that drops a command, the install
-//! section, or the deploy note fails the build — the same set the issue's AC1
-//! probe greps, anchored here so CI (nextest) gates it. It does not judge prose
-//! quality; that is a manual readability skim.
+//! `init → new → validate → run → eval → eval-report → build`
+//! authoring/run/eval/deploy workflow, including the GitHub Pages + COOP/COEP
+//! cross-origin-isolation note a built webR/Pyodide site needs (see
+//! `docs/agent-notes/site-build.md`). This pins each required token so a README
+//! that drops a command, the install section, or the deploy note fails the
+//! build — the same set the issue's AC1 probe greps, anchored here so CI
+//! (nextest) gates it. It does not judge prose quality; that is a manual
+//! readability skim.
 
 use std::path::Path;
 
@@ -36,6 +37,11 @@ fn readme_documents_the_cli_install_and_workflow() {
         ("validate command", "blendtutor validate"),
         ("run command", "blendtutor run"),
         ("eval command", "blendtutor eval"),
+        // Substring gotcha: `"blendtutor eval"` (the eval pin above) is a
+        // substring of `"blendtutor eval-report"`, so the eval pin cannot
+        // detect a README that drops the eval-report command — an explicit
+        // tuple is required (issue #200).
+        ("eval-report command", "blendtutor eval-report"),
         ("build command", "blendtutor build"),
         ("GitHub Pages deploy", "github pages"),
     ];

--- a/crates/core/src/smevals_gen.rs
+++ b/crates/core/src/smevals_gen.rs
@@ -9,7 +9,7 @@
 //! identical inputs yield byte-identical output, and every value is emitted
 //! through an injection-proof YAML scalar discipline proven by round-trip tests
 //! (§1.3.1). The model id in `configs/default.yaml` is single-sourced from
-//! [`ProviderChoice::Fireworks::default_model`], never a divergent literal.
+//! [`ProviderChoice::default_model()`], never a divergent literal.
 //!
 //! This module owns *only* the lesson+suite → smevals-dir translation. It is
 //! NOT the runner (AC-3), the LLM judge (AC-4), or the report command (AC-5);

--- a/docs/agent-notes/eval.md
+++ b/docs/agent-notes/eval.md
@@ -2,6 +2,7 @@
 topic: eval
 created: 2026-06-07
 slices: [12, 13]
+acs: [1, 2, 3, 5]
 ---
 
 The eval-case model (`core::eval`): the typed shape the `eval` command will later
@@ -90,3 +91,56 @@ ADR-0007 for the verdict-representation decision.
   (`commands::eval::sibling_suite_path`, prefix the whole file name with
   `eval_`). core::eval still never touches the filesystem (§2.1); the path
   derivation + read live at the cli edge.
+- 2026-08-08 (#AC-1): **`CaseResult` gained `feedback_message: String`**,
+  captured in `CaseResult::score` — the only constructor — so the message can
+  never be inconsistent with the verdict it came from; both `Verdict` variants
+  carry `message` (there is NO public `message()` accessor; read inline via
+  exhaustive match, feedback.rs untouched). Serialize-only derive: additive
+  JSON field, `eval-course.sh`'s jq (`.cases` selects) unaffected. `--case N`
+  single-case selection is **1-based** (human-report numbering), and the
+  ORIGINAL suite index is threaded through the filter so
+  `EvalRunError::CaseOutOfRange { requested, suite_size }` reports the user's
+  number, never a post-filter index; the range check lives inside `run_eval`
+  (pure core), clap exits 2 for parse errors and 1 only for out-of-range.
+- 2026-08-08 (#AC-2): **The smevals eval-dir generator is pure Rust in
+  `core::smevals_gen`** — `generate_eval_dir(&Lesson, &EvalSuite, lesson_id)
+  -> Vec<(PathBuf, String)>`, the FIRST YAML *emitter* in the codebase
+  (serde-saphyr is parse-only). Generated dir is `<course>/.smevals/`
+  (dotdir, `**/.smevals/` rule — provably no collision with committed
+  `docs/evals/`); an empty suite is an Err, not a vacuous pass. Two
+  implementation deviations from plan: (1) emission uses double-quoted
+  scalars with full control-char escaping, NOT block scalars — serde-saphyr
+  0.0.27 `|+`/`|-` chomping cannot round-trip arbitrary strings byte-exact
+  (the injection round-trip test pins byte-identity regardless); (2)
+  `runner:`/`checker:` paths resolve relative to the config/grader FILE, so
+  the effectful `write_eval_dir` recomputes the relative prefix by walking to
+  the repo root — the pure fn cannot know course depth. Provider default
+  bumped to `accounts/fireworks/models/deepseek-v4-flash-0731` (matches the
+  browser BYOK pin).
+- 2026-08-08 (#AC-3): **smevals runner (run.sh) + deterministic polarity
+  checker (check_polarity.sh)** — the runner reads `SMEVALS_TASK_*` env,
+  shells `blendtutor eval <lesson> --case N --format json` under
+  `timeout ${SMEVALS_TIMEOUT:-120}` (env-overridable, so the stub test
+  exercises the timeout path in ~2s), and exposes the verdict via a
+  **line-1 stdout header** (`verdict: <polarity>` — fail-closed: a missing or
+  malformed header is a transient failure). Retry is transient-only
+  (exit-1/empty-stdout/malformed-JSON/timeout-124 — never on a mismatch
+  verdict), 3 attempts, sleep-2 backoff. `check_polarity.sh` treats `.actual`
+  as the source of truth (`matched` derives from `score_case`, never set
+  independently) and compares exact equality — no substring slack. No
+  `env -i`: `FIREWORKS_API_KEY` must reach the `blendtutor` subprocess.
+- 2026-08-08 (#AC-5): **`blendtutor eval-report <lesson>` is a thin
+  orchestration shell** (subcommand, not a script): generate `.smevals/` via
+  AC-2's generator → `uvx smevals==0.2.0 run -g` → `uvx smevals==0.2.0 build
+  -o docs/evals/.<lesson>.tmp/` → atomic rename into `docs/evals/<lesson>/`.
+  **Grade-fail is evidence, not a gate:** a `run` exiting non-zero *with*
+  recorded `runs/` still proceeds to build and exits 0 (a low accuracy is a
+  result); only a run that exited non-zero with NO runs fails the command,
+  naming the `run` stage. A build failure always fails naming `build` and
+  discards the temp, so a prior committed report survives — build-into-temp +
+  rename, NOT docs.yml's rm -rf precedent (local re-runs don't lose data).
+  `.smevals/` is cleaned before each generate (stale runs are false
+  evidence); lesson id = file stem via the shared course-root helper; a
+  missing `uvx` is a clean stage-named error with an install hint, never a
+  panic. The committed `docs/evals/01_seed_data/` report doubles as the
+  real-key smoke evidence.

--- a/docs/book/src/creating-lessons.md
+++ b/docs/book/src/creating-lessons.md
@@ -322,7 +322,44 @@ Add `--format json` for machine-readable output:
 blendtutor eval lessons/seed-data.yaml --format json
 ```
 
-## Step 9 — Build a browser site
+## Step 9 — Generate the eval report
+
+Turn-key eval evidence: generate a static report that grades your grading
+prompt — verdict polarity *and* feedback-message quality — on every case, then
+commit it where your deployed site publishes it:
+
+```bash
+blendtutor eval-report lessons/seed-data.yaml
+```
+
+The command drives the pinned [`smevals`](https://pypi.org/project/smevals/)
+package via `uvx`, so [`uv`](https://docs.astral.sh/uv/) must be on your PATH.
+It grades each case with a real paid LLM-judge call and produces two outputs:
+
+- **`<course>/.smevals/`** — an ephemeral working dir (gitignored): the
+  generated eval tasks, LLM judge outputs, and recorded runs. Never commit it.
+- **`docs/evals/<lesson>/`** — the committed static report (`index.html` +
+  `index.json`), published to GitHub Pages at `/evals/<lesson>/` on push.
+
+A completed-but-low-quality grade is evidence, not a failure: the command
+exits 0 as long as the run recorded its cases, even when most verdicts missed
+— the report shows the real accuracy. It fails only when a stage produced
+nothing usable.
+
+The report is generated **locally** and shipped by committing it, so your
+docs site can publish it:
+
+```bash
+git add docs/evals
+git commit -m "eval report: lessons/seed-data.yaml"
+```
+
+`blendtutor eval-report` needs the same `FIREWORKS_API_KEY` as `run` and
+`eval` — each case is a real paid provider call, so watch your spend. Run
+reports against the same provider your deployed site will use, and regenerate
+only when the grading prompt or eval cases change.
+
+## Step 10 — Build a browser site
 
 Once lessons validate and the eval suite passes, build a static browser site.
 Learners edit code in the browser, submit, and get instant AI feedback with no

--- a/docs/evidence/200/probe.log
+++ b/docs/evidence/200/probe.log
@@ -1,0 +1,21 @@
+=== Issue #200 probe chain (docs/evidence/200/probe.log) ===
+=== 2026-08-08T22:05:29Z branch 200-eval-report-docs @ b2012ed ===
+
+--- leg 1: bash scripts/check-docs.sh (structural probe) ---
+check-docs.sh: PASS (exit 0)
+
+--- legs 2-10: content greps ---
+P1 header '## Step 9 — Generate the eval report' present: PASS
+P2 header '## Step 10 — Build a browser site' present: PASS
+P3 exactly one '^## Step 9' (count=1): PASS
+P4 no eval-report.json in Step 9 section: PASS
+P5 README has 'blendtutor eval-report': PASS
+P6 README workflow regex 'eval.*eval-report.*build': PASS
+P7 eval.md has AC-1 tag: PASS
+P8 eval.md has '^acs:' frontmatter: PASS
+
+--- leg 11: readme spec test (crate package is blendtutor-cli; the probe's '-p blendtutor' is a package-name typo for '-p blendtutor-cli') ---
+test readme_documents_the_cli_install_and_workflow ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+


### PR DESCRIPTION
## Summary
Document the turn-key eval-report flow (issue #200): a new "Step 9 — Generate the eval report" in `creating-lessons.md` (old Step 9 renumbered to Step 10), a README eval-evidence pointer + workflow-string update, dated AC-1/2/3/5 entries in `docs/agent-notes/eval.md` (with `acs: [1, 2, 3, 5]` frontmatter), and an explicit `("eval-report command", "blendtutor eval-report")` pin in the readme spec test — the eval pin alone cannot detect a missing eval-report pin (substring gotcha).

The new Step 9 documents the REAL command + outputs: `<course>/.smevals/` (ephemeral, gitignored) vs `docs/evals/<lesson>/` (committed, published to `/evals/<lesson>/` on Pages), grade-fail-is-evidence exit semantics, the paid-Fireworks cost warning, `FIREWORKS_API_KEY` requirement, local-only generation, `git add docs/evals` scoping, and the `uv`/`uvx` prerequisite — with zero references to the OLD `eval-report.json` site-build artifact (anti-conflation).

**Bonus fix (pre-existing break):** `smevals_gen.rs` module doc had a broken intra-doc link (`[ProviderChoice::Fireworks::default_model]` — links through a variant), which fails the `RUSTDOCFLAGS="-D warnings"` rustdoc gate in both `scripts/check-docs.sh` and CI's `docs.yml`. Repaired to `[ProviderChoice::default_model()]`. Without this, the issue's structural probe could not pass — verified pre-existing on `origin/main@b2012ed` via stash + isolated rerun.

## Issue
Closes #200

## ACs implemented
- [x] Step 9 header present (exactly one), Step 10 renumbered, sits between Step 8 and Step 10
- [x] New Step 9 does NOT reference `eval-report.json` (0 hits in section; 6+ live refs elsewhere correctly describe the site-build artifact)
- [x] All Step 9 content greps: `blendtutor eval-report`, cost/paid/spend warning, `FIREWORKS_API_KEY`, local-only, grade-fail-is-evidence, `.smevals/` vs `docs/evals/<lesson>/`, `git add docs/evals`, `uv` prerequisite, `smevals` named
- [x] README: `eval-report` present (3×), workflow regex `eval.*eval-report.*build`, bullet pointer to `docs/evals/<lesson>/` eval evidence
- [x] agent-notes/eval.md: `acs: [1, 2, 3, 5]` frontmatter + dated `(#AC-1/2/3/5)` entries
- [x] readme.rs: `("eval-report command", "blendtutor eval-report")` tuple + docstring workflow updated; `cargo test -p blendtutor-cli --test readme` exits 0
- [x] `bash scripts/check-docs.sh` exits 0 (structural probe)

## Test plan
- [x] `bash scripts/check-docs.sh` — exit 0 (rustdoc -D warnings, mdBook, example sites, demos, evals assembly, failure propagation)
- [x] `cargo test -p blendtutor-cli` — all suites green (incl. readme + eval_report_cli)
- [x] Full probe chain + per-predicate results: `docs/evidence/200/probe.log`
- [x] Probe note: the issue's `cargo test -p blendtutor` package selector is a typo for `blendtutor-cli` (workspace package name); ran the equivalent `-p blendtutor-cli --test readme` — exits 0

## Self-Review
- [x] All ACs exercised by tests/probes
- [x] Predicates match spec
- [x] Negative case tested (duplicate-Step-9, eval-report.json conflation, missing cost warning / git scoping — all grep-guarded)
- [x] Verification medium satisfied (code · bash: check-docs.sh + content greps + readme.rs test)
- [x] Design intent respected (anti-conflation scope, README scope, agent-notes tag convention)
- [x] No scope creep (only the pre-existing rustdoc-link fix beyond declared docs files — required by the binding probe)
