### PR TITLE
[feature] uv-style install.sh — curl|sh installer with checksum verification (#224)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,15 @@ jobs:
       - name: Release workflow test
         run: bash scripts/tests/test_release_yml.sh
 
+      # Issue #224 — install.sh (uv-style curl|sh installer): OS/arch →
+      # target-triple mapping (4-target matrix), latest-release resolution,
+      # tarball + checksums fetch byte-matching the release.yml contract,
+      # fail-closed SHA256 verification, ~/.local/bin install
+      # (BLENDTUTOR_INSTALL_DIR override), PATH hint. Stub-based shell BDD —
+      # fake curl/uname via PATH injection; zero network.
+      - name: install.sh test
+        run: bash scripts/tests/test_install_sh.sh
+
   quarto-render:
     name: quarto render
     runs-on: ubuntu-latest

--- a/.opencode/plans/user-friendliness/AC-2.md
+++ b/.opencode/plans/user-friendliness/AC-2.md
@@ -25,6 +25,9 @@ status: complete
 - [x] ci.yml check-job wiring (one step) — committed ab4a7fb (2026-09-08)
 - [x] README install section leads with curl|sh one-liner (minimal edit; cargo-from-clone kept) — committed 5cdfc1f (2026-09-08)
 - [x] E2E evidence at docs/evidence/224/ (test-suite.log + real-endpoint fail-closed + stubbed-layout install flow) — committed 46f9c33 (2026-09-08)
+- [x] Review cycle 1 fixes (PR #234): env fail-arm coverage (P11, 5 clauses) + trailing-slash PATH-hint clause (P9, 3 clauses) + P10 relabel — committed d4b7052 (2026-09-08)
+- [x] install.sh trailing-slash normalization (review nit 4) — committed 7efbe13 (2026-09-08)
+- [x] README assets-requirement caveat + refreshed evidence (47/28/91 green) — committed 1cf952d (2026-09-08)
 
 ### Decision Log
 - No ADR: install.sh consumes the asset contract release.yml already pins (and test_release_yml.sh enforces); no new interface or boundary introduced.
@@ -32,10 +35,14 @@ status: complete
 - `no $0` hygiene pin is strict — install.sh avoids the literal `$0` even in comments (header reworded to "no script-path assumptions").
 - Test corrupt-scenario uses its own BLENDTUTOR_INSTALL_DIR (happy path populates the default dir first — ordering bug caught by the suite itself).
 - POSIX sh (`set -eu`, no pipefail): fail-closed guaranteed by explicit `|| fail` guards + empty-result checks, not by pipe semantics.
+- Review cycle 1: no-sha256-tool arm isolated via a STRIPPED coreutils dir (symlink /usr/bin+/bin minus sha256sum/shasum), not `PATH=$STUB_DIR` as the review list suggested — stubs alone die earlier at mktemp ("mktemp -d failed"), the wrong arm. Strip-at-resolution (`INSTALL_DIR="${INSTALL_DIR%/}"`) chosen over case-site normalization so the final installed-path message is also double-slash-free.
+- P10 relabel ("contains set -eu") over first-lines scoping: `set -eu` sits at install.sh line 26, so `sed -n '1,5p'` scoping would fail — relabel was the only valid option of the two the review offered.
 
 ### Surprises & Discoveries
 - Release v0.1.0 exists on GitHub but has ZERO assets — so the real-network e2e run exercises the fail-closed arm for real: API resolves v0.1.0, tarball 404s, install.sh exits 1 with a message naming the failed download URL, nothing installed. Captured in docs/evidence/224/e2e-real-endpoint.log.
 - The suite's own "nothing installed on checksum mismatch" clause initially failed against a CORRECT implementation — leftover binary from the happy-path scenario in the shared default dir. Fixed by giving the corrupt scenario its own BLENDTUTOR_INSTALL_DIR; test-ordering isolation matters in stateful shell suites.
+- Review cycle 1: the no-sha256-tool clause's "nothing installed" check initially watched $TEST_HOME/.local/bin — which the happy path (P1) had already populated. Same test-ordering isolation lesson resurfacing; gave the scenario its own BLENDTUTOR_INSTALL_DIR.
+- Review cycle 1: the review list's literal probe `PATH=$STUB_DIR` for the no-sha256-tool arm would have pinned the WRONG arm (mktemp fails first with "mktemp -d failed"). Env-dependent fail-arm probes need per-arm tool-availability analysis, not just a poisoned PATH.
 
 ### Idempotence & Recovery
 - Safe retry: re-run builder on same branch; tests are idempotent

--- a/.opencode/plans/user-friendliness/AC-2.md
+++ b/.opencode/plans/user-friendliness/AC-2.md
@@ -2,7 +2,7 @@
 ac: 2
 depends_on: AC-1
 risk: medium
-status: spec
+status: complete
 ---
 
 ### AC-2 — install.sh
@@ -19,13 +19,23 @@ status: spec
 - Literal grep: `mcmullarkey/blendtutor` base URL literal — grep across `scripts/ tests/ rodney-probes/` at spec-compile to catch existing pins (quarto add tests use the same org/repo string).
 
 ### Progress
-- (none yet)
+- [x] RED suite `scripts/tests/test_install_sh.sh` (10 predicates, 39 clauses) — committed 0247952 (2026-09-08)
+- [x] Negative control: throwaway stub → 39/39 green; sneaky-pass variant (checksum verify removed) → 3 clauses fail; deleted → RED again
+- [x] `scripts/install.sh` implemented to green — committed a3acb5d (2026-09-08)
+- [x] ci.yml check-job wiring (one step) — committed ab4a7fb (2026-09-08)
+- [x] README install section leads with curl|sh one-liner (minimal edit; cargo-from-clone kept) — committed 5cdfc1f (2026-09-08)
+- [x] E2E evidence at docs/evidence/224/ (test-suite.log + real-endpoint fail-closed + stubbed-layout install flow) — committed 46f9c33 (2026-09-08)
 
 ### Decision Log
-- (none yet)
+- No ADR: install.sh consumes the asset contract release.yml already pins (and test_release_yml.sh enforces); no new interface or boundary introduced.
+- Checksum verify happens BEFORE extraction (corrupt-tarball test uses a VALID tarball with wrong bytes, isolating the verify arm from tar-parse errors).
+- `no $0` hygiene pin is strict — install.sh avoids the literal `$0` even in comments (header reworded to "no script-path assumptions").
+- Test corrupt-scenario uses its own BLENDTUTOR_INSTALL_DIR (happy path populates the default dir first — ordering bug caught by the suite itself).
+- POSIX sh (`set -eu`, no pipefail): fail-closed guaranteed by explicit `|| fail` guards + empty-result checks, not by pipe semantics.
 
 ### Surprises & Discoveries
-- (none yet)
+- Release v0.1.0 exists on GitHub but has ZERO assets — so the real-network e2e run exercises the fail-closed arm for real: API resolves v0.1.0, tarball 404s, install.sh exits 1 with a message naming the failed download URL, nothing installed. Captured in docs/evidence/224/e2e-real-endpoint.log.
+- The suite's own "nothing installed on checksum mismatch" clause initially failed against a CORRECT implementation — leftover binary from the happy-path scenario in the shared default dir. Fixed by giving the corrupt scenario its own BLENDTUTOR_INSTALL_DIR; test-ordering isolation matters in stateful shell suites.
 
 ### Idempotence & Recovery
 - Safe retry: re-run builder on same branch; tests are idempotent

--- a/.opencode/plans/user-friendliness/AC-2.md
+++ b/.opencode/plans/user-friendliness/AC-2.md
@@ -28,6 +28,7 @@ status: complete
 - [x] Review cycle 1 fixes (PR #234): env fail-arm coverage (P11, 5 clauses) + trailing-slash PATH-hint clause (P9, 3 clauses) + P10 relabel — committed d4b7052 (2026-09-08)
 - [x] install.sh trailing-slash normalization (review nit 4) — committed 7efbe13 (2026-09-08)
 - [x] README assets-requirement caveat + refreshed evidence (47/28/91 green) — committed 1cf952d (2026-09-08)
+- [x] Review cycle 2 fixes (PR #234, final batch): ci.yml self-wiring pin (P0) + recovery arms (P12: shasum fallback, HOME empty + override dir) + P11 HOME relabel + e2e-stubbed log ls-output re-capture + PR body counts — 52 clauses / 12 predicates, 52/28/91 green (2026-09-08)
 
 ### Decision Log
 - No ADR: install.sh consumes the asset contract release.yml already pins (and test_release_yml.sh enforces); no new interface or boundary introduced.
@@ -43,6 +44,7 @@ status: complete
 - The suite's own "nothing installed on checksum mismatch" clause initially failed against a CORRECT implementation — leftover binary from the happy-path scenario in the shared default dir. Fixed by giving the corrupt scenario its own BLENDTUTOR_INSTALL_DIR; test-ordering isolation matters in stateful shell suites.
 - Review cycle 1: the no-sha256-tool clause's "nothing installed" check initially watched $TEST_HOME/.local/bin — which the happy path (P1) had already populated. Same test-ordering isolation lesson resurfacing; gave the scenario its own BLENDTUTOR_INSTALL_DIR.
 - Review cycle 1: the review list's literal probe `PATH=$STUB_DIR` for the no-sha256-tool arm would have pinned the WRONG arm (mktemp fails first with "mktemp -d failed"). Env-dependent fail-arm probes need per-arm tool-availability analysis, not just a poisoned PATH.
+- Review cycle 2: the e2e-stubbed log's run 3 originally reused the dest dir from runs 1/2 — adding the requested `ls -la` output exposed the binary still present (leftover from happy-path runs), contradicting the "must be empty" claim. Re-captured with a FRESH dest for run 3; ls now shows "total 0". Same test-ordering isolation lesson, third resurface — stateful shell probes need per-scenario fresh state.
 
 ### Idempotence & Recovery
 - Safe retry: re-run builder on same branch; tests are idempotent

--- a/README.md
+++ b/README.md
@@ -27,7 +27,17 @@ evaluation prompt. `blendtutor` handles the rest:
 
 ## Installation
 
-`blendtutor` is a Rust binary. Install it from a clone with Cargo:
+Install the latest release with one command (macOS and Linux):
+
+```bash
+curl -LsSf https://raw.githubusercontent.com/mcmullarkey/blendtutor/main/scripts/install.sh | sh
+```
+
+The installer verifies the release tarball's SHA256 checksum before installing
+the `blendtutor` binary to `~/.local/bin` (override the location with
+`BLENDTUTOR_INSTALL_DIR`).
+
+Alternatively, install from a clone with Cargo:
 
 ```bash
 git clone https://github.com/mcmullarkey/blendtutor.git

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ curl -LsSf https://raw.githubusercontent.com/mcmullarkey/blendtutor/main/scripts
 
 The installer verifies the release tarball's SHA256 checksum before installing
 the `blendtutor` binary to `~/.local/bin` (override the location with
-`BLENDTUTOR_INSTALL_DIR`).
-
-Alternatively, install from a clone with Cargo:
+`BLENDTUTOR_INSTALL_DIR`). The one-liner needs a release with binary assets —
+none are published yet, so until the next release, install from a clone with
+Cargo:
 
 ```bash
 git clone https://github.com/mcmullarkey/blendtutor.git

--- a/docs/evidence/224/e2e-real-endpoint.log
+++ b/docs/evidence/224/e2e-real-endpoint.log
@@ -1,0 +1,14 @@
+# e2e-real-endpoint.log — REAL network run of scripts/install.sh
+# No stubs: real uname (Darwin arm64), real curl, real api.github.com.
+# Expected: API resolves latest release v0.1.0, tarball download 404s
+# (release v0.1.0 has no assets yet) -> install.sh fails CLOSED with a
+# message naming the failed download. Nothing installed.
+# Install dir pointed at a throwaway temp dir so the real HOME is untouched.
+
+$ env -i PATH=/usr/bin:/bin HOME=/Users/carbonite/Documents/coding/portfolio/worktree-issue-224/.e2e-home BLENDTUTOR_INSTALL_DIR=/Users/carbonite/Documents/coding/portfolio/worktree-issue-224/.e2e-dest sh scripts/install.sh
+# exit status: 1 (nonzero = fail-closed)
+# installed dir contents (must be empty):
+total 0
+drwxr-xr-x@  2 carbonite  staff   64 Sep  8 16:55 .
+drwxr-xr-x@ 30 carbonite  staff  960 Sep  8 16:55 ..
+# VERDICT: fail-closed against the real endpoint — PASS

--- a/docs/evidence/224/e2e-stubbed-install.log
+++ b/docs/evidence/224/e2e-stubbed-install.log
@@ -1,0 +1,25 @@
+# e2e-stubbed-install.log — full install flow vs a stubbed release layout
+# Stubbed: curl (serves a canned v0.1.0 release layout) + uname (linux x86_64).
+# REAL: tar, sha256sum, mktemp, checksum comparison, extraction, install,
+# executable bit, installed-binary execution, stdin-piped (curl|sh) mode.
+
+--- run 1: file mode (sh scripts/install.sh) ---
+$ env -i PATH=<stubbin>:/usr/bin:/bin HOME=/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.IUhx9lIesz/home BLENDTUTOR_INSTALL_DIR=/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.IUhx9lIesz/dest sh scripts/install.sh
+blendtutor v0.1.0 installed to /var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.IUhx9lIesz/dest/blendtutor
+# exit status: 0
+# installed binary runs:
+$ /var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.IUhx9lIesz/dest/blendtutor
+blendtutor-stub-binary v0.1.0
+
+--- run 2: stdin-piped mode (cat scripts/install.sh | sh) — the curl|sh shape ---
+$ env -i ... sh < scripts/install.sh   # stdin = the script itself
+blendtutor v0.1.0 installed to /var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.IUhx9lIesz/dest/blendtutor
+# exit status: 0
+# installed binary runs:
+blendtutor-stub-binary v0.1.0
+
+--- run 3: checksum mismatch fails closed ---
+$ env -i ... sh scripts/install.sh   # tarball bytes no longer match checksums
+# exit status: 1 (nonzero = fail-closed)
+# dest contents after failed verify (must be empty):
+# VERDICT: happy path installs + runs (file + stdin modes); mismatch fails closed — PASS

--- a/docs/evidence/224/e2e-stubbed-install.log
+++ b/docs/evidence/224/e2e-stubbed-install.log
@@ -4,22 +4,38 @@
 # executable bit, installed-binary execution, stdin-piped (curl|sh) mode.
 
 --- run 1: file mode (sh scripts/install.sh) ---
-$ env -i PATH=<stubbin>:/usr/bin:/bin HOME=/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.IUhx9lIesz/home BLENDTUTOR_INSTALL_DIR=/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.IUhx9lIesz/dest sh scripts/install.sh
-blendtutor v0.1.0 installed to /var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.IUhx9lIesz/dest/blendtutor
+$ env -i PATH=<stubbin>:/usr/bin:/bin HOME=/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.hgFhK28Hph/home BLENDTUTOR_INSTALL_DIR=/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.hgFhK28Hph/dest sh scripts/install.sh
+
+note: /var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.hgFhK28Hph/dest is not on your PATH.
+add it to your shell profile, e.g.:
+  export PATH="/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.hgFhK28Hph/dest:$PATH"
+blendtutor v0.1.0 installed to /var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.hgFhK28Hph/dest/blendtutor
 # exit status: 0
 # installed binary runs:
-$ /var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.IUhx9lIesz/dest/blendtutor
+$ /var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.hgFhK28Hph/dest/blendtutor
 blendtutor-stub-binary v0.1.0
 
 --- run 2: stdin-piped mode (cat scripts/install.sh | sh) — the curl|sh shape ---
-$ env -i ... sh < scripts/install.sh   # stdin = the script itself
-blendtutor v0.1.0 installed to /var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.IUhx9lIesz/dest/blendtutor
+$ env -i PATH=<stubbin>:/usr/bin:/bin HOME=/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.hgFhK28Hph/home BLENDTUTOR_INSTALL_DIR=/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.hgFhK28Hph/dest sh < scripts/install.sh   # stdin = the script itself
+
+note: /var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.hgFhK28Hph/dest is not on your PATH.
+add it to your shell profile, e.g.:
+  export PATH="/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.hgFhK28Hph/dest:$PATH"
+blendtutor v0.1.0 installed to /var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.hgFhK28Hph/dest/blendtutor
 # exit status: 0
 # installed binary runs:
 blendtutor-stub-binary v0.1.0
 
 --- run 3: checksum mismatch fails closed ---
-$ env -i ... sh scripts/install.sh   # tarball bytes no longer match checksums
+$ env -i PATH=<stubbin>:/usr/bin:/bin HOME=/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.hgFhK28Hph/home BLENDTUTOR_INSTALL_DIR=/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.hgFhK28Hph/dest-verify sh scripts/install.sh   # tarball bytes no longer match checksums; FRESH dest (runs 1/2 used /var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.hgFhK28Hph/dest)
+checksum mismatch for blendtutor-v0.1.0-x86_64-unknown-linux-gnu.tar.gz:
+  expected: 72155b2538f0bc98562e49ba10af645e1d881da4a02f518df81ac9412de99247
+  actual:   cf04d718c0de7cd7407f90a6fe656de91589f41712bf117d8e62c60256e43afd
+error: checksum verification failed — refusing to install a corrupted tarball
 # exit status: 1 (nonzero = fail-closed)
 # dest contents after failed verify (must be empty):
+$ ls -la /var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.hgFhK28Hph/dest-verify
+total 0
+drwxr-xr-x@ 2 carbonite  staff   64 Sep  8 17:15 .
+drwx------@ 8 carbonite  staff  256 Sep  8 17:15 ..
 # VERDICT: happy path installs + runs (file + stdin modes); mismatch fails closed — PASS

--- a/docs/evidence/224/quarto-distribution-suite.log
+++ b/docs/evidence/224/quarto-distribution-suite.log
@@ -1,0 +1,140 @@
+== Group 1: README ==
+== Clause 1: install command ==
+  PASS: install command present (quarto add mcmullarkey/blendtutor)
+== Clause 2: syntax both languages ==
+  PASS: R exercise syntax shown in README
+  PASS: Python exercise syntax shown in README
+== Clause 3: BYOK ==
+  PASS: BYOK mentioned in README
+== Clause 4: minimum Quarto version ==
+  PASS: minimum Quarto version stated in README
+== Clause 5: demo book link ==
+  PASS: demo book link present in README
+== Clause 6: install path contract ==
+  PASS: install command present (quarto add mcmullarkey/blendtutor)
+  PASS: install path stated (_extensions/mcmullarkey/blendtutor/)
+  PASS: old wrong install path claim removed
+  PASS: install-path independence stated in README
+  PASS: ADR-0017 annotated with org/repo install path (CI actually + _extensions/mcmullarkey/blendtutor/)
+== Clause 7: zero-bootstrap quick-start ==
+  PASS: quick-start uses by-name filter (filters: [mcmullarkey/blendtutor])
+  PASS: quick-start prose states zero hand-written bootstrap
+  PASS: quick-start shows .blendtutor exercise div
+== Clause 8: quick-start example integrity ==
+  PASS: quick-start example has no script/module/scanExercises/start(/buildRegistry tokens
+== Clause 9: auto-bootstrap opt-out ==
+  PASS: opt-out literal present (bt-auto-bootstrap: false)
+  PASS: opt-out prose present
+== Clause 10: feedback auto-mount ==
+  PASS: feedback names exercise-feedback.js
+  PASS: feedback auto-mounts via mountAllFeedback
+  PASS: feedback stated auto-mounted (not manual opt-in)
+  PASS: no stale 'manual opt-in' / 'not auto-mounted' claim survives
+  PASS: CLI ANTHROPIC_API_KEY env-var doc survives (rig/ADR-0006)
+  PASS: BYOK section has zero ANTHROPIC_API_KEY (Fireworks-only)
+== Clause 11: COI book-mode caveat ==
+  PASS: COI caveat names Quarto type: book
+  PASS: COI caveat states book-mode does not function
+  PASS: COI caveat explains _output/ scope
+  PASS: demo book no longer overclaims 'COI configuration'
+== Clause 12: no stale mechanism, command/version consistency ==
+  PASS: stale mechanism claim removed (relative to filter script / PANDOC_SCRIPT_FILE)
+  PASS: no stale runtime bootstrap import (import .*exercise-runtime.js)
+  PASS: no short-form install command (full org/repo required, matches ci.yml:148)
+  PASS: version stated matches _extension.yml (0.1.0)
+== Clause 13: demo book serve-over-HTTP instructions ==
+  PASS: README serve-over-HTTP instruction present (python3 -m http.server 8000)
+  PASS: README explains file:// blocks ES modules
+  PASS: README notes file:// shows static fallback content only
+
+== Group 2: Demo book ==
+== AC-5 Clause 1: by-name install committed ==
+  PASS: .gitignore no longer ignores /_extensions/
+  PASS: /_output/ added to .gitignore (render artifacts excluded)
+  PASS: vendored install present at demo-book/_extensions/mcmullarkey/blendtutor/ (extension.yml + lua + assets)
+== AC-5 Clause 2: vendored extension current (markers) ==
+  PASS: vendored lua current (add_html_dependency + BT_DEP_VERSION + libs URL markers)
+== AC-5 Clause 3: by-name filter reference ==
+  PASS: filters reference mcmullarkey/blendtutor (full org/repo form)
+  PASS: no ../_extensions filter path in _quarto.yml
+== Clause 7: render exits 0 ==
+  PASS: quarto render demo-book exits 0
+  PASS: asset href target exists: site_libs/quarto-contrib/blendtutor-0.1.0/styles.css
+== AC-7 P5: rendered api-key page + __btConfig ==
+  PASS: api-key.html rendered with class="blendtutor-key"
+  PASS: api-key.html carries __btConfig
+  PASS: r-exercises.html carries __btConfig
+  PASS: python-exercises.html carries __btConfig
+== AC-5 Clause 5: book libs URLs (site_libs) + no _extensions/ in bootstrap ==
+  PASS: r-exercises references site_libs exercise-runtime.js URL
+  PASS: r-exercises references site_libs webr-adapter.js URL (conditional import)
+  PASS: r-exercises does not import pyodide-adapter.js (conditional per-language import)
+  PASS: r-exercises references site_libs styles.css URL
+  PASS: r-exercises bootstrap specifiers contain no _extensions/ substring
+  PASS: python-exercises references site_libs exercise-runtime.js URL
+  PASS: python-exercises references site_libs pyodide-adapter.js URL (conditional import)
+  PASS: python-exercises does not import webr-adapter.js (conditional per-language import)
+  PASS: python-exercises references site_libs styles.css URL
+  PASS: python-exercises bootstrap specifiers contain no _extensions/ substring
+== AC-5 Clause 6: files on disk at _output/site_libs/... ==
+  PASS: book site_libs contains exercise-runtime.js
+  PASS: book site_libs contains styles.css
+  PASS: book site_libs contains codemirror.js
+  PASS: book site_libs contains webr-adapter.js (book has R exercises)
+  PASS: book site_libs contains pyodide-adapter.js (book has python exercises)
+== AC-5 Clause 7: COI stays out of blendtutor libs dir (Quarto-managed src) ==
+  PASS: r-exercises loads coi-serviceworker.js via include_text (src present)
+  PASS: coi shim src does not point into blendtutor-0.1.0 libs dir
+  PASS: coi-serviceworker.js not in blendtutor libs dir
+== Clause 8: ≥2 exercises per language ==
+  PASS: ≥2 R exercises (4 found)
+  PASS: ≥2 Python exercises (4 found)
+== Clause 9: non-empty content ==
+  PASS: non-empty content (no empty exercise divs)
+  PASS: non-empty content (code blocks present: 8)
+== Clause 10: mixed-language ==
+  PASS: mixed-language (R: 4, Python: 4)
+== Clause 11: no llm_evaluation_prompt ==
+  PASS: no llm_evaluation_prompt (0 occurrences)
+== Clause 12: COI config ==
+  PASS: COI config present (coi="true" or coi: true)
+== Clause 13: index.qmd has R and Python exercises ==
+  PASS: index.qmd has >=1 R exercise (1 found)
+  PASS: index.qmd has >=1 Python exercise (1 found)
+== AC-7: demo-book API key page (structural) ==
+  PASS: api-key.qmd has fenced div ::: {.blendtutor-key}
+  PASS: api-key.qmd registered before r-exercises.qmd in book.chapters (line 11 < 12)
+  PASS: r-exercises.qmd front matter has bt-key-page: api-key.html
+  PASS: python-exercises.qmd front matter has bt-key-page: api-key.html
+  PASS: index.qmd BYOK section mentions Fireworks
+  PASS: index.qmd BYOK section links api-key.html
+  PASS: index.qmd has zero ANTHROPIC_API_KEY (Fireworks-only BYOK)
+
+== P9: demo-book side-effect free (org/repo-aware, issue #143) ==
+  PASS: demo-book side-effect free — no bare extension-dir residue (non-org path absent)
+  PASS: org/repo by-name install present (allowed by P9)
+
+== Group 3: CI ==
+== Clause 13: quarto add in temp dir ==
+  PASS: quarto add mcmullarkey/blendtutor present in CI
+  PASS: temp dir creation in CI
+  PASS: test -f paths use _extensions/mcmullarkey/blendtutor/ (actual install path)
+== Clause 14: setup@v2 ==
+  PASS: quarto-dev/quarto-actions/setup@v2 present in CI
+== Clause 15: no continue-on-error ==
+  PASS: no continue-on-error in quarto-distribution job
+
+== Negative cases ==
+== Negative 1: correct org/repo ==
+  PASS: correct org/repo (mcmullarkey/blendtutor)
+== Negative 2: no empty JSON (exercises have content) ==
+  PASS: no empty JSON (all exercises have content)
+== Negative 3: CI does not use _extensions: copy ==
+  PASS: CI does not use _extensions: copy (uses quarto add instead)
+== Negative 4: README mentions BYOK ==
+  PASS: README mentions BYOK
+
+=========================================
+  Results: 91 passed, 0 failed
+=========================================
+All tests passed.

--- a/docs/evidence/224/release-yml-suite.log
+++ b/docs/evidence/224/release-yml-suite.log
@@ -1,0 +1,39 @@
+== Phase 0: file presence ==
+  PASS: .github/workflows/release.yml exists
+== Phase 1: trigger pins ==
+  PASS: workflow_dispatch trigger present (on-block pin)
+  PASS: tag trigger present: tags: v* (on-block pin)
+== Phase 2: build job pins ==
+  PASS: matrix covers 4 targets: linux x86_64/aarch64 + macOS x86_64/aarch64 (4/4)
+  PASS: build runs cargo build --release --locked -p blendtutor-cli --target <matrix.target>
+  PASS: toolchain pinned via rust-toolchain.toml (rustup show active-toolchain pattern)
+  PASS: no dtolnay/rust-toolchain action (rust-toolchain.toml is the single source of truth)
+  PASS: binary staged from target/<matrix.target>/release/blendtutor
+  PASS: tar root layout: bare blendtutor binary at tarball root (-C dist blendtutor)
+  PASS: tarball contract: blendtutor-<tag>-<target>.tar.gz (exact literal in build job)
+  PASS: build job uploads tarball artifact (actions/upload-artifact)
+== Phase 3: release job pins ==
+  PASS: release job declared after build block (line 103 > build end 102)
+  PASS: release job needs build
+  PASS: release job gated to v* tag refs (workflow_dispatch builds without publishing)
+  PASS: release job downloads build artifacts (actions/download-artifact)
+  PASS: release job has repo context (actions/checkout or GH_REPO env) for gh release create
+  PASS: checksums contract: sha256sum generated + blendtutor-<tag>-sha256sums.txt uploaded (literal in gh-release-create step)
+  PASS: checksums filename written by Generate step (blendtutor-<tag>-sha256sums.txt literal in generate step)
+  PASS: release uploads tarballs (blendtutor-*.tar.gz arg in gh-release-create step)
+  PASS: release name = tag (gh release create --title <tag>)
+  PASS: ref_name sanitized for filenames (TAG=<sanitized> in build + release jobs; upload name via pack step output)
+== Phase 4: doctrine pins ==
+  PASS: workflow-level permissions: contents: read (least privilege)
+  PASS: release job scoped contents: write (job-level, creates the release)
+  PASS: build job does NOT hold contents: write (least privilege)
+  PASS: no continue-on-error anywhere in release.yml
+  PASS: no || true anywhere in release.yml
+  PASS: no if: always() anywhere in release.yml
+== Phase 5: ci.yml wiring ==
+  PASS: ci.yml check job runs test_release_yml.sh
+
+=========================================
+  Results: 28 passed, 0 failed
+=========================================
+All tests passed.

--- a/docs/evidence/224/test-suite.log
+++ b/docs/evidence/224/test-suite.log
@@ -1,5 +1,6 @@
 == Phase 0: file presence ==
   PASS: scripts/install.sh exists
+  PASS: wired into ci.yml (check job runs this test)
 == Predicate 1: happy path (linux x86_64, default install dir) ==
   PASS: install.sh exits 0 (got: 0)
   PASS: binary installed executable at $HOME/.local/bin/blendtutor
@@ -52,13 +53,18 @@
   PASS: no $0 anywhere (curl|sh contract)
   PASS: repo literal mcmullarkey/blendtutor present
 == Predicate 11: environment fail arms ==
-  PASS: HOME unset → nonzero exit
-  PASS: HOME-unset message names BLENDTUTOR_INSTALL_DIR
+  PASS: HOME unset/empty → nonzero exit
+  PASS: HOME-unset/empty message names BLENDTUTOR_INSTALL_DIR
   PASS: no sha256 tool → nonzero exit
   PASS: no-sha256-tool message names the missing tool
   PASS: nothing installed without a sha256 tool
+== Predicate 12: recovery arms ==
+  PASS: shasum-only PATH (no sha256sum) exits 0 (fallback) (got: 0)
+  PASS: binary installed via shasum fallback
+  PASS: HOME empty + BLENDTUTOR_INSTALL_DIR set exits 0 (got: 0)
+  PASS: binary installed to override dir despite empty HOME
 
 =========================================
-  Results: 47 passed, 0 failed
+  Results: 52 passed, 0 failed
 =========================================
 All tests passed.

--- a/docs/evidence/224/test-suite.log
+++ b/docs/evidence/224/test-suite.log
@@ -43,13 +43,22 @@
   PASS: PATH hint printed when install dir not on PATH
   PASS: on-PATH scenario exits 0 (got: 0)
   PASS: no PATH hint when install dir IS on PATH
+  PASS: trailing-slash scenario exits 0 (got: 0)
+  PASS: trailing-slash install dir still installs the binary
+  PASS: no false PATH hint when trailing-slash install dir IS on PATH
 == Predicate 10: hygiene pins ==
   PASS: shebang is #!/bin/sh (POSIX sh) (got: #!/bin/sh)
-  PASS: starts with set -eu (fail-closed hygiene)
+  PASS: contains set -eu (fail-closed hygiene)
   PASS: no $0 anywhere (curl|sh contract)
   PASS: repo literal mcmullarkey/blendtutor present
+== Predicate 11: environment fail arms ==
+  PASS: HOME unset → nonzero exit
+  PASS: HOME-unset message names BLENDTUTOR_INSTALL_DIR
+  PASS: no sha256 tool → nonzero exit
+  PASS: no-sha256-tool message names the missing tool
+  PASS: nothing installed without a sha256 tool
 
 =========================================
-  Results: 39 passed, 0 failed
+  Results: 47 passed, 0 failed
 =========================================
 All tests passed.

--- a/docs/evidence/224/test-suite.log
+++ b/docs/evidence/224/test-suite.log
@@ -1,0 +1,55 @@
+== Phase 0: file presence ==
+  PASS: scripts/install.sh exists
+== Predicate 1: happy path (linux x86_64, default install dir) ==
+  PASS: install.sh exits 0 (got: 0)
+  PASS: binary installed executable at $HOME/.local/bin/blendtutor
+  PASS: installed binary runs (bare member extracted) (got: blendtutor-stub-binary v0.1.0)
+  PASS: curl called exactly 3 times (api + tarball + sums) (got: 3)
+  PASS: fetched contract URLs: latest API + blendtutor-<tag>-<target>.tar.gz + blendtutor-<tag>-sha256sums.txt
+== Predicate 2: curl|sh (stdin-piped, $0=sh) ==
+  PASS: stdin-piped install.sh exits 0 (got: 0)
+  PASS: stdin-piped run installed the binary (no $0 assumptions, no stdin eating)
+== Predicate 3: checksum mismatch fails closed ==
+  PASS: corrupt tarball → nonzero exit
+  PASS: mismatch message names the checksum
+  PASS: nothing installed on checksum mismatch
+== Predicate 4: unsupported OS/arch ==
+  PASS: unsupported OS (Plan9) → nonzero + message
+  PASS: unsupported arch (sparc) → nonzero + message
+== Predicate 5: uname → target-triple mapping (4 targets) ==
+  PASS: mapping Linux/x86_64 → exit 0 (got: 0)
+  PASS: mapping Linux/x86_64 → x86_64-unknown-linux-gnu tarball fetched
+  PASS: mapping Linux/aarch64 → exit 0 (got: 0)
+  PASS: mapping Linux/aarch64 → aarch64-unknown-linux-gnu tarball fetched
+  PASS: mapping Darwin/x86_64 → exit 0 (got: 0)
+  PASS: mapping Darwin/x86_64 → x86_64-apple-darwin tarball fetched
+  PASS: mapping Darwin/arm64 → exit 0 (got: 0)
+  PASS: mapping Darwin/arm64 → aarch64-apple-darwin tarball fetched
+== Predicate 6: BLENDTUTOR_INSTALL_DIR override ==
+  PASS: override install exits 0 (got: 0)
+  PASS: binary installed at BLENDTUTOR_INSTALL_DIR
+== Predicate 7: fetch failures fail closed ==
+  PASS: api-fail → nonzero exit
+  PASS: api-fail → message on stderr
+  PASS: download-fail → nonzero exit
+  PASS: download-fail → message on stderr
+  PASS: sums-fail → nonzero exit
+  PASS: sums-fail → message on stderr
+== Predicate 8: tarball not in checksums file ==
+  PASS: unlisted tarball → nonzero exit
+  PASS: unlisted-tarball message names the verification failure
+== Predicate 9: PATH hint ==
+  PASS: hint scenario exits 0 (got: 0)
+  PASS: PATH hint printed when install dir not on PATH
+  PASS: on-PATH scenario exits 0 (got: 0)
+  PASS: no PATH hint when install dir IS on PATH
+== Predicate 10: hygiene pins ==
+  PASS: shebang is #!/bin/sh (POSIX sh) (got: #!/bin/sh)
+  PASS: starts with set -eu (fail-closed hygiene)
+  PASS: no $0 anywhere (curl|sh contract)
+  PASS: repo literal mcmullarkey/blendtutor present
+
+=========================================
+  Results: 39 passed, 0 failed
+=========================================
+All tests passed.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,141 @@
+#!/bin/sh
+# uv-style installer for the blendtutor CLI (issue #224).
+#
+#   curl -LsSf https://raw.githubusercontent.com/mcmullarkey/blendtutor/main/scripts/install.sh | sh
+#
+# Works via `curl | sh` (stdin-piped): POSIX sh, no script-path assumptions
+# (the shell's script-name variable is never referenced — the script is
+# stdin, not a file), and no command reads stdin (a stdin-reading child would
+# eat the remaining script bytes). All fetches go to files via `curl -o`.
+#
+# Asset contract — pinned by .github/workflows/release.yml and structurally
+# enforced by scripts/tests/test_release_yml.sh (consumed HERE):
+#   blendtutor-<tag>-<target>.tar.gz   — bare `blendtutor` binary at tar root
+#   blendtutor-<tag>-sha256sums.txt    — sha256 of every release tarball
+#
+# Fail-closed doctrine: any fetch, parse, or checksum failure exits nonzero
+# with a message — nothing is installed on a failed verification, and there
+# is no `|| true` / continue-on-error anywhere.
+#
+# Install dir: $HOME/.local/bin by default, overridable via
+# BLENDTUTOR_INSTALL_DIR (mirrors uv's UV_INSTALL_DIR).
+#
+# Tested by scripts/tests/test_install_sh.sh (stub curl/uname via PATH
+# injection — zero network), wired into ci.yml's check job.
+
+set -eu
+
+REPO="mcmullarkey/blendtutor"
+
+warn() { printf '%s\n' "$1" >&2; }
+fail() { warn "error: $1"; exit 1; }
+
+# --- install dir (BLENDTUTOR_INSTALL_DIR overrides ~/.local/bin) ------------
+
+if [ -n "${BLENDTUTOR_INSTALL_DIR:-}" ]; then
+  INSTALL_DIR="$BLENDTUTOR_INSTALL_DIR"
+elif [ -n "${HOME:-}" ]; then
+  INSTALL_DIR="$HOME/.local/bin"
+else
+  fail "cannot determine install dir: set BLENDTUTOR_INSTALL_DIR (HOME is unset)"
+fi
+
+# --- OS/arch → release target triple (release.yml 4-target matrix) ----------
+
+os_name=$(uname -s)
+case "$os_name" in
+  Linux) os=linux ;;
+  Darwin) os=darwin ;;
+  *) fail "unsupported operating system: $os_name (supported: Linux, macOS)" ;;
+esac
+
+arch_name=$(uname -m)
+case "$arch_name" in
+  x86_64|amd64) arch=x86_64 ;;
+  aarch64|arm64) arch=aarch64 ;;
+  *) fail "unsupported architecture: $arch_name (supported: x86_64, aarch64/arm64)" ;;
+esac
+
+case "$os-$arch" in
+  linux-x86_64) target=x86_64-unknown-linux-gnu ;;
+  linux-aarch64) target=aarch64-unknown-linux-gnu ;;
+  darwin-x86_64) target=x86_64-apple-darwin ;;
+  darwin-aarch64) target=aarch64-apple-darwin ;;
+  *) fail "no release target for $os_name/$arch_name" ;;
+esac
+
+# --- scratch dir -------------------------------------------------------------
+
+SCRATCH=$(mktemp -d) || fail "mktemp -d failed"
+trap 'rm -rf "$SCRATCH"' EXIT INT TERM
+
+# --- resolve the latest release tag ------------------------------------------
+
+api_url="https://api.github.com/repos/$REPO/releases/latest"
+curl -fsSL "$api_url" -o "$SCRATCH/release.json" \
+  || fail "failed to fetch latest release info from $api_url"
+tag=$(sed -n 's/.*"tag_name" *: *"\([^"]*\)".*/\1/p' "$SCRATCH/release.json" | head -n 1)
+[ -n "$tag" ] || fail "could not parse tag_name from $api_url response"
+
+# --- download tarball + checksums --------------------------------------------
+
+base_url="https://github.com/$REPO/releases/download/$tag"
+tarball="blendtutor-$tag-$target.tar.gz"
+sums_file="blendtutor-$tag-sha256sums.txt"
+
+curl -fsSL "$base_url/$tarball" -o "$SCRATCH/$tarball" \
+  || fail "failed to download $base_url/$tarball"
+curl -fsSL "$base_url/$sums_file" -o "$SCRATCH/$sums_file" \
+  || fail "failed to download $base_url/$sums_file"
+
+# --- verify checksum (fail-closed, before any extraction) --------------------
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    return 1
+  fi
+}
+
+expected_hash=$(grep -F "$tarball" "$SCRATCH/$sums_file" \
+  | awk -v t="$tarball" '$2 == t {print $1}' | head -n 1)
+[ -n "$expected_hash" ] \
+  || fail "$tarball not listed in $sums_file — refusing to install an unverified tarball"
+
+actual_hash=$(sha256_of "$SCRATCH/$tarball") \
+  || fail "no sha256 tool available (need sha256sum or shasum)"
+
+if [ "$actual_hash" != "$expected_hash" ]; then
+  warn "checksum mismatch for $tarball:"
+  warn "  expected: $expected_hash"
+  warn "  actual:   $actual_hash"
+  fail "checksum verification failed — refusing to install a corrupted tarball"
+fi
+
+# --- extract + install --------------------------------------------------------
+# Tar-root contract (pinned in release.yml): the archive holds the bare
+# `blendtutor` binary at its root — extract that member by its exact path.
+
+tar -xzf "$SCRATCH/$tarball" -C "$SCRATCH" blendtutor \
+  || fail "failed to extract blendtutor from $tarball (expected bare blendtutor member at tarball root)"
+
+mkdir -p "$INSTALL_DIR" || fail "cannot create install dir $INSTALL_DIR"
+mv "$SCRATCH/blendtutor" "$INSTALL_DIR/blendtutor" || fail "cannot move binary into $INSTALL_DIR"
+chmod +x "$INSTALL_DIR/blendtutor" || fail "cannot chmod $INSTALL_DIR/blendtutor"
+
+# --- PATH hint ----------------------------------------------------------------
+
+case ":${PATH:-}:" in
+  *":$INSTALL_DIR:"*) ;;
+  *)
+    warn ""
+    warn "note: $INSTALL_DIR is not on your PATH."
+    warn "add it to your shell profile, e.g.:"
+    warn "  export PATH=\"$INSTALL_DIR:\$PATH\""
+    ;;
+esac
+
+printf '%s\n' "blendtutor $tag installed to $INSTALL_DIR/blendtutor"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -40,6 +40,11 @@ else
   fail "cannot determine install dir: set BLENDTUTOR_INSTALL_DIR (HOME is unset)"
 fi
 
+# Strip a trailing slash so the PATH-hint case match doesn't false-positive
+# (BLENDTUTOR_INSTALL_DIR=/opt/tools/ must match PATH entry /opt/tools) and
+# installed-path messages don't double-slash.
+INSTALL_DIR="${INSTALL_DIR%/}"
+
 # --- OS/arch → release target triple (release.yml 4-target matrix) ----------
 
 os_name=$(uname -s)

--- a/scripts/tests/test_install_sh.sh
+++ b/scripts/tests/test_install_sh.sh
@@ -20,9 +20,13 @@
 #      failure → nonzero (fail-closed, no || true).
 #   8. Tarball absent from the checksums file → fail closed.
 #   9. PATH hint: printed when the install dir is not on PATH; absent when
-#      it is.
+#      it is — including when the dir is given with a trailing slash and the
+#      PATH entry has none (no false hint).
 #  10. Hygiene pins: `#!/bin/sh` shebang, `set -eu`, no `$0` anywhere (the
 #      curl|sh contract), `mcmullarkey/blendtutor` repo literal present.
+#  11. Environment fail arms: HOME unset → nonzero + message naming
+#      BLENDTUTOR_INSTALL_DIR; no sha256 tool on PATH → nonzero + "no sha256
+#      tool" message (fail-closed before any install).
 #
 # Stub pattern follows scripts/tests/test_smevals_runner.sh: fake curl/uname
 # via PATH injection + counter file proving invocation. The stub curl serves
@@ -470,6 +474,26 @@ else
   ok "no PATH hint when install dir IS on PATH"
 fi
 
+# Trailing-slash install dir: BLENDTUTOR_INSTALL_DIR=/dir/ must match a PATH
+# entry of /dir (the case match normalizes the trailing slash — a false
+# "not on your PATH" hint here is the bug this clause pins).
+: > "$COUNTER"
+HINT_DIR3="$TMPDIR/hint-bin3"
+run_install "$OUT" "$ERR" \
+  "BLENDTUTOR_INSTALL_DIR=$HINT_DIR3/" \
+  "PATH=$STUB_DIR:$HINT_DIR3:/usr/bin:/bin"
+assert_eq "trailing-slash scenario exits 0" "0" "$INSTALL_STATUS"
+if [ -x "$HINT_DIR3/blendtutor" ]; then
+  ok "trailing-slash install dir still installs the binary"
+else
+  ko "trailing-slash install dir still installs the binary — got: $(ls -la "$HINT_DIR3" 2>&1 || echo dir-missing)"
+fi
+if grep -qF "not on your PATH" "$OUT" "$ERR"; then
+  ko "no false PATH hint when trailing-slash dir IS on PATH — got: $(cat "$OUT") $(cat "$ERR")"
+else
+  ok "no false PATH hint when trailing-slash install dir IS on PATH"
+fi
+
 # ---------------------------------------------------------------------------
 # Predicate 10 — hygiene pins (shebang, set -eu, no $0, repo literal).
 # ---------------------------------------------------------------------------
@@ -479,9 +503,9 @@ echo "== Predicate 10: hygiene pins =="
 assert_eq "shebang is #!/bin/sh (POSIX sh)" "#!/bin/sh" "$(sed -n '1p' "$INSTALL_SH")"
 
 if grep -qE '^set -eu$' "$INSTALL_SH"; then
-  ok "starts with set -eu (fail-closed hygiene)"
+  ok "contains set -eu (fail-closed hygiene)"
 else
-  ko "starts with set -eu — missing"
+  ko "contains set -eu — missing"
 fi
 
 if grep -qF '$0' "$INSTALL_SH"; then
@@ -494,6 +518,64 @@ if grep -qF 'mcmullarkey/blendtutor' "$INSTALL_SH"; then
   ok "repo literal mcmullarkey/blendtutor present"
 else
   ko "repo literal mcmullarkey/blendtutor present — missing"
+fi
+
+# ---------------------------------------------------------------------------
+# Predicate 11 — environment fail arms (fail-closed on a poisoned env).
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 11: environment fail arms =="
+
+# Arm 1 — HOME unset (empty): neither BLENDTUTOR_INSTALL_DIR nor HOME
+# resolves, so install.sh must fail naming the override var. The run_install
+# wrapper sets HOME="$TEST_HOME" before "$@", so the "HOME=" override wins
+# (env applies later assignments last) and the elif arm sees an empty value.
+: > "$COUNTER"
+run_install "$OUT" "$ERR" "HOME="
+if [ "$INSTALL_STATUS" -ne 0 ]; then
+  ok "HOME unset → nonzero exit"
+else
+  ko "HOME unset → nonzero exit — installed with unknown dir!"
+fi
+if grep -qF 'BLENDTUTOR_INSTALL_DIR' "$ERR"; then
+  ok "HOME-unset message names BLENDTUTOR_INSTALL_DIR"
+else
+  ko "HOME-unset message names BLENDTUTOR_INSTALL_DIR — got: $(cat "$ERR")"
+fi
+
+# Arm 2 — no sha256 tool: PATH has the stubs plus a stripped coreutils dir
+# (everything from /usr/bin and /bin EXCEPT sha256sum/shasum), so every
+# pre-verify step succeeds and the failure isolates sha256_of's no-tool arm.
+# (PATH=$STUB_DIR alone would die earlier at mktemp — wrong arm.)
+NOTOOL_BIN="$TMPDIR/notool-bin"
+mkdir -p "$NOTOOL_BIN"
+for src_dir in /usr/bin /bin; do
+  [ -d "$src_dir" ] || continue
+  for src in "$src_dir"/*; do
+    [ -e "$src" ] || continue
+    b=${src##*/}
+    case "$b" in sha256sum|shasum) continue ;; esac
+    ln -sf "$src" "$NOTOOL_BIN/$b" 2>/dev/null || :
+  done
+done
+
+: > "$COUNTER"
+NOTOOL_INST="$TMPDIR/notool-inst"
+run_install "$OUT" "$ERR" "PATH=$STUB_DIR:$NOTOOL_BIN" "BLENDTUTOR_INSTALL_DIR=$NOTOOL_INST"
+if [ "$INSTALL_STATUS" -ne 0 ]; then
+  ok "no sha256 tool → nonzero exit"
+else
+  ko "no sha256 tool → nonzero exit — installed an unverified tarball!"
+fi
+if grep -qi 'sha256 tool' "$ERR"; then
+  ok "no-sha256-tool message names the missing tool"
+else
+  ko "no-sha256-tool message names the missing tool — got: $(cat "$ERR")"
+fi
+if [ ! -e "$NOTOOL_INST/blendtutor" ]; then
+  ok "nothing installed without a sha256 tool"
+else
+  ko "nothing installed without a sha256 tool — binary exists after failed verify"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_install_sh.sh
+++ b/scripts/tests/test_install_sh.sh
@@ -24,9 +24,15 @@
 #      PATH entry has none (no false hint).
 #  10. Hygiene pins: `#!/bin/sh` shebang, `set -eu`, no `$0` anywhere (the
 #      curl|sh contract), `mcmullarkey/blendtutor` repo literal present.
-#  11. Environment fail arms: HOME unset → nonzero + message naming
+#  11. Environment fail arms: HOME unset/empty → nonzero + message naming
 #      BLENDTUTOR_INSTALL_DIR; no sha256 tool on PATH → nonzero + "no sha256
 #      tool" message (fail-closed before any install).
+#  12. Recovery arms: shasum-only PATH (sha256sum absent, shasum present) →
+#      install succeeds via the sha256_of fallback; HOME empty but
+#      BLENDTUTOR_INSTALL_DIR set → installs to the override dir.
+#  13. Self-wiring: ci.yml's check job invokes this test (a deleted step
+#      fails this suite instead of silently dropping coverage — sibling
+#      precedent: test_release_yml.sh Phase 5).
 #
 # Stub pattern follows scripts/tests/test_smevals_runner.sh: fake curl/uname
 # via PATH injection + counter file proving invocation. The stub curl serves
@@ -78,6 +84,16 @@ if [ ! -f "$INSTALL_SH" ]; then
   exit 1
 fi
 ok "$INSTALL_SH exists"
+
+# Self-wiring pin (sibling precedent: test_release_yml.sh Phase 5) — this
+# suite is invoked by ci.yml's check job; if that step is ever deleted, this
+# clause fails instead of the coverage silently dropping out of CI.
+CI_FILE=".github/workflows/ci.yml"
+if [ -f "$CI_FILE" ] && grep -qF 'bash scripts/tests/test_install_sh.sh' "$CI_FILE"; then
+  ok "wired into ci.yml (check job runs this test)"
+else
+  ko "wired into ci.yml — 'bash scripts/tests/test_install_sh.sh' not found in $CI_FILE"
+fi
 
 # ---------------------------------------------------------------------------
 # Setup: temp dir + stub curl/uname on PATH + canned release layout.
@@ -533,14 +549,14 @@ echo "== Predicate 11: environment fail arms =="
 : > "$COUNTER"
 run_install "$OUT" "$ERR" "HOME="
 if [ "$INSTALL_STATUS" -ne 0 ]; then
-  ok "HOME unset → nonzero exit"
+  ok "HOME unset/empty → nonzero exit"
 else
-  ko "HOME unset → nonzero exit — installed with unknown dir!"
+  ko "HOME unset/empty → nonzero exit — installed with unknown dir!"
 fi
 if grep -qF 'BLENDTUTOR_INSTALL_DIR' "$ERR"; then
-  ok "HOME-unset message names BLENDTUTOR_INSTALL_DIR"
+  ok "HOME-unset/empty message names BLENDTUTOR_INSTALL_DIR"
 else
-  ko "HOME-unset message names BLENDTUTOR_INSTALL_DIR — got: $(cat "$ERR")"
+  ko "HOME-unset/empty message names BLENDTUTOR_INSTALL_DIR — got: $(cat "$ERR")"
 fi
 
 # Arm 2 — no sha256 tool: PATH has the stubs plus a stripped coreutils dir
@@ -576,6 +592,53 @@ if [ ! -e "$NOTOOL_INST/blendtutor" ]; then
   ok "nothing installed without a sha256 tool"
 else
   ko "nothing installed without a sha256 tool — binary exists after failed verify"
+fi
+
+# ---------------------------------------------------------------------------
+# Predicate 12 — recovery arms (degraded env still installs).
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 12: recovery arms =="
+
+# Arm 1 — shasum fallback: PATH has shasum but NOT sha256sum (same stripped-
+# coreutils symlink pattern as the no-tool arm, minus the shasum exclusion),
+# so sha256_of must fall back to shasum and the install succeeds. On macOS
+# hosts sha256sum is absent system-wide, so this doubles as the native path;
+# on Linux CI it exercises the actual fallback branch.
+SHASUM_ONLY_BIN="$TMPDIR/shasum-only-bin"
+mkdir -p "$SHASUM_ONLY_BIN"
+for src_dir in /usr/bin /bin; do
+  [ -d "$src_dir" ] || continue
+  for src in "$src_dir"/*; do
+    [ -e "$src" ] || continue
+    b=${src##*/}
+    case "$b" in sha256sum) continue ;; esac
+    ln -sf "$src" "$SHASUM_ONLY_BIN/$b" 2>/dev/null || :
+  done
+done
+
+: > "$COUNTER"
+SHASUM_INST="$TMPDIR/shasum-inst"
+run_install "$OUT" "$ERR" "PATH=$STUB_DIR:$SHASUM_ONLY_BIN" "BLENDTUTOR_INSTALL_DIR=$SHASUM_INST"
+assert_eq "shasum-only PATH (no sha256sum) exits 0 (fallback)" "0" "$INSTALL_STATUS"
+if [ -x "$SHASUM_INST/blendtutor" ]; then
+  ok "binary installed via shasum fallback"
+else
+  ko "binary installed via shasum fallback — got: $(ls -la "$SHASUM_INST" 2>&1 || echo dir-missing)"
+fi
+
+# Arm 2 — HOME empty but BLENDTUTOR_INSTALL_DIR set: the advertised recovery
+# path (install.sh checks the override var BEFORE HOME). The "HOME=" override
+# wins over the wrapper's HOME="$TEST_HOME" (env applies later assignments
+# last).
+: > "$COUNTER"
+NOHOME_INST="$TMPDIR/nohome-inst"
+run_install "$OUT" "$ERR" "HOME=" "BLENDTUTOR_INSTALL_DIR=$NOHOME_INST"
+assert_eq "HOME empty + BLENDTUTOR_INSTALL_DIR set exits 0" "0" "$INSTALL_STATUS"
+if [ -x "$NOHOME_INST/blendtutor" ]; then
+  ok "binary installed to override dir despite empty HOME"
+else
+  ko "binary installed to override dir despite empty HOME — got: $(ls -la "$NOHOME_INST" 2>&1 || echo dir-missing)"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_install_sh.sh
+++ b/scripts/tests/test_install_sh.sh
@@ -1,0 +1,512 @@
+#!/usr/bin/env bash
+# Stub-based BDD test for scripts/install.sh (issue #224).
+#
+# Verifies the AC-2 predicate — a uv-style `curl | sh` installer whose asset
+# naming byte-matches the release.yml contract pinned by test_release_yml.sh:
+#
+#   1. Happy path (linux x86_64, file mode): exit 0; binary installed to the
+#      DEFAULT dir ($HOME/.local/bin) and executable; curl fetched exactly
+#      (a) the latest-release API URL, (b) the tarball URL byte-matching
+#      blendtutor-<tag>-<target>.tar.gz, (c) blendtutor-<tag>-sha256sums.txt.
+#   2. curl|sh contract: `sh < install.sh` (stdin-piped, $0=sh) also installs
+#      — no $0 assumptions, no stdin consumption by any child command.
+#   3. Fail-closed: a tarball whose hash differs from the checksums file →
+#      nonzero exit + message naming the checksum.
+#   4. Unsupported OS (uname -s) / arch (uname -m) → nonzero + message.
+#   5. uname mapping covers ALL 4 release targets, incl. macOS `arm64` →
+#      aarch64-apple-darwin (Darwin reports arm64, not aarch64).
+#   6. BLENDTUTOR_INSTALL_DIR override honored (binary lands there).
+#   7. API fetch failure / tarball download failure / checksums download
+#      failure → nonzero (fail-closed, no || true).
+#   8. Tarball absent from the checksums file → fail closed.
+#   9. PATH hint: printed when the install dir is not on PATH; absent when
+#      it is.
+#  10. Hygiene pins: `#!/bin/sh` shebang, `set -eu`, no `$0` anywhere (the
+#      curl|sh contract), `mcmullarkey/blendtutor` repo literal present.
+#
+# Stub pattern follows scripts/tests/test_smevals_runner.sh: fake curl/uname
+# via PATH injection + counter file proving invocation. The stub curl serves
+# a canned release layout (a REAL tar.gz with the bare `blendtutor` member at
+# its root, per the pinned tar-root contract) — zero network.
+#
+# Usage: bash scripts/tests/test_install_sh.sh
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+INSTALL_SH="scripts/install.sh"
+PASS=0
+FAIL=0
+
+ok() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+ko() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    ok "$label (got: $actual)"
+  else
+    ko "$label — expected [$expected], got [$actual]"
+  fi
+}
+
+# Portable sha256 (macOS lacks GNU sha256sum; CI ubuntu has it).
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Phase 0 — file presence (early exit: every later clause needs the file)
+# ---------------------------------------------------------------------------
+
+echo "== Phase 0: file presence =="
+
+if [ ! -f "$INSTALL_SH" ]; then
+  ko "$INSTALL_SH exists"
+  echo ""
+  echo "========================================="
+  echo "  Results: $PASS passed, $FAIL failed"
+  echo "========================================="
+  exit 1
+fi
+ok "$INSTALL_SH exists"
+
+# ---------------------------------------------------------------------------
+# Setup: temp dir + stub curl/uname on PATH + canned release layout.
+# ---------------------------------------------------------------------------
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+STUB_DIR="$TMPDIR/bin"
+mkdir -p "$STUB_DIR"
+
+# Counter file — proves the stub curl was invoked with the contracted URLs
+# (predicate 1: no canned assumptions about what install.sh fetches).
+COUNTER="$TMPDIR/curl-calls.txt"
+: > "$COUNTER"
+
+# Canned release layout — mirrors the release.yml contract: a tar.gz holding
+# the bare `blendtutor` member at its root, plus a sha256sums file listing
+# the tarball under ALL 4 target triples (one layout serves every
+# uname-mapping scenario). Tag canned as v0.1.0.
+LAYOUT="$TMPDIR/layout"
+mkdir -p "$LAYOUT"
+printf '#!/bin/sh\necho "blendtutor-stub-binary v0.1.0"\n' > "$LAYOUT/blendtutor"
+chmod +x "$LAYOUT/blendtutor"
+tar -czf "$LAYOUT/canned.tar.gz" -C "$LAYOUT" blendtutor
+TARBALL_SHA=$(sha256_of "$LAYOUT/canned.tar.gz")
+
+SUMS="$LAYOUT/blendtutor-v0.1.0-sha256sums.txt"
+: > "$SUMS"
+for t in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-apple-darwin aarch64-apple-darwin; do
+  printf '%s  blendtutor-v0.1.0-%s.tar.gz\n' "$TARBALL_SHA" "$t" >> "$SUMS"
+done
+
+# A checksums file that does NOT list the fetched tarball (predicate 8:
+# fail closed when the release ships no entry for our platform).
+printf '%s  blendtutor-v9.9.9-x86_64-unknown-linux-gnu.tar.gz\n' "$TARBALL_SHA" \
+  > "$LAYOUT/partial-sums.txt"
+
+# A VALID tarball with different bytes (predicate 3: checksum MISMATCH, not
+# a tar-parse error — isolates the fail-closed verify arm).
+mkdir -p "$LAYOUT/corruptsrc"
+printf '#!/bin/sh\necho "TAMPERED"\n' > "$LAYOUT/corruptsrc/blendtutor"
+tar -czf "$LAYOUT/corrupt.tar.gz" -C "$LAYOUT/corruptsrc" blendtutor
+
+# Contract URLs (deliberate contract pins — these byte-match the
+# release.yml asset-name contract pinned by test_release_yml.sh; the canned
+# tag is v0.1.0).
+API_URL="https://api.github.com/repos/mcmullarkey/blendtutor/releases/latest"
+TARBALL_URL="https://github.com/mcmullarkey/blendtutor/releases/download/v0.1.0/blendtutor-v0.1.0-x86_64-unknown-linux-gnu.tar.gz"
+SUMS_URL="https://github.com/mcmullarkey/blendtutor/releases/download/v0.1.0/blendtutor-v0.1.0-sha256sums.txt"
+
+cat > "$STUB_DIR/curl" <<'STUB'
+#!/usr/bin/env bash
+# Stub curl — serves the canned release layout by URL pattern, records every
+# invocation, and honors `-o <file>` (install.sh fetches to files). Modes:
+#   ok (default) | api-fail | download-fail | sums-fail | sums-missing | corrupt
+set -euo pipefail
+
+COUNTER="${INSTALL_TEST_COUNTER:?INSTALL_TEST_COUNTER not set}"
+LAYOUT="${INSTALL_TEST_LAYOUT:?INSTALL_TEST_LAYOUT not set}"
+
+url=""
+out="/dev/stdout"
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-o" ]; then
+    out="$arg"
+  fi
+  case "$arg" in
+    http*) [ -z "$url" ] && url="$arg" ;;
+  esac
+  prev="$arg"
+done
+if [ -z "$url" ]; then
+  echo "stub-curl: no URL in args: $*" >&2
+  exit 1
+fi
+
+echo "$url" >> "$COUNTER"
+
+emit() {
+  if [ "$out" = "/dev/stdout" ]; then
+    cat
+  else
+    cat > "$out"
+  fi
+}
+
+mode="${STUB_CURL_MODE:-ok}"
+
+case "$url" in
+  *"api.github.com/repos/mcmullarkey/blendtutor/releases/latest")
+    if [ "$mode" = "api-fail" ]; then
+      echo "stub-curl: simulated api failure" >&2
+      exit 7
+    fi
+    printf '{"tag_name": "v0.1.0", "name": "v0.1.0", "assets": []}\n' | emit
+    ;;
+  *"releases/download/v0.1.0/"*)
+    case "$url" in
+      *-sha256sums.txt)
+        if [ "$mode" = "sums-fail" ]; then
+          echo "stub-curl: simulated checksums download failure" >&2
+          exit 22
+        fi
+        if [ "$mode" = "sums-missing" ]; then
+          cat "$LAYOUT/partial-sums.txt" | emit
+        else
+          cat "$LAYOUT/blendtutor-v0.1.0-sha256sums.txt" | emit
+        fi
+        ;;
+      *.tar.gz)
+        if [ "$mode" = "download-fail" ]; then
+          echo "stub-curl: simulated tarball download failure" >&2
+          exit 22
+        fi
+        if [ "$mode" = "corrupt" ]; then
+          cat "$LAYOUT/corrupt.tar.gz" | emit
+        else
+          cat "$LAYOUT/canned.tar.gz" | emit
+        fi
+        ;;
+      *)
+        echo "stub-curl: unexpected download path: $url" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    echo "stub-curl: unexpected URL: $url" >&2
+    exit 1
+    ;;
+esac
+STUB
+chmod +x "$STUB_DIR/curl"
+
+cat > "$STUB_DIR/uname" <<'STUB'
+#!/usr/bin/env bash
+# Stub uname — serves INSTALL_TEST_UNAME_S / INSTALL_TEST_UNAME_M
+# (defaults mimic the CI runner: Linux x86_64).
+set -euo pipefail
+case "${1:-}" in
+  -m) printf '%s\n' "${INSTALL_TEST_UNAME_M:-x86_64}" ;;
+  *)  printf '%s\n' "${INSTALL_TEST_UNAME_S:-Linux}" ;;
+esac
+STUB
+chmod +x "$STUB_DIR/uname"
+
+TEST_HOME="$TMPDIR/home"
+mkdir -p "$TEST_HOME"
+
+OUT="$TMPDIR/out.txt"
+ERR="$TMPDIR/err.txt"
+
+# run_install <out> <err> [VAR=val ...] — clean-env run of install.sh in
+# FILE mode (sh <path>). Sets INSTALL_STATUS. Stub curl/uname win PATH;
+# real coreutils come after. STUB_CURL_MODE / INSTALL_TEST_* / env overrides
+# pass through "$@".
+run_install() {
+  local out="$1" err="$2"
+  shift 2
+  INSTALL_STATUS=0
+  env -i \
+    PATH="$STUB_DIR:/usr/bin:/bin" \
+    INSTALL_TEST_COUNTER="$COUNTER" \
+    INSTALL_TEST_LAYOUT="$LAYOUT" \
+    HOME="$TEST_HOME" \
+    "$@" \
+    sh "$INSTALL_SH" >"$out" 2>"$err" || INSTALL_STATUS=$?
+}
+
+# run_install_stdin <out> <err> [VAR=val ...] — same, but the script is
+# PIPED VIA STDIN (`sh` with stdin = the script), the actual `curl | sh`
+# execution shape: $0 is "sh" and any stdin-reading command would eat the
+# remaining script bytes and truncate it.
+run_install_stdin() {
+  local out="$1" err="$2"
+  shift 2
+  INSTALL_STATUS=0
+  env -i \
+    PATH="$STUB_DIR:/usr/bin:/bin" \
+    INSTALL_TEST_COUNTER="$COUNTER" \
+    INSTALL_TEST_LAYOUT="$LAYOUT" \
+    HOME="$TEST_HOME" \
+    "$@" \
+    sh >"$out" 2>"$err" <"$INSTALL_SH" || INSTALL_STATUS=$?
+}
+
+# ---------------------------------------------------------------------------
+# Predicate 1 — happy path: default dir, executable binary, contract URLs.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 1: happy path (linux x86_64, default install dir) =="
+
+: > "$COUNTER"
+run_install "$OUT" "$ERR"
+assert_eq "install.sh exits 0" "0" "$INSTALL_STATUS"
+
+DEFAULT_BIN="$TEST_HOME/.local/bin/blendtutor"
+if [ -x "$DEFAULT_BIN" ]; then
+  ok "binary installed executable at \$HOME/.local/bin/blendtutor"
+else
+  ko "binary installed executable at \$HOME/.local/bin/blendtutor — got: $(ls -la "$TEST_HOME/.local/bin" 2>&1 || echo dir-missing)"
+fi
+
+assert_eq "installed binary runs (bare member extracted)" \
+  "blendtutor-stub-binary v0.1.0" "$("$DEFAULT_BIN" 2>/dev/null || echo RUN-FAILED)"
+
+assert_eq "curl called exactly 3 times (api + tarball + sums)" \
+  "3" "$(wc -l < "$COUNTER" | tr -d ' ')"
+
+if grep -qF "$API_URL" "$COUNTER" \
+    && grep -qF "$TARBALL_URL" "$COUNTER" \
+    && grep -qF "$SUMS_URL" "$COUNTER"; then
+  ok "fetched contract URLs: latest API + blendtutor-<tag>-<target>.tar.gz + blendtutor-<tag>-sha256sums.txt"
+else
+  ko "fetched contract URLs — counter: $(cat "$COUNTER")"
+fi
+
+# ---------------------------------------------------------------------------
+# Predicate 2 — curl|sh contract: stdin-piped execution installs too.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 2: curl|sh (stdin-piped, \$0=sh) =="
+
+: > "$COUNTER"
+run_install_stdin "$OUT" "$ERR"
+assert_eq "stdin-piped install.sh exits 0" "0" "$INSTALL_STATUS"
+
+STDIN_BIN="$TEST_HOME/.local/bin/blendtutor"
+if [ -x "$STDIN_BIN" ]; then
+  ok "stdin-piped run installed the binary (no \$0 assumptions, no stdin eating)"
+else
+  ko "stdin-piped run installed the binary — script truncated or \$0-dependent"
+fi
+
+# ---------------------------------------------------------------------------
+# Predicate 3 — fail-closed on checksum mismatch.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 3: checksum mismatch fails closed =="
+
+: > "$COUNTER"
+# Own install dir: the happy path (P1) already populated the default dir, so
+# the nothing-installed assertion must watch a fresh dir.
+CORRUPT_DIR="$TMPDIR/corrupt-inst"
+run_install "$OUT" "$ERR" "STUB_CURL_MODE=corrupt" "BLENDTUTOR_INSTALL_DIR=$CORRUPT_DIR"
+if [ "$INSTALL_STATUS" -ne 0 ]; then
+  ok "corrupt tarball → nonzero exit"
+else
+  ko "corrupt tarball → nonzero exit — sneaky-pass install!"
+fi
+if grep -qi 'checksum' "$ERR"; then
+  ok "mismatch message names the checksum"
+else
+  ko "mismatch message names the checksum — got: $(cat "$ERR")"
+fi
+if [ ! -e "$CORRUPT_DIR/blendtutor" ]; then
+  ok "nothing installed on checksum mismatch"
+else
+  ko "nothing installed on checksum mismatch — binary exists after failed verify"
+fi
+
+# ---------------------------------------------------------------------------
+# Predicate 4 — unsupported OS / arch fail with a message.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 4: unsupported OS/arch =="
+
+run_install "$OUT" "$ERR" "INSTALL_TEST_UNAME_S=Plan9"
+if [ "$INSTALL_STATUS" -ne 0 ] && grep -qi 'unsupported' "$ERR"; then
+  ok "unsupported OS (Plan9) → nonzero + message"
+else
+  ko "unsupported OS (Plan9) → nonzero + message — status: ${INSTALL_STATUS:-?}, err: $(cat "$ERR")"
+fi
+
+run_install "$OUT" "$ERR" "INSTALL_TEST_UNAME_M=sparc"
+if [ "$INSTALL_STATUS" -ne 0 ] && grep -qi 'unsupported' "$ERR"; then
+  ok "unsupported arch (sparc) → nonzero + message"
+else
+  ko "unsupported arch (sparc) → nonzero + message — status: ${INSTALL_STATUS:-?}, err: $(cat "$ERR")"
+fi
+
+# ---------------------------------------------------------------------------
+# Predicate 5 — uname mapping covers all 4 release targets.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 5: uname → target-triple mapping (4 targets) =="
+
+i=0
+for combo in \
+  "Linux:x86_64:x86_64-unknown-linux-gnu" \
+  "Linux:aarch64:aarch64-unknown-linux-gnu" \
+  "Darwin:x86_64:x86_64-apple-darwin" \
+  "Darwin:arm64:aarch64-apple-darwin"; do
+  i=$((i + 1))
+  s="${combo%%:*}"
+  rest="${combo#*:}"
+  m="${rest%%:*}"
+  t="${rest##*:}"
+  : > "$COUNTER"
+  run_install "$OUT" "$ERR" \
+    "INSTALL_TEST_UNAME_S=$s" "INSTALL_TEST_UNAME_M=$m" \
+    "BLENDTUTOR_INSTALL_DIR=$TMPDIR/inst-$i"
+  assert_eq "mapping $s/$m → exit 0" "0" "$INSTALL_STATUS"
+  if grep -qF "releases/download/v0.1.0/blendtutor-v0.1.0-$t.tar.gz" "$COUNTER"; then
+    ok "mapping $s/$m → $t tarball fetched"
+  else
+    ko "mapping $s/$m → $t tarball fetched — counter: $(cat "$COUNTER")"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Predicate 6 — BLENDTUTOR_INSTALL_DIR override.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 6: BLENDTUTOR_INSTALL_DIR override =="
+
+: > "$COUNTER"
+OVERRIDE_DIR="$TMPDIR/custom-tools"
+run_install "$OUT" "$ERR" "BLENDTUTOR_INSTALL_DIR=$OVERRIDE_DIR"
+assert_eq "override install exits 0" "0" "$INSTALL_STATUS"
+if [ -x "$OVERRIDE_DIR/blendtutor" ]; then
+  ok "binary installed at BLENDTUTOR_INSTALL_DIR"
+else
+  ko "binary installed at BLENDTUTOR_INSTALL_DIR — got: $(ls -la "$OVERRIDE_DIR" 2>&1 || echo dir-missing)"
+fi
+
+# ---------------------------------------------------------------------------
+# Predicate 7 — fetch failures fail closed.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 7: fetch failures fail closed =="
+
+for arm in api-fail download-fail sums-fail; do
+  : > "$COUNTER"
+  run_install "$OUT" "$ERR" "STUB_CURL_MODE=$arm"
+  if [ "$INSTALL_STATUS" -ne 0 ]; then
+    ok "$arm → nonzero exit"
+  else
+    ko "$arm → nonzero exit — error swallowed!"
+  fi
+  if [ -s "$ERR" ]; then
+    ok "$arm → message on stderr"
+  else
+    ko "$arm → message on stderr — silent failure"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Predicate 8 — tarball absent from checksums file fails closed.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 8: tarball not in checksums file =="
+
+: > "$COUNTER"
+run_install "$OUT" "$ERR" "STUB_CURL_MODE=sums-missing"
+if [ "$INSTALL_STATUS" -ne 0 ]; then
+  ok "unlisted tarball → nonzero exit"
+else
+  ko "unlisted tarball → nonzero exit — installed without verification!"
+fi
+if grep -qi 'not listed\|checksum' "$ERR"; then
+  ok "unlisted-tarball message names the verification failure"
+else
+  ko "unlisted-tarball message names the verification failure — got: $(cat "$ERR")"
+fi
+
+# ---------------------------------------------------------------------------
+# Predicate 9 — PATH hint on/off.
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 9: PATH hint =="
+
+: > "$COUNTER"
+HINT_DIR="$TMPDIR/hint-bin"
+run_install "$OUT" "$ERR" "BLENDTUTOR_INSTALL_DIR=$HINT_DIR"
+assert_eq "hint scenario exits 0" "0" "$INSTALL_STATUS"
+if grep -qF "not on your PATH" "$OUT" "$ERR"; then
+  ok "PATH hint printed when install dir not on PATH"
+else
+  ko "PATH hint printed when install dir not on PATH — out: $(cat "$OUT"), err: $(cat "$ERR")"
+fi
+
+: > "$COUNTER"
+HINT_DIR2="$TMPDIR/hint-bin2"
+run_install "$OUT" "$ERR" \
+  "BLENDTUTOR_INSTALL_DIR=$HINT_DIR2" \
+  "PATH=$STUB_DIR:$HINT_DIR2:/usr/bin:/bin"
+assert_eq "on-PATH scenario exits 0" "0" "$INSTALL_STATUS"
+if grep -qF "not on your PATH" "$OUT" "$ERR"; then
+  ko "no PATH hint when install dir IS on PATH — false hint: $(cat "$OUT") $(cat "$ERR")"
+else
+  ok "no PATH hint when install dir IS on PATH"
+fi
+
+# ---------------------------------------------------------------------------
+# Predicate 10 — hygiene pins (shebang, set -eu, no $0, repo literal).
+# ---------------------------------------------------------------------------
+
+echo "== Predicate 10: hygiene pins =="
+
+assert_eq "shebang is #!/bin/sh (POSIX sh)" "#!/bin/sh" "$(sed -n '1p' "$INSTALL_SH")"
+
+if grep -qE '^set -eu$' "$INSTALL_SH"; then
+  ok "starts with set -eu (fail-closed hygiene)"
+else
+  ko "starts with set -eu — missing"
+fi
+
+if grep -qF '$0' "$INSTALL_SH"; then
+  ko "no \$0 anywhere (curl|sh contract — script is stdin-piped, \$0 is sh)"
+else
+  ok "no \$0 anywhere (curl|sh contract)"
+fi
+
+if grep -qF 'mcmullarkey/blendtutor' "$INSTALL_SH"; then
+  ok "repo literal mcmullarkey/blendtutor present"
+else
+  ko "repo literal mcmullarkey/blendtutor present — missing"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "========================================="
+echo "  Results: $PASS passed, $FAIL failed"
+echo "========================================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+
+echo "All tests passed."


### PR DESCRIPTION
## Summary
Adds `scripts/install.sh` — a uv-style `curl | sh` installer for the blendtutor binary. Detects OS/arch (linux/macOS × x86_64/aarch64, incl. macOS `arm64`), resolves the latest release via the GitHub API, fetches the release tarball + SHA256 checksums (asset names byte-match the release.yml contract pinned in #231), verifies the checksum fail-closed BEFORE extraction, and installs the bare `blendtutor` binary to `~/.local/bin` (overridable via `BLENDTUTOR_INSTALL_DIR`) with a PATH hint when the dir is off PATH. POSIX sh, no script-path assumptions, no stdin reads — safe under `curl | sh`.

README install section now leads with the one-liner (minimal edit; cargo-from-clone kept as alternative — final README wording lands in AC-3/#225).

## Issue
Closes #224

## ACs implemented
- [x] `scripts/install.sh` (NEW) works via `curl | sh` (stdin-piped, no `$0` assumptions, POSIX-ish sh); asset naming byte-matches AC-1's pinned contract
- [x] Fail-closed: checksum mismatch → exit nonzero with message; install dir default `~/.local/bin`, overridable via `BLENDTUTOR_INSTALL_DIR`
- [x] Stub-based shell BDD `scripts/tests/test_install_sh.sh` (fake `curl`/`uname` via PATH injection) added AND invoked in ci.yml

## Test plan
- [x] `scripts/tests/test_install_sh.sh` — 52 clauses / 12 predicates, all passing: happy path (default dir + contract URLs), stdin-piped curl|sh mode, checksum-mismatch fail-closed, unsupported OS/arch, 4-target uname mapping, install-dir override, fetch-failure arms, unlisted-tarball arm, PATH hint on/off, hygiene pins (shebang, set -eu, no `$0`, repo literal), env fail arms (HOME empty, no sha256 tool), recovery arms (shasum fallback, HOME empty + override dir), ci.yml self-wiring pin
- [x] Negative control performed: throwaway stub → green; sneaky-pass variant (verify removed) → 3 clauses fail; suite has teeth
- [x] `test_release_yml.sh` 28/28 (contract source of truth untouched), `test_smevals_runner.sh` green, `test_quarto_distribution.sh` 91/91 (README pins intact)
- [x] E2E evidence at `docs/evidence/224/`: real-network run (real API resolves v0.1.0 → tarball 404 → fail-closed, nothing installed) + stubbed-layout full install flow (file mode, stdin-pipe mode, checksum-mismatch demo)
- [x] PR review findings resolved

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested
- [x] Verification medium satisfied (code)
- [x] Design intent respected (uv prior art; test_smevals_runner.sh stub pattern)
- [x] No scope creep (book untouched — #226 territory; no ADR — contract already pinned by release.yml)

Plan ref: `.opencode/plans/user-friendliness/AC-2.md`
