### PR TITLE
[bug] fix smevals generator wrong-depth runner path (scripts/smevals marker + refusal)

### DIFF
--- a/.opencode/plans/evidence-hardening/AC-216.md
+++ b/.opencode/plans/evidence-hardening/AC-216.md
@@ -59,6 +59,7 @@ status: spec
 
 ### Progress
 - [x] — implemented + green (2026-08-10): marker walk-up (`scripts/smevals` `.is_dir()`), `GenError::NoRepoRoot` + Display arm, `write_eval_dir` resolve-first refusal, 4 new in-module tests + rewritten refusal test + strengthened depth-1 canonicalize-equal; lib 196 passed, golden byte-identical (regenerated + `git diff --exit-code` clean), golden test 12 passed
+- [x] — review cycle 1 fix (2026-08-10): (1) rewrote `canonicalize-verification.log` header — scratch example `verify_216` was never committed, so header now states manual probe + exact command instead of a phantom binary run (fix-now); (2) mirrored the dual-consumer graders canonicalize-equal assertion (check_polarity.sh) into depth-3 and no-git tests (consider); scripts_rel 4 passed, golden_non_default 1 passed, generate_eval_dir 12 passed
 
 ### Decision Log
 - 2026-08-10 — synthesized A (marker walk-up, subsumes .git) + B (refuse-no-fallback): marker root + GenError::NoRepoRoot refusal; DEFAULT_SCRIPTS_REL deleted from effectful path entirely; golden byte-identical (re-baseline = regenerate + diff-confirm); P4 non-4-hop as in-module unit test (generate_eval_dir_with is private, cannot be committed-fixture integration test); no CLI test churn
@@ -68,6 +69,7 @@ status: spec
 - canonicalize-resolve from `<course>/.smevals/configs/` requires the `.smevals` dirs to EXIST on disk — `Path::canonicalize` walks physically, not lexically; `..` hops through a non-existent intermediate dir return `NotFound`. Tests must create the dirs (as `write_eval_dir` does before emitting) before resolving. First depth-1 run panicked on this.
 - Repo's own `.git` is a FILE (worktree pointer), not a directory — the marker-based root finder sidesteps worktree/`.git`-shape fragility entirely; `scripts/smevals/` is a real dir in every checkout.
 - rtk output filtering mangles grep of `write_eval_dir`/`GenError`-heavy lines (words replaced with `n`) — use raw grep (no rtk prefix) when verifying symbol consumers.
+- Evidence log claimed `Running target/debug/examples/verify_216` but the scratch example binary was never committed — reviewers cannot re-run a probe whose source is absent. Manual-probe logs must state "manual probe + exact command" rather than cargo-run output for uncommitted scratch binaries.
 
 ### Idempotence & Recovery
 - Safe retry: re-run cargo test -p blendtutor-core --lib; pure generator untouched so golden deterministic

--- a/.opencode/plans/evidence-hardening/AC-216.md
+++ b/.opencode/plans/evidence-hardening/AC-216.md
@@ -58,13 +58,16 @@ status: spec
 - **Risk level:** low — private/local function area, single call site changed, golden integrity asserted by existing test
 
 ### Progress
-- [ ] — pending impl
+- [x] — implemented + green (2026-08-10): marker walk-up (`scripts/smevals` `.is_dir()`), `GenError::NoRepoRoot` + Display arm, `write_eval_dir` resolve-first refusal, 4 new in-module tests + rewritten refusal test + strengthened depth-1 canonicalize-equal; lib 196 passed, golden byte-identical (regenerated + `git diff --exit-code` clean), golden test 12 passed
 
 ### Decision Log
 - 2026-08-10 — synthesized A (marker walk-up, subsumes .git) + B (refuse-no-fallback): marker root + GenError::NoRepoRoot refusal; DEFAULT_SCRIPTS_REL deleted from effectful path entirely; golden byte-identical (re-baseline = regenerate + diff-confirm); P4 non-4-hop as in-module unit test (generate_eval_dir_with is private, cannot be committed-fixture integration test); no CLI test churn
+- 2026-08-10 (impl) — canonicalize is physical: new depth-1/3/no-git tests must `create_dir_all` the `.smevals/configs`(+`graders`) dirs before canonicalize-resolving (NotFound otherwise); the existing kept test already did this — copied the pattern.
 
 ### Surprises & Discoveries
-- (none yet)
+- canonicalize-resolve from `<course>/.smevals/configs/` requires the `.smevals` dirs to EXIST on disk — `Path::canonicalize` walks physically, not lexically; `..` hops through a non-existent intermediate dir return `NotFound`. Tests must create the dirs (as `write_eval_dir` does before emitting) before resolving. First depth-1 run panicked on this.
+- Repo's own `.git` is a FILE (worktree pointer), not a directory — the marker-based root finder sidesteps worktree/`.git`-shape fragility entirely; `scripts/smevals/` is a real dir in every checkout.
+- rtk output filtering mangles grep of `write_eval_dir`/`GenError`-heavy lines (words replaced with `n`) — use raw grep (no rtk prefix) when verifying symbol consumers.
 
 ### Idempotence & Recovery
 - Safe retry: re-run cargo test -p blendtutor-core --lib; pure generator untouched so golden deterministic

--- a/crates/cli/tests/eval_report_cli.rs
+++ b/crates/cli/tests/eval_report_cli.rs
@@ -82,9 +82,12 @@ struct Harness {
 impl Harness {
     fn new() -> Self {
         let root = tempfile::tempdir().expect("a tempdir for the fake repo");
-        // The repo-root boundary: like the real repo, a `.git` dir marks it,
-        // and `docs/evals/` lives just below.
+        // The repo-root boundary: like the real repo, a `.git` dir marks it for
+        // eval-report's docs/evals placement, and a `scripts/smevals/` dir
+        // marks it for the generator's script-prefix walk-up (both are needed —
+        // a `.git`-only root now refuses generation).
         fs::create_dir_all(root.path().join(".git")).unwrap();
+        fs::create_dir_all(root.path().join("scripts").join("smevals")).unwrap();
         let course = root.path().join("examples").join("demo-course");
         fs::create_dir_all(&course).unwrap();
         fs::write(

--- a/crates/core/src/smevals_gen.rs
+++ b/crates/core/src/smevals_gen.rs
@@ -68,6 +68,15 @@ pub enum GenError {
     /// The suite has no cases. A vacuous "100% pass" is a sneaky pass, so an
     /// empty suite is refused rather than emitting `tasks/` with zero files.
     EmptySuite,
+    /// No ancestor of the course root contains `scripts/smevals/`, so the
+    /// script-path prefix cannot be computed exactly (and the old four-hop
+    /// guess is exactly the wrong-depth bug this refusal replaces). The
+    /// effectful shell refuses rather than emit a path that resolves
+    /// somewhere else (§1.1).
+    NoRepoRoot {
+        /// The canonicalized course root that was walked up from.
+        course_root: PathBuf,
+    },
     /// Writing a generated file failed (the effectful shell only — the pure
     /// generator never touches the filesystem).
     Write {
@@ -90,6 +99,11 @@ impl fmt::Display for GenError {
                 f,
                 "refusing to generate an eval dir for an empty eval suite: no cases \
                  to evaluate"
+            ),
+            GenError::NoRepoRoot { course_root } => write!(
+                f,
+                "no repo root (an ancestor containing scripts/smevals/) found above {}",
+                course_root.display()
             ),
             GenError::Write { path, source } => {
                 write!(f, "writing {} failed: {source}", path.display())
@@ -391,13 +405,14 @@ pub fn write_eval_dir(
         path: dir.to_path_buf(),
         source,
     })?;
-    let files = generate_eval_dir_with(
-        lesson,
-        suite,
-        lesson_id,
-        lesson_path,
-        &scripts_rel_from(&dir),
-    )?;
+    // Resolve the exact script-path prefix first — the only thing this shell
+    // knows and the pure generator doesn't. Refusal (rather than a wrong-depth
+    // fallback) happens here, before any `create_dir_all`/`fs::write`, so no
+    // partial tree is left behind (§1.1, §2.4).
+    let scripts_rel = scripts_rel_from(&dir).ok_or_else(|| GenError::NoRepoRoot {
+        course_root: dir.clone(),
+    })?;
+    let files = generate_eval_dir_with(lesson, suite, lesson_id, lesson_path, &scripts_rel)?;
     for (path, contents) in &files {
         let target = dir.join(".smevals").join(path);
         if let Some(parent) = target.parent() {
@@ -415,18 +430,21 @@ pub fn write_eval_dir(
 }
 
 /// The `scripts/smevals/` prefix (with trailing `/`) that, relative to the
-/// generated `configs/` (or `graders/`) directory, reaches the repo's scripts:
-/// walk up from the course root to the repo root (the nearest ancestor with a
-/// `.git`), then compute the relative descent. Falls back to
-/// [`DEFAULT_SCRIPTS_REL`] when no repo root is found (e.g. a course outside a
-/// git checkout), which smevals surfaces loudly at run time rather than this
-/// function guessing.
-fn scripts_rel_from(course_root: &Path) -> String {
+/// generated `configs/` (or `graders/`) directory, reaches the repo's scripts.
+///
+/// The repo root is the nearest ancestor containing a `scripts/smevals/`
+/// directory (the marker — the repo root always has it; `.git` alone does NOT
+/// count, since a course inside some other git project would otherwise get a
+/// wrong-depth guess). Returns `None` when no such ancestor exists; the
+/// effectful [`write_eval_dir`] then refuses with [`GenError::NoRepoRoot`]
+/// rather than emit a fallback prefix. The four-hop [`DEFAULT_SCRIPTS_REL`]
+/// default belongs to the pure layer only, which has no filesystem context.
+fn scripts_rel_from(course_root: &Path) -> Option<String> {
     let mut current = Some(course_root);
     let repo_root = loop {
         match current {
             Some(dir) => {
-                if dir.join(".git").exists() {
+                if dir.join("scripts").join("smevals").is_dir() {
                     break Some(dir);
                 }
                 current = dir.parent();
@@ -434,15 +452,10 @@ fn scripts_rel_from(course_root: &Path) -> String {
             None => break None,
         }
     };
-    let Some(repo_root) = repo_root else {
-        return DEFAULT_SCRIPTS_REL.to_string();
-    };
+    let repo_root = repo_root?;
     let configs_dir = course_root.join(".smevals").join("configs");
     let scripts_dir = repo_root.join("scripts").join("smevals");
-    match relative_path(&configs_dir, &scripts_dir) {
-        Some(rel) => format!("{}/", rel.to_string_lossy()),
-        None => DEFAULT_SCRIPTS_REL.to_string(),
-    }
+    relative_path(&configs_dir, &scripts_dir).map(|rel| format!("{}/", rel.to_string_lossy()))
 }
 
 /// The path from `from` to `to`, both absolute, as `../..` hops then descent.
@@ -533,7 +546,7 @@ mod tests {
         let course = repo.path().join("examples/write-less-code-r");
         std::fs::create_dir_all(&course).unwrap();
 
-        let rel = scripts_rel_from(&course);
+        let rel = scripts_rel_from(&course).unwrap();
         assert_eq!(rel, "../../../../scripts/smevals/");
         // The emitted runner path resolves to the real script (canonicalize
         // requires the leaf to exist, so create the placeholder script).
@@ -554,9 +567,69 @@ mod tests {
     }
 
     #[test]
-    fn scripts_rel_defaults_when_no_repo_root_exists() {
+    fn write_eval_dir_errors_when_no_scripts_ancestor() {
         let dir = tempfile::tempdir().unwrap();
-        assert_eq!(scripts_rel_from(dir.path()), DEFAULT_SCRIPTS_REL);
+        // No ancestor of the tempdir contains `scripts/smevals/` — with or
+        // without a `.git` present, the marker walk-up finds no repo root and
+        // the effectful shell must refuse rather than emit the wrong-depth
+        // four-hop default.
+        assert_eq!(
+            scripts_rel_from(dir.path()),
+            None,
+            "no scripts/smevals ancestor must resolve to None, not a default prefix"
+        );
+
+        let lesson = Lesson::parse(
+            "lesson_name: x\nlanguage: R\nexercise:\n  prompt: do it\n  \
+             llm_evaluation_prompt: grade {student_code}\n",
+        )
+        .unwrap();
+        let suite = EvalSuite {
+            cases: vec![EvalCase {
+                submission: "cat(\"hi\\n\")\n".to_string(),
+                expected: ExpectedVerdict::Correct,
+            }],
+        };
+        let err = write_eval_dir(
+            dir.path(),
+            &lesson,
+            &suite,
+            "my-lesson",
+            Path::new("/lessons/my-lesson.yaml"),
+        )
+        .expect_err("a course with no scripts/smevals ancestor must be refused");
+        match err {
+            GenError::NoRepoRoot { course_root } => assert_eq!(
+                course_root,
+                dir.path().canonicalize().unwrap(),
+                "the error names the canonicalized course root it refused"
+            ),
+            other => panic!("expected GenError::NoRepoRoot, got: {other}"),
+        }
+        assert!(
+            !dir.path().join(".smevals").exists(),
+            "refusal must happen before any directory is created — no partial tree"
+        );
+
+        // A `.git`-only ancestor does NOT count as a repo root either: a course
+        // inside a git project that is not this repo must refuse instead of
+        // guessing (behavior change, intentional — §1.1).
+        let git_only = dir.path().join("git-only-course");
+        std::fs::create_dir_all(git_only.join(".git")).unwrap();
+        assert_eq!(
+            scripts_rel_from(&git_only),
+            None,
+            "a .git ancestor without the scripts/smevals marker must not resolve"
+        );
+        let err = write_eval_dir(
+            &git_only,
+            &lesson,
+            &suite,
+            "my-lesson",
+            Path::new("/lessons/my-lesson.yaml"),
+        )
+        .expect_err("a .git-only ancestor must also be refused");
+        assert!(matches!(err, GenError::NoRepoRoot { .. }));
     }
 
     #[test]
@@ -564,6 +637,9 @@ mod tests {
         let repo = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(repo.path().join(".git")).unwrap();
         std::fs::create_dir_all(repo.path().join("scripts/smevals")).unwrap();
+        // canonicalize requires the leaf to exist, so create the placeholder
+        // runner before resolving the emitted path.
+        std::fs::write(repo.path().join("scripts/smevals/run.sh"), "#!/bin/sh\n").unwrap();
         let course = repo.path().join("my-course");
         std::fs::create_dir_all(&course).unwrap();
 
@@ -592,11 +668,19 @@ mod tests {
         assert!(eval_dir.join("configs/default.yaml").is_file());
         assert!(eval_dir.join("graders/default.yaml").is_file());
         assert!(eval_dir.join("tasks/case-1.yaml").is_file());
-        let config = std::fs::read_to_string(eval_dir.join("configs/default.yaml")).unwrap();
-        // Course is one level below the repo root here → 3 `..` hops.
-        assert!(
-            config.contains("../../../scripts/smevals/run.sh"),
-            "config must reference the runner relative to the course, got: {config}"
+        // Course is one level below the repo root here → 3 `..` hops; the
+        // emitted runner must canonicalize-resolve to the real script (not just
+        // contain the expected substring — the whole point of the fix).
+        let resolved_runner = eval_dir
+            .join("configs")
+            .join("../../../scripts/smevals/run.sh");
+        assert_eq!(
+            resolved_runner.canonicalize().unwrap(),
+            repo.path()
+                .join("scripts/smevals/run.sh")
+                .canonicalize()
+                .unwrap(),
+            "runner emitted into configs/default.yaml must resolve to the real script"
         );
         // The task's `lesson:` key carries the lesson file path (not the slug):
         // the runner forwards it verbatim to `blendtutor eval <path>`.
@@ -604,6 +688,156 @@ mod tests {
         assert!(
             task.contains("lesson: /lessons/my-lesson.yaml\n"),
             "task must carry the lesson path the runner grades, got: {task}"
+        );
+    }
+
+    #[test]
+    fn scripts_rel_resolves_at_depth_1_below_repo_root() {
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(repo.path().join(".git")).unwrap();
+        std::fs::create_dir_all(repo.path().join("scripts/smevals")).unwrap();
+        std::fs::write(repo.path().join("scripts/smevals/run.sh"), "#!/bin/sh\n").unwrap();
+        std::fs::write(
+            repo.path().join("scripts/smevals/check_polarity.sh"),
+            "#!/bin/sh\n",
+        )
+        .unwrap();
+        let course = repo.path().join("my-course");
+        std::fs::create_dir_all(&course).unwrap();
+
+        let rel = scripts_rel_from(&course).unwrap();
+        assert_eq!(rel, "../../../scripts/smevals/", "depth 1 needs 3 hops");
+        // Both consumers (configs runner + graders checker) thread the same
+        // prefix and must canonicalize-resolve to the real scripts dir.
+        // (canonicalize is physical, so the `.smevals` dirs must exist first —
+        // write_eval_dir creates them before any resolution happens.)
+        std::fs::create_dir_all(course.join(".smevals/configs")).unwrap();
+        std::fs::create_dir_all(course.join(".smevals/graders")).unwrap();
+        let configs_resolved = course
+            .join(".smevals")
+            .join("configs")
+            .join(&rel)
+            .join("run.sh");
+        assert_eq!(
+            configs_resolved.canonicalize().unwrap(),
+            repo.path()
+                .join("scripts/smevals/run.sh")
+                .canonicalize()
+                .unwrap()
+        );
+        let graders_resolved = course
+            .join(".smevals")
+            .join("graders")
+            .join(&rel)
+            .join("check_polarity.sh");
+        assert_eq!(
+            graders_resolved.canonicalize().unwrap(),
+            repo.path()
+                .join("scripts/smevals/check_polarity.sh")
+                .canonicalize()
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn scripts_rel_resolves_at_depth_3_below_repo_root() {
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(repo.path().join(".git")).unwrap();
+        std::fs::create_dir_all(repo.path().join("scripts/smevals")).unwrap();
+        std::fs::write(repo.path().join("scripts/smevals/run.sh"), "#!/bin/sh\n").unwrap();
+        let course = repo.path().join("a").join("b").join("my-course");
+        std::fs::create_dir_all(&course).unwrap();
+
+        let rel = scripts_rel_from(&course).unwrap();
+        assert_eq!(
+            rel, "../../../../../scripts/smevals/",
+            "depth 3 needs 5 hops"
+        );
+        std::fs::create_dir_all(course.join(".smevals/configs")).unwrap();
+        let resolved = course
+            .join(".smevals")
+            .join("configs")
+            .join(&rel)
+            .join("run.sh");
+        assert_eq!(
+            resolved.canonicalize().unwrap(),
+            repo.path()
+                .join("scripts/smevals/run.sh")
+                .canonicalize()
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn scripts_rel_resolves_without_git_when_marker_present() {
+        // Release tarballs / export-quarto'd courses have no `.git`; the marker
+        // alone must resolve (refusal here would be a false negative).
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(repo.path().join("scripts/smevals")).unwrap();
+        std::fs::write(repo.path().join("scripts/smevals/run.sh"), "#!/bin/sh\n").unwrap();
+        let course = repo.path().join("examples").join("tarball-course");
+        std::fs::create_dir_all(&course).unwrap();
+
+        let rel = scripts_rel_from(&course).unwrap();
+        assert_eq!(rel, "../../../../scripts/smevals/", "depth 2 needs 4 hops");
+        std::fs::create_dir_all(course.join(".smevals/configs")).unwrap();
+        let resolved = course
+            .join(".smevals")
+            .join("configs")
+            .join(&rel)
+            .join("run.sh");
+        assert_eq!(
+            resolved.canonicalize().unwrap(),
+            repo.path()
+                .join("scripts/smevals/run.sh")
+                .canonicalize()
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn golden_non_default_depth_emits_plain_3hop_prefix() {
+        // P4: the fix is exercised in the pure layer — an explicit 3-hop prefix
+        // flows through BOTH consumers as plain, unquoted YAML scalars (the
+        // same charset as today's `emit_inline_scalar` output, no escaping).
+        let lesson = Lesson::parse(
+            "lesson_name: x\nlanguage: R\nexercise:\n  prompt: do it\n  \
+             llm_evaluation_prompt: grade {student_code}\n",
+        )
+        .unwrap();
+        let suite = EvalSuite {
+            cases: vec![EvalCase {
+                submission: "cat(\"hi\\n\")\n".to_string(),
+                expected: ExpectedVerdict::Correct,
+            }],
+        };
+        let files = generate_eval_dir_with(
+            &lesson,
+            &suite,
+            "x",
+            Path::new("lessons/x.yaml"),
+            "../../../scripts/smevals/",
+        )
+        .unwrap();
+        let contents: std::collections::HashMap<_, _> = files.into_iter().collect();
+
+        let configs = &contents[&PathBuf::from("configs/default.yaml")];
+        assert!(
+            configs.contains("runner: ../../../scripts/smevals/run.sh\n"),
+            "configs runner must be the plain 3-hop scalar, got: {configs}"
+        );
+        assert!(
+            !configs.contains("\"../../../scripts/smevals/"),
+            "configs runner must not be quoted, got: {configs}"
+        );
+        let graders = &contents[&PathBuf::from("graders/default.yaml")];
+        assert!(
+            graders.contains("checker: ../../../scripts/smevals/check_polarity.sh\n"),
+            "graders checker must be the plain 3-hop scalar, got: {graders}"
+        );
+        assert!(
+            !graders.contains("\"../../../scripts/smevals/"),
+            "graders checker must not be quoted, got: {graders}"
         );
     }
 

--- a/crates/core/src/smevals_gen.rs
+++ b/crates/core/src/smevals_gen.rs
@@ -745,6 +745,11 @@ mod tests {
         std::fs::create_dir_all(repo.path().join(".git")).unwrap();
         std::fs::create_dir_all(repo.path().join("scripts/smevals")).unwrap();
         std::fs::write(repo.path().join("scripts/smevals/run.sh"), "#!/bin/sh\n").unwrap();
+        std::fs::write(
+            repo.path().join("scripts/smevals/check_polarity.sh"),
+            "#!/bin/sh\n",
+        )
+        .unwrap();
         let course = repo.path().join("a").join("b").join("my-course");
         std::fs::create_dir_all(&course).unwrap();
 
@@ -754,6 +759,7 @@ mod tests {
             "depth 3 needs 5 hops"
         );
         std::fs::create_dir_all(course.join(".smevals/configs")).unwrap();
+        std::fs::create_dir_all(course.join(".smevals/graders")).unwrap();
         let resolved = course
             .join(".smevals")
             .join("configs")
@@ -766,6 +772,20 @@ mod tests {
                 .canonicalize()
                 .unwrap()
         );
+        // Both consumers thread the same prefix — the graders checker must
+        // resolve exactly like the configs runner (dual-consumer drift guard).
+        let graders_resolved = course
+            .join(".smevals")
+            .join("graders")
+            .join(&rel)
+            .join("check_polarity.sh");
+        assert_eq!(
+            graders_resolved.canonicalize().unwrap(),
+            repo.path()
+                .join("scripts/smevals/check_polarity.sh")
+                .canonicalize()
+                .unwrap()
+        );
     }
 
     #[test]
@@ -775,12 +795,18 @@ mod tests {
         let repo = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(repo.path().join("scripts/smevals")).unwrap();
         std::fs::write(repo.path().join("scripts/smevals/run.sh"), "#!/bin/sh\n").unwrap();
+        std::fs::write(
+            repo.path().join("scripts/smevals/check_polarity.sh"),
+            "#!/bin/sh\n",
+        )
+        .unwrap();
         let course = repo.path().join("examples").join("tarball-course");
         std::fs::create_dir_all(&course).unwrap();
 
         let rel = scripts_rel_from(&course).unwrap();
         assert_eq!(rel, "../../../../scripts/smevals/", "depth 2 needs 4 hops");
         std::fs::create_dir_all(course.join(".smevals/configs")).unwrap();
+        std::fs::create_dir_all(course.join(".smevals/graders")).unwrap();
         let resolved = course
             .join(".smevals")
             .join("configs")
@@ -790,6 +816,20 @@ mod tests {
             resolved.canonicalize().unwrap(),
             repo.path()
                 .join("scripts/smevals/run.sh")
+                .canonicalize()
+                .unwrap()
+        );
+        // Both consumers thread the same prefix — the graders checker must
+        // resolve exactly like the configs runner (dual-consumer drift guard).
+        let graders_resolved = course
+            .join(".smevals")
+            .join("graders")
+            .join(&rel)
+            .join("check_polarity.sh");
+        assert_eq!(
+            graders_resolved.canonicalize().unwrap(),
+            repo.path()
+                .join("scripts/smevals/check_polarity.sh")
                 .canonicalize()
                 .unwrap()
         );

--- a/docs/evidence/216/canonicalize-verification.log
+++ b/docs/evidence/216/canonicalize-verification.log
@@ -1,6 +1,10 @@
-   Compiling blendtutor-core v0.1.0 (/Users/carbonite/Documents/coding/portfolio/worktree-issue-216/crates/core)
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.33s
-     Running `target/debug/examples/verify_216`
+Manual probe (scratch binary, source not committed — not reproducible from tree):
+  command: cargo run -p blendtutor-core --example verify_216
+  exercised scripts_rel_from at course depths 1/2/3 below a repo root, with and
+  without .git, canonicalizing each emitted scripts/smevals path; refusal paths
+  probed for no-marker/no-git and no-marker/git-only. The same assertions are
+  covered by committed unit tests (see probe.log: scripts_rel probes 1-4) and
+  the D=1/2/3 resolution results recorded below were observed on 2026-08-10.
 OK D1 (.git): configs/../../../scripts/smevals/run.sh -> /private/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/.tmpBvhKg9/scripts/smevals/run.sh
 OK D1 (.git): graders/../../../scripts/smevals/check_polarity.sh -> /private/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/.tmpBvhKg9/scripts/smevals/check_polarity.sh
 OK D1 (.git): graders/../../../scripts/smevals/judge_feedback.py -> /private/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/.tmpBvhKg9/scripts/smevals/judge_feedback.py

--- a/docs/evidence/216/canonicalize-verification.log
+++ b/docs/evidence/216/canonicalize-verification.log
@@ -1,0 +1,19 @@
+   Compiling blendtutor-core v0.1.0 (/Users/carbonite/Documents/coding/portfolio/worktree-issue-216/crates/core)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.33s
+     Running `target/debug/examples/verify_216`
+OK D1 (.git): configs/../../../scripts/smevals/run.sh -> /private/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/.tmpBvhKg9/scripts/smevals/run.sh
+OK D1 (.git): graders/../../../scripts/smevals/check_polarity.sh -> /private/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/.tmpBvhKg9/scripts/smevals/check_polarity.sh
+OK D1 (.git): graders/../../../scripts/smevals/judge_feedback.py -> /private/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/.tmpBvhKg9/scripts/smevals/judge_feedback.py
+OK D2 (.git): configs/../../../../scripts/smevals/run.sh -> /private/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/.tmpBvhKg9/scripts/smevals/run.sh
+OK D2 (.git): graders/../../../../scripts/smevals/check_polarity.sh -> /private/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/.tmpBvhKg9/scripts/smevals/check_polarity.sh
+OK D2 (.git): graders/../../../../scripts/smevals/judge_feedback.py -> /private/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/.tmpBvhKg9/scripts/smevals/judge_feedback.py
+OK D3 (.git): configs/../../../../../scripts/smevals/run.sh -> /private/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/.tmpBvhKg9/scripts/smevals/run.sh
+OK D3 (.git): graders/../../../../../scripts/smevals/check_polarity.sh -> /private/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/.tmpBvhKg9/scripts/smevals/check_polarity.sh
+OK D3 (.git): graders/../../../../../scripts/smevals/judge_feedback.py -> /private/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/.tmpBvhKg9/scripts/smevals/judge_feedback.py
+OK D2 (no .git): configs/../../../../scripts/smevals/run.sh -> /private/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/.tmpOQhjI4/scripts/smevals/run.sh
+OK D2 (no .git): graders/../../../../scripts/smevals/check_polarity.sh -> /private/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/.tmpOQhjI4/scripts/smevals/check_polarity.sh
+OK D2 (no .git): graders/../../../../scripts/smevals/judge_feedback.py -> /private/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/.tmpOQhjI4/scripts/smevals/judge_feedback.py
+NEGATIVE-OK: old 4-hop default at D1 does not resolve (would ENOENT at run time) — fix replaces it with exact 3-hop
+REFUSED no-marker/no-git: no repo root (an ancestor containing scripts/smevals/) found above <course>
+REFUSED no-marker/git-only: no repo root (an ancestor containing scripts/smevals/) found above <course>
+ALL VERIFICATIONS PASSED

--- a/docs/evidence/216/golden-byte-identical.log
+++ b/docs/evidence/216/golden-byte-identical.log
@@ -1,0 +1,11 @@
+=== re-baseline: regenerate golden via fixed generate_eval_dir ===
+regenerated /Users/carbonite/Documents/coding/portfolio/worktree-issue-216/crates/core/tests/fixtures/generate_eval_dir/eval.yaml
+regenerated /Users/carbonite/Documents/coding/portfolio/worktree-issue-216/crates/core/tests/fixtures/generate_eval_dir/configs/default.yaml
+regenerated /Users/carbonite/Documents/coding/portfolio/worktree-issue-216/crates/core/tests/fixtures/generate_eval_dir/graders/default.yaml
+regenerated /Users/carbonite/Documents/coding/portfolio/worktree-issue-216/crates/core/tests/fixtures/generate_eval_dir/tasks/case-1.yaml
+regenerated /Users/carbonite/Documents/coding/portfolio/worktree-issue-216/crates/core/tests/fixtures/generate_eval_dir/tasks/case-2.yaml
+regenerated /Users/carbonite/Documents/coding/portfolio/worktree-issue-216/crates/core/tests/fixtures/generate_eval_dir/tasks/case-3.yaml
+regenerated 6 files
+
+=== git diff --exit-code on golden fixtures ===
+GOLDEN BYTE-IDENTICAL: no diff (re-baseline = no content change)

--- a/docs/evidence/216/probe.log
+++ b/docs/evidence/216/probe.log
@@ -1,0 +1,23 @@
+=== probe 1: cargo test -p blendtutor-core --lib scripts_rel ===
+running 4 tests
+test smevals_gen::tests::scripts_rel_resolves_without_git_when_marker_present ... ok
+test smevals_gen::tests::scripts_rel_reaches_repo_scripts_from_a_nested_course ... ok
+test smevals_gen::tests::scripts_rel_resolves_at_depth_3_below_repo_root ... ok
+test smevals_gen::tests::scripts_rel_resolves_at_depth_1_below_repo_root ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 192 filtered out; finished in 0.00s
+
+
+=== probe 2: cargo test -p blendtutor-core --lib golden_non_default ===
+running 1 test
+test smevals_gen::tests::golden_non_default_depth_emits_plain_3hop_prefix ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 195 filtered out; finished in 0.00s
+
+
+=== probe 3: cargo test -p blendtutor-core --test generate_eval_dir ===
+examples/write-less-code-r/.smevals/configs/default.yaml
+test generated_dir_is_gitignored_but_committed_output_is_not ... ok
+
+test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
+


### PR DESCRIPTION
## Summary

`scripts_rel_from` (smevals_gen.rs) walked up to the nearest `.git` ancestor and fell back to `DEFAULT_SCRIPTS_REL` (four hops) when none existed — emitting a wrong-depth `runner:`/`checker:` path that resolves one level short of the repo's `scripts/` (ENOENT on re-execution from the committed eval dir, e.g. `../../../../scripts/smevals/run.sh` from `docs/evals/lesson_hello/evals/lesson_hello/eval.json`).

The repo root is now the nearest ancestor containing a `scripts/smevals/` directory (the marker — subsumes `.git`; a `.git`-only ancestor now **refuses** instead of guessing, per §1.1). `scripts_rel_from` returns `Option` and the effectful `write_eval_dir` resolves it **before** generating, refusing with the new `GenError::NoRepoRoot { course_root }` when no marker exists — no partial tree, no sentinel path into emitted YAML. The four-hop default survives only in the pure `generate_eval_dir` (no FS context).

## Issue
Closes #216

## ACs implemented
- [x] Marker walk-up: D=1→3 hops, D=2→4, D=3→5 — both `configs/default.yaml` `runner:` and `graders/default.yaml` `checker:` canonicalize-resolve to the real scripts dir (with `.git` and no-`.git`)
- [x] Refusal: no `scripts/smevals/` ancestor (with or without `.git`) → `Err(GenError::NoRepoRoot)`, `scripts_rel_from` == `None`, no partial tree
- [x] Non-regression: golden `generate_eval_dir` byte-identical (regenerate + `git diff --exit-code` clean), golden test passes un-re-staged
- [x] Pure-layer exercise: `generate_eval_dir_with(..., "../../../scripts/smevals/")` emits plain unquoted 3-hop scalars in both consumers

## Test plan
- [x] `cargo test -p blendtutor-core --lib` — 196 passed (probe: `scripts_rel` 4, `golden_non_default` 1)
- [x] `cargo test -p blendtutor-core --test generate_eval_dir` — 12 passed (golden unchanged)
- [x] Full workspace `cargo test` — 352 passed; `cargo fmt --all --check` + `cargo clippy --all-targets --locked -- -D warnings` clean
- [x] E2E evidence: `docs/evidence/216/` (probe.log, canonicalize-verification.log incl. old-4-hop negative + refusal, golden-byte-identical.log)

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested (silent-fallback, dual-consumer drift, YAML discipline, no-.git-marker, refusal)
- [x] Verification medium satisfied (code — full suite green)
- [x] Design intent respected (§1.1 types, §2.1 pure/effectful, §3 boundary — eval_report.rs `repo_root_for` untouched, §4 header, §5 one-thing)
- [x] No scope creep (smevals_gen.rs + anticipated files-of-scope CLI harness fixture fix + evidence/plan)