### PR TITLE
[docs] Add 'The whole game' mdBook chapter (#210)

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -2,6 +2,7 @@
 
 [Introduction](./introduction.md)
 
+- [The whole game](./whole-game.md)
 - [Creating Lessons](./creating-lessons.md)
 - [Architecture](./architecture.md)
 - [Example sites](./examples.md)

--- a/docs/book/src/whole-game.md
+++ b/docs/book/src/whole-game.md
@@ -1,0 +1,151 @@
+# The whole game
+
+This chapter walks one course end to end: scaffold it, add a lesson, validate
+it, run it, grade it with the LLM judge, generate an eval report, and deploy it
+two ways — as a static browser site and as a Quarto document. Every command is
+copy-paste ready. For the field-by-field anatomy of a lesson file, see
+[Creating Lessons](./creating-lessons.md); for the Quarto extension and site
+deployment details, see the [README](../../../README.md).
+
+## Init — scaffold a course
+
+`blendtutor init` creates a course directory with a runnable starter lesson:
+
+```bash
+blendtutor init hello-course
+```
+
+The starter lesson `lesson_hello.yaml` sits at the course root, so its manifest
+path is `lesson_hello.yaml` with no `lessons/` prefix. It is a complete R
+lesson — the rest of this walkthrough follows it.
+
+## New lesson — author your own
+
+The scaffold is a starting point. Real lessons live under `lessons/` and are
+created with `new lesson`:
+
+```bash
+blendtutor new lesson --lang r hello
+```
+
+This writes `lessons/hello.yaml`. `--lang r` picks R; `--lang python` picks
+Python. Edit the file to change the prompt and code template.
+
+## Validate — check the lesson
+
+Validate a lesson file before running anything:
+
+```bash
+blendtutor validate lesson_hello.yaml
+```
+
+Validation checks structure and semantics, naming the field and value when
+something is wrong. Add `--format json` for machine-readable output.
+
+## Run — see the lesson live
+
+Run the starter lesson locally and read the feedback it produces:
+
+```bash
+blendtutor run lesson_hello.yaml
+```
+
+`run` executes the lesson and returns the LLM feedback a student would see.
+Pipe a submission in, or pass `--code <file>` to grade a submission file.
+
+## Eval — grade it with the LLM judge
+
+`eval` runs the lesson's cases through the LLM judge. This makes real paid LLM
+calls, so set the API key first and expect spend:
+
+```bash
+export FIREWORKS_API_KEY=fw_...
+blendtutor eval lesson_hello.yaml
+```
+
+The starter lesson ships two cases — a correct submission and an incorrect one.
+Use `--case N` for a single case, `--format json` for JSON output.
+
+## Eval report — generate the report
+
+`eval-report` aggregates every graded run into a browsable report under
+`docs/evals/<lesson>/`, where `<lesson>` is the stem of the lesson filename —
+`lesson_hello.yaml` reports to `docs/evals/lesson_hello/`:
+
+```bash
+blendtutor eval-report lesson_hello.yaml
+```
+
+This needs the same `FIREWORKS_API_KEY` as `eval`.
+
+## Reading the eval report
+
+The report is static files under `docs/evals/lesson_hello/` — no server
+required. The committed starter report shows the shape.
+
+`index.json` is the overview: the eval slug, run counts, `graded`, `fails`, and
+`best` — the best score across configs (0.76 for the starter).
+
+Each graded run has a `grade.yaml` under `.../runs/<case>/default/.../grades/`
+with an `outcome` (`pass` or `fail`), a `score`, and `checks`. The judge check
+scores five metrics from 0.0 to 5.0:
+`verdict_rationale_correctness`, `actionability`, `references_check_results`,
+`no_solution_leak`, `no_hallucinated_errors`.
+
+A case passes when its score is at least the 0.8 threshold. The starter report
+has one of each: case-1 passes at 0.96 with every metric at 4.0 or above, and
+case-2 fails at 0.56 — its `no_solution_leak` scored 0.0 because the feedback
+gave away the answer string. A failing grade is evidence the case needs
+rework, and the metrics say exactly where.
+
+`output.txt` holds the judged feedback: line 1 is `verdict: correct` or
+`verdict: incorrect`, and the remaining lines are the feedback text the judge
+scored.
+
+Two gotchas. First, `index.html` is a single-page app that fetches the report
+data over HTTP, so opening it directly with `file://` shows a blank page. Serve
+the directory instead:
+
+```bash
+cd docs/evals/lesson_hello && python3 -m http.server
+```
+
+Second, the `lesson` field in `eval.json` holds the absolute path the eval ran
+against — treat the report as evidence of a run, not as a portable path
+reference.
+
+## Build — a static browser site
+
+`build` turns the course into a fully static site with an in-browser runtime:
+
+```bash
+blendtutor build hello-course --target webr -o site
+```
+
+`--target` picks the runtime: `webr` for R lessons, `pyodide` for Python. The
+`site/` output deploys to GitHub Pages as-is, and the build embeds an
+eval-results page when the course has a report.
+
+## Quarto deploy
+
+`export-quarto` prints the lesson as a Quarto fenced div, ready to paste into a
+Quarto document:
+
+```bash
+blendtutor export-quarto lesson_hello.yaml
+```
+
+````markdown
+::: {.blendtutor language="r"}
+<!-- the lesson's prompt and code template, rendered from the YAML -->
+:::
+````
+
+To render exercises, install the blendtutor Quarto extension — see the
+[README](../../../README.md) for requirements (Quarto 1.4 or newer) — then
+render:
+
+```bash
+quarto add mcmullarkey/blendtutor
+quarto render
+```

--- a/docs/book/src/whole-game.md
+++ b/docs/book/src/whole-game.md
@@ -1,9 +1,10 @@
 # The whole game
 
 This chapter walks one course end to end: scaffold it, add a lesson, validate
-it, run it, grade it with the LLM judge, generate an eval report, and deploy it
-two ways — as a static browser site and as a Quarto document. Every command is
-copy-paste ready. For the field-by-field anatomy of a lesson file, see
+it, run it, score the grader's polarity, generate an eval report with the LLM
+judge, and deploy it two ways — as a static browser site and as a Quarto
+document. Every command is copy-paste ready. For the field-by-field anatomy of
+a lesson file, see
 [Creating Lessons](./creating-lessons.md); for the Quarto extension and site
 deployment details, see the [README](../../../README.md).
 
@@ -71,8 +72,8 @@ Use `--case N` for a single case, `--format json` for JSON output.
 ## Eval report — grade with the LLM judge
 
 `eval-report` drives the pinned smevals runner, which grades each case with
-polarity AND a real paid LLM-judge call, then aggregates the graded runs into a
-browsable report under `docs/evals/<lesson>/`, where `<lesson>` is the stem of
+polarity AND a real paid LLM-judge call, then publishes the smevals report into
+a browsable site under `docs/evals/<lesson>/`, where `<lesson>` is the stem of
 the lesson filename — `lesson_hello.yaml` reports to `docs/evals/lesson_hello/`:
 
 ```bash
@@ -87,8 +88,8 @@ The report is static files under `docs/evals/lesson_hello/` — no server
 required. The committed starter report shows the shape.
 
 `index.json` is the overview: the eval slug, run counts, `graded`, `fails`, and
-`best` — the aggregate accuracy across the suite's cases (0.76 for the
-starter).
+`best` — the best score across configs (for the starter's single `default`
+config, that's the aggregate accuracy across the suite's cases, 0.76).
 
 Each graded run has a `grade.yaml` under `.../runs/<case>/default/.../grades/`
 with an `outcome` (`pass` or `fail`), a `score`, and `checks`. The judge check

--- a/docs/book/src/whole-game.md
+++ b/docs/book/src/whole-game.md
@@ -53,10 +53,12 @@ blendtutor run lesson_hello.yaml
 `run` executes the lesson and returns the LLM feedback a student would see.
 Pipe a submission in, or pass `--code <file>` to grade a submission file.
 
-## Eval — grade it with the LLM judge
+## Eval — score grading accuracy
 
-`eval` runs the lesson's cases through the LLM judge. This makes real paid LLM
-calls, so set the API key first and expect spend:
+`eval` replays each case through the run pipeline and reports how often the
+grader's verdict matches the expected one — polarity scoring. This still makes
+real paid LLM calls (the student feedback for each case), so set the API key
+first and expect spend:
 
 ```bash
 export FIREWORKS_API_KEY=fw_...
@@ -66,11 +68,12 @@ blendtutor eval lesson_hello.yaml
 The starter lesson ships two cases — a correct submission and an incorrect one.
 Use `--case N` for a single case, `--format json` for JSON output.
 
-## Eval report — generate the report
+## Eval report — grade with the LLM judge
 
-`eval-report` aggregates every graded run into a browsable report under
-`docs/evals/<lesson>/`, where `<lesson>` is the stem of the lesson filename —
-`lesson_hello.yaml` reports to `docs/evals/lesson_hello/`:
+`eval-report` drives the pinned smevals runner, which grades each case with
+polarity AND a real paid LLM-judge call, then aggregates the graded runs into a
+browsable report under `docs/evals/<lesson>/`, where `<lesson>` is the stem of
+the lesson filename — `lesson_hello.yaml` reports to `docs/evals/lesson_hello/`:
 
 ```bash
 blendtutor eval-report lesson_hello.yaml
@@ -84,7 +87,8 @@ The report is static files under `docs/evals/lesson_hello/` — no server
 required. The committed starter report shows the shape.
 
 `index.json` is the overview: the eval slug, run counts, `graded`, `fails`, and
-`best` — the best score across configs (0.76 for the starter).
+`best` — the aggregate accuracy across the suite's cases (0.76 for the
+starter).
 
 Each graded run has a `grade.yaml` under `.../runs/<case>/default/.../grades/`
 with an `outcome` (`pass` or `fail`), a `score`, and `checks`. The judge check
@@ -96,7 +100,8 @@ A case passes when its score is at least the 0.8 threshold. The starter report
 has one of each: case-1 passes at 0.96 with every metric at 4.0 or above, and
 case-2 fails at 0.56 — its `no_solution_leak` scored 0.0 because the feedback
 gave away the answer string. A failing grade is evidence the case needs
-rework, and the metrics say exactly where.
+rework, and the metrics say exactly where. `references_check_results` scored
+2.0, the only other metric below the 4.0 floor — both are rework targets.
 
 `output.txt` holds the judged feedback: line 1 is `verdict: correct` or
 `verdict: incorrect`, and the remaining lines are the feedback text the judge

--- a/docs/evidence/210/ac2-probe.log
+++ b/docs/evidence/210/ac2-probe.log
@@ -1,0 +1,18 @@
+A: OK
+B: OK
+C: OK
+D: OK
+E: OK
+F: OK
+G: OK
+H: OK
+I: OK
+J: OK
+K: OK
+L: OK (22 fence lines)
+ INFO Book building has started
+ INFO Running the html backend
+ INFO HTML book written to `/Users/carbonite/Documents/coding/portfolio/worktree-issue-210/docs/book/book`
+M: OK
+N: OK
+AC-2 merged probe: OK

--- a/docs/evidence/210/ac2-probe.log
+++ b/docs/evidence/210/ac2-probe.log
@@ -9,10 +9,11 @@ H: OK
 I: OK
 J: OK
 K: OK
-L: OK (22 fence lines)
+L (22 fence lines): OK
  INFO Book building has started
  INFO Running the html backend
  INFO HTML book written to `/Users/carbonite/Documents/coding/portfolio/worktree-issue-210/docs/book/book`
 M: OK
 N: OK
-AC-2 merged probe: OK
+O (intro pin): OK
+AC-2 merged probe: OK (38 clauses + intro pin)


### PR DESCRIPTION
## Summary
Adds the "The whole game" mdBook chapter (`docs/book/src/whole-game.md`) + SUMMARY entry: one continuous init → new lesson → validate → run → eval → eval-report → build → deploy walkthrough using the scaffold starter (`lesson_hello.yaml` at course root), a "Reading the eval report" section describing the REAL committed AC-1 report (`docs/evals/lesson_hello/` — case-1 pass 0.96, case-2 fail 0.56, 0.8 threshold, five judge metrics, output.txt verdict format), the file:// serving gotcha, both deploy paths (`build --target webr`, `export-quarto` → `quarto add`/`quarto render`), and the FIREWORKS_API_KEY requirement. Terse r4ds whole-game style, no emojis, copy-paste-ready commands.

## Issue
Closes #210

## ACs implemented
- [x] File existence + SUMMARY order + `# The whole game` H1
- [x] No emoji (incl. variation-selector) — merged union regex
- [x] All 8 stages present in order (first-occurrence monotonic)
- [x] Scaffold at course root: `lesson_hello.yaml`, no `lessons/lesson_hello.yaml`
- [x] Anti-conflation: no "export-quarto ... builds site", no `eval-report.json`
- [x] `/evals/lesson_hello/` (no `/evals/01_seed_data/`)
- [x] Reading-the-report: real shape (index.json, grade.yaml, 0.8, 5 metric names, output.txt, "evidence")
- [x] file:// gotcha → `python3 -m http.server`
- [x] Both deploy paths (`--target webr`, `quarto add`, `quarto render`)
- [x] Cross-links: `./creating-lessons.md`, README, `## Quarto deploy` heading (slug `quarto-deploy` — anchor for AC-3 back-link)
- [x] Fence collision: 4-backtick outer fence around `:::` output
- [x] 22 fence lines (≥16) — predominantly copy-paste
- [x] mdbook build exit 0 + built-HTML content greps (evals/lesson_hello, export-quarto, 0.8, metrics, creating-lessons.html, `:::`)
- [x] `FIREWORKS_API_KEY` disclosed before eval/eval-report legs

## Test plan
- [x] 38-clause probe: PASS (all A–N)
- [x] mdbook build docs/book: exit 0
- [x] Built HTML: `id="quarto-deploy"` anchor present, creating-lessons.html link present
- [x] Probe evidence committed to docs/evidence/210/ac2-probe.log

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested (probe rejects each negative listed in spec)
- [x] Verification medium satisfied (code + manual tone skim)
- [x] Design intent respected (r4ds see-it-all-at-once, real committed report, no fabrication)
- [x] No scope creep

Note: merge order — AC-3's `./whole-game.md#quarto-deploy` back-link targets this chapter's `## Quarto deploy` heading; this PR should merge before AC-3's Step 11 doc (matches AC-2 before-AC-3 dependency).