### PR TITLE
[docs] Document the export-quarto flow — creating-lessons Step 11

### DIFF
--- a/docs/book/src/creating-lessons.md
+++ b/docs/book/src/creating-lessons.md
@@ -389,6 +389,59 @@ webR needs `SharedArrayBuffer`, which requires cross-origin isolation
 the site works on GitHub Pages without header configuration. See the README for
 deployment details.
 
+## Step 11 — Export a lesson to Quarto
+
+Have a lesson you want to hand out as an interactive exercise? `blendtutor
+export-quarto` converts a single lesson YAML file (`.yaml` or `.yml`) into a
+Quarto `.qmd` fenced-div snippet on stdout — no course directory, no build:
+
+```bash
+blendtutor export-quarto lessons/lesson_hello.yaml > my-exercises.qmd
+```
+
+The command validates the lesson first and refuses to export an invalid one.
+The snippet carries the prompt and code template, plus any checks, solution, or
+hints, and omits author-only and out-of-scope fields. For the scaffold
+`lesson_hello.yaml`, it prints exactly:
+
+````markdown
+::: {.blendtutor language="r"}
+Write R code that prints the word "hello" on its own line, using cat().
+
+```r
+# Your code here
+cat("hello\n")
+```
+:::
+````
+
+Paste the snippet into any `.qmd` document and render the exercises with the
+blendtutor Quarto extension:
+
+```bash
+quarto add mcmullarkey/blendtutor
+```
+
+```yaml
+---
+title: "My exercises"
+filters: [mcmullarkey/blendtutor]
+---
+```
+
+```bash
+quarto render my-exercises.qmd
+```
+
+See the
+[README §Quarto Extension](https://github.com/mcmullarkey/blendtutor#quarto-extension)
+for installation and usage details.
+
+`export-quarto` prints a snippet for authoring — it does not build a site. To
+emit a full browser site with an in-browser runtime, use `blendtutor build`
+(Step 10) instead. For the end-to-end journey from lesson file to a deployed
+Quarto page, see the [whole-game tutorial](./whole-game.md#quarto-deploy).
+
 ## Complete example courses
 
 The two reference courses in the repository are the best way to see the full

--- a/docs/evidence/211/probe.log
+++ b/docs/evidence/211/probe.log
@@ -1,0 +1,50 @@
+=== Issue #211 probe chain (docs/evidence/211/probe.log) ===
+=== 2026-08-10 branch 211-export-quarto-step11 ===
+
+--- I1 renumbering integrity: Step 9/10 headings intact, Step 11 after Step 10 ---
+PASS
+
+--- I2 command signature: 'blendtutor export-quarto <file>.yaml' (not course dir) ---
+blendtutor export-quarto lessons/lesson_hello.yaml > my-exercises.qmd
+PASS
+
+--- I3 stdout guidance: redirect to .qmd ---
+Quarto `.qmd` fenced-div snippet on stdout — no course directory, no build:
+blendtutor export-quarto lessons/lesson_hello.yaml > my-exercises.qmd
+Paste the snippet into any `.qmd` document and render the exercises with the
+PASS
+
+--- I4 example opening line byte-identical to real R output ('::: {.blendtutor language="r"}' + ```r) ---
+PASS
+
+--- I5 no llm_evaluation_prompt / gotchas in example ---
+PASS
+
+--- I6 extension flow: quarto add mcmullarkey/blendtutor + filters: [mcmullarkey/blendtutor] + quarto render + README cross-link ---
+quarto render my-exercises.qmd
+PASS
+
+--- I7 anti-conflation: export-quarto NOT claimed to build browser/static site ---
+PASS
+
+--- I8 cross-link to whole-game chapter (./whole-game.md#quarto-deploy) ---
+PASS
+
+--- I9 mdbook build docs/book ---
+ INFO Book building has started
+ INFO Running the html backend
+ INFO HTML book written to `docs/book/book`
+mdbook build: PASS (exit 0)
+
+--- I10 built HTML full example (no nested-fence truncation) ---
+grep '::: {.blendtutor language="r"}' creating-lessons.html: PASS
+grep 'cat("hello' creating-lessons.html (code-template survived): PASS
+HTML <pre><code class="language-markdown"> carries contiguous:
+  ::: {.blendtutor language="r"} ... ```r # Your code here cat("hello\n") ``` :::
+PASS
+
+--- I11 real-binary check: cargo run -q -p blendtutor-cli -- export-quarto crates/core/src/scaffold/lesson_hello.yaml ---
+exit 0; stdout first line '::: {.blendtutor language="r"}' found in creating-lessons.md
+PASS
+
+AC-3 OK (all 11 assertions)


### PR DESCRIPTION
## Summary
Documents the currently-UNDOCUMENTED `blendtutor export-quarto` command as Step 11 in `docs/book/src/creating-lessons.md`, inserted after Step 10 (no renumbering of Steps 1-10). Covers: single-lesson YAML → `.qmd` fenced-div snippet on stdout (redirect guidance, not a course dir, no build); validation-first behavior; the real scaffold-lesson output as the example; Quarto extension install + filter enablement (cross-linking README §Quarto Extension); anti-conflation with `blendtutor build`; and a forward cross-link to the whole-game chapter's Quarto deploy section.

**Nested-fence fix:** the example contains inner ` ```r ` fences, so it is wrapped in a 4-backtick outer fence — a 3-backtick outer fence would close at the first bare ` ``` ` and truncate the example under mdBook (README lines 194-206 have this latent bug; mdBook does not render it loosely).

## Issue
Closes #211

## ACs implemented
- [x] Step 11 heading after Step 10; Steps 9-10 headings intact (no renumbering)
- [x] Command signature `blendtutor export-quarto <lesson>.yaml` (not course dir)
- [x] Stdout redirect guidance to `.qmd`
- [x] Example opening line byte-identical to real `export_lesson_to_qmd` output (`::: {.blendtutor language="r"}`, ` ```r ` tag)
- [x] No `llm_evaluation_prompt` / `gotchas` / `packages` in example
- [x] Extension install (`quarto add mcmullarkey/blendtutor`) + filter (`filters: [mcmullarkey/blendtutor]`) + `quarto render` + README cross-link
- [x] Anti-conflation: export-quarto does NOT build a browser/static site
- [x] Cross-link to whole-game chapter (`./whole-game.md#quarto-deploy`, forward link)
- [x] `mdbook build docs/book` exit 0; built HTML contains full example (no fence truncation)
- [x] Real-binary check: `cargo run -p blendtutor-cli -- export-quarto crates/core/src/scaffold/lesson_hello.yaml` exit 0; stdout first line matches doc example

## Test plan
- [x] 11-assertion probe: PASS ("AC-3 OK"), evidence at `docs/evidence/211/probe.log`
- [x] mdbook build: exit 0
- [x] Real export-quarto binary: exit 0, first stdout line `::: {.blendtutor language="r"}` present in doc

## Self-Review
- [x] All ACs exercised by tests (11-assertion probe)
- [x] Predicates match spec
- [x] Negative case covered (nested-fence truncation + anti-conflation)
- [x] Verification medium satisfied (code: probe + mdbook build + real binary)
- [x] Design intent respected
- [x] No scope creep