### PR TITLE
[feature] Scaffold eval sibling in new lesson; prune dead evals/*.R; eval docs first-class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 .Rproj.user
 .Renviron
-# The top-level R evals working dir only — anchored so it does not also ignore
-# Rust eval fixtures under crates/*/tests/fixtures/evals/.
-/evals/
 # Generated smevals eval dirs (blendtutor eval-report). Unanchored so a course
 # anywhere in the tree is covered; provably does NOT match committed build
 # output under docs/evals/ (deliberately committed) nor Rust eval fixtures

--- a/.opencode/plans/user-friendliness/AC-6.md
+++ b/.opencode/plans/user-friendliness/AC-6.md
@@ -2,7 +2,7 @@
 ac: 6
 depends_on: AC-3, AC-4
 risk: low
-status: spec
+status: complete
 ---
 
 **Factual dispute verdict:** Speculator A correct. `scaffold_plan()` (scaffold.rs:60-83, init-only via `scaffold_course`) plans EVAL_FILENAME (eval_lesson_hello.yaml) + EVAL_TEMPLATE for the starter lesson. `add_lesson()` (scaffold.rs:346-361, called by `blendtutor new lesson` via commands/new.rs) writes ONLY lessons/<id>.yaml + manifest append — no eval sibling. B conflated init starter-files with new-lesson path. Corollary: evals/*.R untracked+gitignored (.gitignore:5 /evals/ anchored) — "prune" in PR = (1) .gitignore tracked edit, (2) doc reference cleanup, (3) local rm -rf evals/ documented in issue (PR cannot delete untracked files).
@@ -66,13 +66,24 @@ status: spec
 **Friction:** planner named nonexistent doctor command — both speculators re-derived from main.rs. Candidate lesson: planner must list command surface from main.rs grep, not memory.
 
 ### Progress
-- (none yet)
+- [x] RED suite committed (4a2c87d): `new_scaffolds_a_sibling_eval_suite` in crates/cli/tests/new.rs (behavioral RED — missing-sibling assertion) + 5 scaffold.rs in-module tests (compile RED on eval_template/eval_sibling_path) — 2026-09-09
+- [x] feat committed (28a4ba9): EVAL_SIBLING_PREFIX + eval_sibling_path + eval_template in core::scaffold; add_lesson writes sibling via write_without_clobber; cli sibling_suite_path delegates to core (single source); negative control confirmed (bogus expected token fails 3 tests) — 2026-09-09
+- [x] prune+docs committed (c595fc9): .gitignore /evals/ entry + comment removed; creating-lessons.md Step 7 + whole-game.md eval region name the sibling convention; agent-notes/eval.md annotated retired; local `rm -rf evals/` done in main checkout (untracked — PR cannot delete) — 2026-09-09
+- [x] evidence committed (b6f166a): docs/evidence/228/ — e2e-new-lesson-sibling.log, e2e-eval-help-sibling-convention.log, e2e-missing-sibling-negative.log, prune-absence-greps.log, test-suite.log — 2026-09-09
+- [x] Full gate green: new 4, eval 7, eval_report_cli 10, readme 2, cli 2, cutover 1, core 201, model-alignment OK, smevals-runner 12, judge-feedback 78, quarto-dist 9, demo-docs 5
 
 ### Decision Log
-- (none yet)
+- Sibling convention single source lives in **core** (`core::scaffold::eval_sibling_path` + `EVAL_SIBLING_PREFIX`), not cli: dependency only points cli → core, so delegation (cli `sibling_suite_path` → core fn) is the only shape with exactly one implementation. Spec's "or same constant if core/cli crate boundary requires" resolved to the stronger full-delegation form.
+- `add_lesson` write order: lesson first, then eval sibling, then manifest append. Duplicate-id refusal (the common case) still fires with zero writes; the rare pre-existing-sibling refusal leaves an unregistered lesson (documented residual window in add_lesson doc comment, same recoverable class as the manifest-append window).
+- `AddLessonError::AlreadyExists` Display: "a lesson already exists" → "a file already exists" — accurate for both collision arms (lesson or sibling); no external pins on the old wording.
+- eval_template emits ONE case (`expected: correct`) with the language's hello-world submission; the starter course's committed two-case suite remains the fuller example (per needs-clarification #2).
+- README left untouched: post-slim line 40 already claims "add lessons/greet.yaml + eval_<name>.yaml sibling" — F1 makes the existing claim TRUE (spec: "becomes TRUE rather than edited weaker").
 
 ### Surprises & Discoveries
-- (none yet)
+- The spec's probe greps `crates/` wholesale but its own P1 prose scopes `crates/*/src` with fixture headers exempt — the literal probe has exactly one hit, the archival provenance comment in `crates/core/tests/fixtures/evals/eval_fireworks_vitals.yaml:2` (`# evals/eval_fireworks_vitals.R (the eval_data tibble…)`). Followed the P1 prose scope (zero hits, PASS) and documented the exempt hit in docs/evidence/228/prune-absence-greps.log rather than editing the archival fixture header.
+- `Language` is Clone-not-Copy, so `add_lesson`'s two template calls need one `language.clone()` (on the first call; the second consumes the original).
+- Post-slim README already carried the sibling claim at line 40 (`eval_<name>.yaml`) — the pre-slim line numbers in the spec (~:80) had drifted; grep located it. No README edit required.
+- `blendtutor eval --help` already names `eval_<lesson>.yaml` via clap doc comment (main.rs:72) — P7's help-grep arm passed with zero changes.
 
 ### Idempotence & Recovery
 - Safe retry: re-run builder on same branch; tests are idempotent

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -4,7 +4,6 @@
 //! renders the result for the terminal. No domain logic lives here — that is
 //! `core`'s responsibility (the dependency only ever points cli → core).
 
-use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 
 pub mod build;
@@ -27,13 +26,12 @@ pub(crate) const PROVIDER_URL_VAR: &str = "BLENDTUTOR_PROVIDER_URL";
 /// the instructor-only sibling convention — the suite is authored next to its
 /// lesson and is never bundled into a built site.
 ///
-/// Shared by `eval` and `eval-report` (single source, so the two commands can
-/// never derive the sibling path differently).
+/// A thin delegate to [`blendtutor_core::scaffold::eval_sibling_path`] — the
+/// single source of the convention, which the `new` scaffolding also derives
+/// sibling names through. Shared by `eval`, `eval-report`, and the scaffolding,
+/// so no consumer can ever derive the sibling path differently.
 pub(crate) fn sibling_suite_path(lesson_path: &Path) -> PathBuf {
-    let file_name = lesson_path.file_name().unwrap_or_else(|| OsStr::new(""));
-    let mut suite_name = OsString::from("eval_");
-    suite_name.push(file_name);
-    lesson_path.with_file_name(suite_name)
+    blendtutor_core::scaffold::eval_sibling_path(lesson_path)
 }
 
 #[cfg(test)]

--- a/crates/cli/src/commands/new.rs
+++ b/crates/cli/src/commands/new.rs
@@ -1,11 +1,12 @@
 //! `blendtutor new lesson --lang <r|python> <id>` — add a language-appropriate
-//! lesson to the current course and register it in the manifest.
+//! lesson to the current course, scaffold its `eval_<id>.yaml` grading suite,
+//! and register the lesson in the manifest.
 //!
 //! A thin shell over [`blendtutor_core::scaffold::add_lesson`]: parse the `--lang`
 //! flag into the core [`Language`] at the boundary (§1.2, §1.3), then hand the
 //! course (the current directory) and id to core. The decision of *what* a lesson
-//! contains and *how* it is registered lives in `core` (§4.1); this command only
-//! names the target and frames the outcome.
+//! and its grading suite contain, and *how* the lesson is registered, lives in
+//! `core` (§4.1); this command only names the target and frames the outcome.
 
 use std::path::Path;
 use std::process::ExitCode;

--- a/crates/cli/src/commands/new.rs
+++ b/crates/cli/src/commands/new.rs
@@ -14,6 +14,8 @@ use std::process::ExitCode;
 use blendtutor_core::lesson::Language;
 use blendtutor_core::scaffold::add_lesson;
 
+use crate::commands::sibling_suite_path;
+
 /// Parse the `--lang` flag into a core [`Language`], rejecting any other value at
 /// the CLI boundary (§1.3) so an unknown language never travels downstream as
 /// data. The accepted spellings are the lowercase wire forms `r` and `python`,
@@ -35,6 +37,11 @@ pub fn parse_language(value: &str) -> Result<Language, String> {
 /// never half-reports success.
 pub fn run(language: Language, id: &str) -> anyhow::Result<ExitCode> {
     let path = add_lesson(Path::new("."), language, id)?;
-    println!("Added {id} lesson at {}", path.display());
+    let eval_path = sibling_suite_path(&path);
+    println!(
+        "Added {id} lesson at {} + eval sibling at {}",
+        path.display(),
+        eval_path.display()
+    );
     Ok(ExitCode::SUCCESS)
 }

--- a/crates/cli/tests/new.rs
+++ b/crates/cli/tests/new.rs
@@ -185,6 +185,31 @@ fn new_scaffolds_a_sibling_eval_suite() {
 }
 
 #[test]
+fn new_stdout_names_the_eval_sibling() {
+    // Discoverability: the success line names BOTH scaffolded files, so the
+    // author sees the grading suite that was written next to the lesson
+    // without having to `ls lessons/`. The sibling name is derived through
+    // the one `eval_` convention, not a test-local literal.
+    let course = fresh_init_course();
+
+    let output = Command::cargo_bin("blendtutor")
+        .unwrap()
+        .current_dir(course.path())
+        .args(["new", "lesson", "--lang", "python", "tally"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let sibling =
+        blendtutor_core::scaffold::eval_sibling_path(std::path::Path::new("lessons/tally.yaml"));
+    assert!(
+        stdout.contains(sibling.to_string_lossy().as_ref()),
+        "success stdout should name the eval sibling {sibling:?}; got {stdout:?}"
+    );
+}
+
+#[test]
 fn new_lesson_refuses_a_duplicate_id_without_clobbering() {
     let course = fresh_init_course();
 

--- a/crates/cli/tests/new.rs
+++ b/crates/cli/tests/new.rs
@@ -139,6 +139,52 @@ fn new_lesson_r_creates_a_lesson_that_validates_and_lists() {
 }
 
 #[test]
+fn new_scaffolds_a_sibling_eval_suite() {
+    // Scaffolding parity (AC-6 F1): `new lesson` writes the lesson AND its
+    // `eval_`-prefixed sibling suite, so the scaffolded pair is immediately
+    // scoreable with `blendtutor eval lessons/<id>.yaml` — the sibling name
+    // derived through the one `eval_` convention `eval` itself resolves by.
+    let course = fresh_init_course();
+
+    Command::cargo_bin("blendtutor")
+        .unwrap()
+        .current_dir(course.path())
+        .args(["new", "lesson", "--lang", "python", "tally"])
+        .assert()
+        .success();
+
+    let lesson_path = course.path().join("lessons").join("tally.yaml");
+    let eval_path = course.path().join("lessons").join("eval_tally.yaml");
+    assert!(
+        lesson_path.is_file(),
+        "new lesson should write lessons/tally.yaml; missing at {lesson_path:?}"
+    );
+    assert!(
+        eval_path.is_file(),
+        "new lesson should write the eval sibling lessons/eval_tally.yaml; missing at {eval_path:?}"
+    );
+
+    // No-clobber (AC-6 F2): a hand-edited sibling is never overwritten. Edit
+    // the scaffolded suite, then re-run `new lesson` on the same id — the
+    // duplicate refusal fires, and the edited sibling's bytes survive verbatim.
+    let edited = "cases:\n  - submission: 'print(1)'\n    expected: incorrect\n";
+    std::fs::write(&eval_path, edited).unwrap();
+
+    Command::cargo_bin("blendtutor")
+        .unwrap()
+        .current_dir(course.path())
+        .args(["new", "lesson", "--lang", "python", "tally"])
+        .assert()
+        .failure();
+
+    assert_eq!(
+        std::fs::read_to_string(&eval_path).unwrap(),
+        edited,
+        "a refused duplicate must not clobber the hand-edited eval sibling"
+    );
+}
+
+#[test]
 fn new_lesson_refuses_a_duplicate_id_without_clobbering() {
     let course = fresh_init_course();
 

--- a/crates/core/src/scaffold.rs
+++ b/crates/core/src/scaffold.rs
@@ -733,6 +733,119 @@ mod tests {
     }
 
     #[test]
+    fn eval_template_produces_a_valid_python_eval_suite() {
+        // The pure eval emitter (§2.1) returns a one-case suite the production
+        // parser accepts, so a scaffolded sibling is scoreable by `eval` as-is.
+        let yaml = eval_template(Language::Python, "greet");
+        let suite = parse_eval_suite(&yaml).expect("the generated python eval suite must parse");
+        assert_eq!(
+            suite.cases.len(),
+            1,
+            "the starter suite is minimal: one case"
+        );
+        assert_eq!(
+            suite.cases[0].expected,
+            crate::eval::ExpectedVerdict::Correct,
+            "the starter case expects a correct verdict"
+        );
+    }
+
+    #[test]
+    fn eval_template_produces_a_valid_r_eval_suite() {
+        // The twin: the same emitter yields a valid R suite, so language drives
+        // the submission snippet rather than a hardcoded default.
+        let yaml = eval_template(Language::R, "loops");
+        let suite = parse_eval_suite(&yaml).expect("the generated r eval suite must parse");
+        assert_eq!(
+            suite.cases.len(),
+            1,
+            "the starter suite is minimal: one case"
+        );
+    }
+
+    #[test]
+    fn eval_sibling_path_prefixes_the_lesson_file_name_with_eval() {
+        // The pure sibling derivation (§2.3), pinned at the same three shapes
+        // `cli`'s `sibling_suite_path` unit tests pin — the two must never
+        // diverge, because `eval` resolves the suite by this exact convention.
+        assert_eq!(
+            eval_sibling_path(Path::new("lessons/tally.yaml")),
+            PathBuf::from("lessons/eval_tally.yaml")
+        );
+        assert_eq!(
+            eval_sibling_path(Path::new("lesson_hello.yaml")),
+            PathBuf::from("eval_lesson_hello.yaml")
+        );
+        assert_eq!(
+            eval_sibling_path(Path::new("/")),
+            PathBuf::from("/eval_"),
+            "a degenerate path yields the prefix alone, so a later read fails \
+             with a path-named error"
+        );
+    }
+
+    #[test]
+    fn add_lesson_writes_the_eval_sibling_next_to_the_lesson() {
+        // Scaffolding parity: one `add_lesson` call lands BOTH the lesson and
+        // its `eval_`-prefixed sibling under lessons/, the sibling parses with
+        // the production eval parser, and the manifest registers only the
+        // lesson (the sibling is a derived path, never manifest state).
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_course(dir.path()).unwrap();
+
+        add_lesson(dir.path(), Language::Python, "greet").expect("adding a fresh lesson succeeds");
+
+        let eval_path = dir.path().join(LESSONS_DIR).join("eval_greet.yaml");
+        let suite_yaml = std::fs::read_to_string(&eval_path)
+            .unwrap_or_else(|e| panic!("the eval sibling should be written at {eval_path:?}: {e}"));
+        let suite = parse_eval_suite(&suite_yaml)
+            .expect("the scaffolded eval sibling must satisfy the eval schema");
+        assert_eq!(
+            suite.cases.len(),
+            1,
+            "the starter suite is minimal: one case"
+        );
+
+        let manifest =
+            Manifest::parse(&std::fs::read_to_string(dir.path().join(MANIFEST_FILENAME)).unwrap())
+                .expect("the manifest still parses after registration");
+        assert_eq!(
+            manifest.lessons.len(),
+            2,
+            "starter + greet; the eval sibling is not registered"
+        );
+    }
+
+    #[test]
+    fn add_lesson_refuses_when_the_eval_sibling_already_exists_without_clobbering_it() {
+        // No-clobber covers the sibling too (§1.3.1): a pre-existing (e.g.
+        // hand-authored) eval_<id>.yaml is refused via the atomic create-new
+        // write, never overwritten — and the refusal leaves the user's bytes
+        // exactly as they were.
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_course(dir.path()).unwrap();
+        std::fs::create_dir_all(dir.path().join(LESSONS_DIR)).unwrap();
+        let hand_edited = "cases:\n  - submission: '1'\n    expected: incorrect\n";
+        std::fs::write(
+            dir.path().join(LESSONS_DIR).join("eval_greet.yaml"),
+            hand_edited,
+        )
+        .unwrap();
+
+        let err = add_lesson(dir.path(), Language::Python, "greet")
+            .expect_err("a taken eval sibling must be refused");
+        assert!(
+            matches!(err, AddLessonError::AlreadyExists(_)),
+            "an existing eval sibling is an AlreadyExists refusal, got {err:?}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join(LESSONS_DIR).join("eval_greet.yaml")).unwrap(),
+            hand_edited,
+            "the pre-existing eval sibling's bytes must be unchanged"
+        );
+    }
+
+    #[test]
     fn add_lesson_refuses_a_duplicate_without_clobbering_or_double_registering() {
         // No-clobber (§1.3.1): a second add of the same id is refused before any
         // write, so the original lesson's bytes and the manifest are both

--- a/crates/core/src/scaffold.rs
+++ b/crates/core/src/scaffold.rs
@@ -6,11 +6,12 @@
 //! no filesystem, §2.3), and [`scaffold_course`] — the single effectful step
 //! that refuses a non-empty target before any write (§1.3.1) then writes that
 //! plan into it. It also grows an existing course one lesson at a time: the pure
-//! [`lesson_template`] selects a language-appropriate starter (§2.1) and the
-//! effectful [`add_lesson`] writes it and registers it in the manifest. This
-//! module owns *what a course's content is*; it does not parse CLI flags or decide
-//! where the course lives (§4.1). The templates are data the writer consumes, so
-//! changing a template never changes the writer (§3.2).
+//! [`lesson_template`] selects a language-appropriate starter (§2.1), the pure
+//! [`eval_template`] emits the lesson's `eval_`-prefixed grading suite, and the
+//! effectful [`add_lesson`] writes the pair and registers the lesson in the
+//! manifest. This module owns *what a course's content is*; it does not parse
+//! CLI flags or decide where the course lives (§4.1). The templates are data the
+//! writer consumes, so changing a template never changes the writer (§3.2).
 
 use std::error::Error;
 use std::fmt;
@@ -247,6 +248,59 @@ pub fn lesson_template(language: Language, id: &str) -> String {
     )
 }
 
+/// The `eval_` prefix of the sibling-suite naming convention: a lesson
+/// `lessons/foo.yaml` pairs with the suite `lessons/eval_foo.yaml`. The single
+/// source of the convention — the scaffolding derives the sibling name through
+/// [`eval_sibling_path`], and `cli`'s `sibling_suite_path` (which `eval` and
+/// `eval-report` resolve suites by) delegates to the same function, so the two
+/// ends of the convention can never drift apart.
+pub const EVAL_SIBLING_PREFIX: &str = "eval_";
+
+/// The eval-suite sibling of `lesson_path`: the same file name prefixed with
+/// [`EVAL_SIBLING_PREFIX`], in the same directory.
+///
+/// Pure (§2.1): a path-to-path derivation with no filesystem access. This is
+/// THE convention — `new` scaffolds the sibling here, `eval` and `eval-report`
+/// discover it through `cli`'s delegating `sibling_suite_path` — so a suite
+/// authored (or scaffolded) next to its lesson is found by every consumer
+/// without configuration. A path with no file name (a bare root) yields the
+/// prefix alone, so a subsequent read fails with a path-named error rather
+/// than silently scoring nothing.
+pub fn eval_sibling_path(lesson_path: &Path) -> PathBuf {
+    let file_name = lesson_path.file_name().unwrap_or_default();
+    let mut suite_name = std::ffi::OsString::from(EVAL_SIBLING_PREFIX);
+    suite_name.push(file_name);
+    lesson_path.with_file_name(suite_name)
+}
+
+/// Render a starter eval suite for `language` under the lesson slug `id`.
+///
+/// Pure (§2.1): the [`lesson_template`] twin for grading — it picks the
+/// language-appropriate hello-world submission and frames a minimal one-case
+/// suite (a `correct` verdict) as data with no filesystem access, so the result
+/// is asserted directly against the production eval parser. One case, not two:
+/// the scaffold's job is a parseable starting point the instructor edits, and
+/// the starter course's committed suite (with its correct *and* incorrect
+/// cases) remains the fuller example. The caller is responsible for `id` being
+/// a safe slug; [`add_lesson`] guards it.
+pub fn eval_template(language: Language, id: &str) -> String {
+    let submission = match language {
+        Language::R => r#"cat("hello\n")"#,
+        Language::Python => r#"print("hello")"#,
+    };
+    format!(
+        "# The eval suite scaffolded by `blendtutor new lesson` for\n\
+         # lessons/{id}.yaml — this file's `eval_`-prefixed sibling. Each case\n\
+         # pairs a sample submission with the verdict you expect a good grader\n\
+         # to return (correct or incorrect). Edit it, then score it with\n\
+         # `blendtutor eval lessons/{id}.yaml`.\n\
+         cases:\n\
+         \x20 - submission: |-\n\
+         \x20     {submission}\n\
+         \x20   expected: correct\n"
+    )
+}
+
 /// Why a lesson could not be added to a course.
 ///
 /// The three refusals are kept distinct from a genuine write failure so the cli
@@ -267,8 +321,9 @@ pub enum AddLessonError {
     /// rather than leaving an orphan lesson in a non-course directory. Carries the
     /// directory. (Run `blendtutor init` first, or `cd` into a course.)
     NotACourse(PathBuf),
-    /// A lesson already exists at the target path, so the command refuses to
-    /// overwrite it (no clobber), before any write. Carries the course-relative
+    /// A file already exists at the target path — the lesson itself, or its
+    /// `eval_`-prefixed sibling suite — so the command refuses to overwrite it
+    /// (no clobber), before any write to that path. Carries the course-relative
     /// path that is already taken.
     AlreadyExists(PathBuf),
     /// A filesystem operation failed while writing the lesson file or registering
@@ -291,7 +346,7 @@ impl fmt::Display for AddLessonError {
             ),
             AddLessonError::AlreadyExists(path) => write!(
                 f,
-                "a lesson already exists at {path:?}; new lesson refuses to \
+                "a file already exists at {path:?}; new lesson refuses to \
                  overwrite it — choose a different id",
             ),
             AddLessonError::Write(e) => write!(f, "could not write the new lesson: {e}"),
@@ -325,34 +380,51 @@ fn is_valid_slug(id: &str) -> bool {
 }
 
 /// Add a `language` lesson `id` to the course rooted at `dir`: write
-/// `lessons/<id>.yaml` from [`lesson_template`] and register it in the manifest.
+/// `lessons/<id>.yaml` from [`lesson_template`] and its `eval_`-prefixed
+/// sibling suite from [`eval_template`], then register the lesson in the
+/// manifest.
 ///
 /// The effectful shell (§2.2) over the pure template selection. Three guards fire
 /// before any write (§1.3.1): an unsafe slug is refused as
 /// [`AddLessonError::InvalidId`]; a directory with no `blendtutor.toml` is refused
 /// as [`AddLessonError::NotACourse`] — its manifest is *opened* up front, so a
 /// non-course directory is never left with an orphan lesson; and an id whose
-/// lesson file already exists is refused as [`AddLessonError::AlreadyExists`], the
-/// create-new write making that check atomic so a duplicate never clobbers the
-/// existing lesson nor appends a second manifest entry. On success the lesson file
-/// is written, a `[[lessons]]` entry appended to `blendtutor.toml`, and the
-/// course-relative lesson path returned.
+/// lesson file — or whose eval sibling — already exists is refused as
+/// [`AddLessonError::AlreadyExists`], the create-new write making that check
+/// atomic so a duplicate never clobbers the existing lesson, a hand-authored
+/// sibling suite, nor appends a second manifest entry. On success the lesson file
+/// and its sibling are written, a `[[lessons]]` entry appended to
+/// `blendtutor.toml`, and the course-relative lesson path returned. The sibling
+/// is deliberately *not* registered in the manifest: it is a derived path
+/// ([`eval_sibling_path`]), so it can never drift from the lesson it grades.
 ///
 /// The manifest is opened first (the not-a-course guard) but its entry is appended
-/// last, after the lesson file is written. The only residual non-atomic window is
-/// a rare append failure after a good write, which leaves an orphan lesson `list`
-/// (manifest-driven) simply omits — a valid, recoverable state. Registering first
-/// would be worse: a `list` row pointing at a file that was never written.
+/// last, after the files are written. Two residual non-atomic windows remain, each
+/// leaving a valid, recoverable state: a rare append failure after good writes
+/// leaves an orphan lesson `list` (manifest-driven) simply omits; and a
+/// pre-existing eval sibling refuses *after* the lesson file is written, leaving
+/// an unregistered lesson a re-run then refuses on — recoverable by deleting the
+/// scaffolded lesson or adopting it. Registering first would be worse: a `list`
+/// row pointing at a file that was never written.
 pub fn add_lesson(dir: &Path, language: Language, id: &str) -> Result<PathBuf, AddLessonError> {
     if !is_valid_slug(id) {
         return Err(AddLessonError::InvalidId(id.to_string()));
     }
     let mut manifest = open_manifest_for_append(dir)?;
     let rel_path = PathBuf::from(LESSONS_DIR).join(format!("{id}.yaml"));
+    let eval_rel_path = eval_sibling_path(&rel_path);
     std::fs::create_dir_all(dir.join(LESSONS_DIR)).map_err(AddLessonError::Write)?;
-    write_without_clobber(&dir.join(&rel_path), &lesson_template(language, id)).map_err(
+    write_without_clobber(&dir.join(&rel_path), &lesson_template(language.clone(), id)).map_err(
         |e| match e.kind() {
             std::io::ErrorKind::AlreadyExists => AddLessonError::AlreadyExists(rel_path.clone()),
+            _ => AddLessonError::Write(e),
+        },
+    )?;
+    write_without_clobber(&dir.join(&eval_rel_path), &eval_template(language, id)).map_err(
+        |e| match e.kind() {
+            std::io::ErrorKind::AlreadyExists => {
+                AddLessonError::AlreadyExists(eval_rel_path.clone())
+            }
             _ => AddLessonError::Write(e),
         },
     )?;

--- a/docs/agent-notes/eval.md
+++ b/docs/agent-notes/eval.md
@@ -39,6 +39,10 @@ ADR-0007 for the verdict-representation decision.
   top-level R working dir) was unanchored, so it also ignored Rust eval fixtures
   under `crates/*/tests/fixtures/evals/`. Anchored to `/evals/` — fixtures track,
   the R dir stays ignored. Watch for this if adding eval fixtures elsewhere.
+  (2026-09-08, #228: the R working dir and its scripts are retired — the
+  `/evals/` rule was removed from `.gitignore` and the untracked `evals/` tree
+  deleted; the fixture-anchoring lesson above stands for any future ignore
+  rules.)
 - 2026-06-07 (#12): Fixtures in `crates/core/tests/fixtures/evals/`:
   `eval_fireworks_vitals.yaml` (10 cases ported from
   `evals/eval_fireworks_vitals.R`, each `submission` + `expected:

--- a/docs/book/src/creating-lessons.md
+++ b/docs/book/src/creating-lessons.md
@@ -81,7 +81,7 @@ Executes the `checks`, then asks the LLM for a verdict; the exit code reflects t
 
 ## Step 7 — Write an eval suite
 
-Each lesson pairs with a sibling `eval_<name>.yaml` — create it by hand next to the lesson (`new` writes only the lesson file; `eval` discovers the suite by the sibling convention) — containing sample submissions and expected verdicts (abridged from `examples/write-less-code-r/eval_01_seed_data.yaml`):
+Each lesson pairs with a sibling `eval_<name>.yaml` — `new` scaffolds a minimal one-case starter suite next to the lesson (edit it in place; `eval` discovers the suite by the sibling convention), and the starter course's `eval_lesson_hello.yaml` shows the fuller two-case shape — containing sample submissions and expected verdicts (abridged from `examples/write-less-code-r/eval_01_seed_data.yaml`):
 
 ```yaml
 cases:

--- a/docs/book/src/whole-game.md
+++ b/docs/book/src/whole-game.md
@@ -66,7 +66,9 @@ export FIREWORKS_API_KEY=fw_...
 blendtutor eval lesson_hello.yaml
 ```
 
-The starter lesson ships two cases — a correct submission and an incorrect one.
+The starter lesson ships its `eval_lesson_hello.yaml` sibling with two cases —
+a correct submission and an incorrect one. Every lesson added with `new lesson`
+gets the same treatment: an `eval_<name>.yaml` sibling scaffolded alongside it.
 Use `--case N` for a single case, `--format json` for JSON output.
 
 ## Eval report — grade with the LLM judge

--- a/docs/evidence/228/e2e-eval-help-sibling-convention.log
+++ b/docs/evidence/228/e2e-eval-help-sibling-convention.log
@@ -1,0 +1,24 @@
+# P7: blendtutor eval --help names the eval_ sibling convention
+Run feedback-quality evals for a lesson
+
+Usage: blendtutor eval [OPTIONS] <LESSON>
+
+Arguments:
+  <LESSON>
+          Path to the lesson YAML file; its sibling `eval_<lesson>.yaml` supplies the eval cases
+
+Options:
+      --format <FORMAT>
+          Output format: `human` (default) or `json`
+
+          Possible values:
+          - human: Human-readable text (the default)
+          - json:  Stable, machine-readable JSON
+          
+          [default: human]
+
+      --case <CASE>
+          Score only the 1-based case `N` instead of the whole suite
+
+  -h, --help
+          Print help (see a summary with '-h')

--- a/docs/evidence/228/e2e-missing-sibling-negative.log
+++ b/docs/evidence/228/e2e-missing-sibling-negative.log
@@ -1,0 +1,7 @@
+# Negative arm: eval with the sibling suite absent → exit 1 naming the resolved path
+$ rm lessons/eval_tally.yaml && blendtutor eval lessons/tally.yaml
+Error: reading eval suite lessons/eval_tally.yaml
+
+Caused by:
+    No such file or directory (os error 2)
+exit=1

--- a/docs/evidence/228/e2e-new-lesson-sibling.log
+++ b/docs/evidence/228/e2e-new-lesson-sibling.log
@@ -1,8 +1,8 @@
 # E2E: blendtutor init + new lesson scaffolds lesson AND eval sibling (issue #228 F1/F2)
-$ blendtutor init /var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.wxwVJOGFGT/course
-Scaffolded a new course in /var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.wxwVJOGFGT/course
+$ blendtutor init <tmp>/course
+Scaffolded a new course in /var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/opencode/e228.go9zpe/course
 $ cd course && blendtutor new lesson --lang python tally
-Added tally lesson at lessons/tally.yaml
+Added tally lesson at lessons/tally.yaml + eval sibling at lessons/eval_tally.yaml
 $ ls lessons/
 eval_tally.yaml
 tally.yaml

--- a/docs/evidence/228/e2e-new-lesson-sibling.log
+++ b/docs/evidence/228/e2e-new-lesson-sibling.log
@@ -1,0 +1,21 @@
+# E2E: blendtutor init + new lesson scaffolds lesson AND eval sibling (issue #228 F1/F2)
+$ blendtutor init /var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.wxwVJOGFGT/course
+Scaffolded a new course in /var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/tmp.wxwVJOGFGT/course
+$ cd course && blendtutor new lesson --lang python tally
+Added tally lesson at lessons/tally.yaml
+$ ls lessons/
+eval_tally.yaml
+tally.yaml
+$ cat lessons/eval_tally.yaml
+# The eval suite scaffolded by `blendtutor new lesson` for
+# lessons/tally.yaml — this file's `eval_`-prefixed sibling. Each case
+# pairs a sample submission with the verdict you expect a good grader
+# to return (correct or incorrect). Edit it, then score it with
+# `blendtutor eval lessons/tally.yaml`.
+cases:
+  - submission: |-
+      print("hello")
+    expected: correct
+$ blendtutor new lesson --lang python tally  (re-run: no-clobber refusal)
+Error: a file already exists at "lessons/tally.yaml"; new lesson refuses to overwrite it — choose a different id
+exit=1

--- a/docs/evidence/228/prune-absence-greps.log
+++ b/docs/evidence/228/prune-absence-greps.log
@@ -1,0 +1,20 @@
+# P1/P2 prune arms (issue #228)
+$ rg 'eval_fireworks_(vitals|sequential)\.R|eval_evaluate_with_llm' crates/*/src .github/ scripts/ docs/book/src README.md   # AC scope — expect zero hits
+exit=1 (1 = zero hits, PASS)
+
+$ same pattern over crates/ — single hit is the ARCHIVAL fixture header comment, exempt per spec:
+crates/core/tests/fixtures/evals/eval_fireworks_vitals.yaml:2:# evals/eval_fireworks_vitals.R (the `eval_data` tibble, cases 1-10). Each case
+
+$ grep '^/evals/$' .gitignore   # expect no match
+exit=1 (1 = entry removed, PASS)
+
+$ rg 'uvx|smevals|SMEVALS_PIN' crates/cli/src/commands/eval.rs   # expect zero hits
+exit=1 (1 = PASS)
+
+$ rg 'smevals==0.2.0' crates/cli/src/commands/eval_report.rs   # expect the pin retained
+5://! smevals==0.2.0` package to run and build the report, and publish it under
+35:const SMEVALS_PIN: &str = "smevals==0.2.0";
+162:/// Invoke `uvx smevals==0.2.0 <args…>` and return its exit status.
+
+$ rg 'format!("eval_' crates/core/src/scaffold.rs crates/cli/src/commands/mod.rs   # no second hand-copied naming rule
+exit=1 (1 = no duplicated naming rule, PASS)

--- a/docs/evidence/228/test-suite.log
+++ b/docs/evidence/228/test-suite.log
@@ -1,0 +1,16 @@
+# Issue #228 non-regression gate — 2026-09-09T00:16Z @ c595fc9
+# cargo test -p blendtutor-cli --test new            → 4 passed
+# cargo test -p blendtutor-cli --test eval           → 7 passed
+# cargo test -p blendtutor-cli --test eval_report_cli → 10 passed
+# cargo test -p blendtutor-cli --test readme         → 2 passed
+# cargo test -p blendtutor-cli --test cli            → 2 passed
+# cargo test -p blendtutor-cli --test cutover        → 1 passed
+# cargo test -p blendtutor-core                      → 201 passed
+# bash scripts/check-model-alignment.sh              → OK (deepseek-v4-flash-0731 pinned)
+# bash scripts/tests/test_smevals_runner.sh          → 12 passed
+# python3 scripts/tests/test_judge_feedback.py       → 78 passed
+# bash scripts/tests/test_quarto_distribution.sh     → 9 passed
+# bash scripts/tests/test_demo_docs.sh               → 5 passed
+
+# cargo test -p blendtutor-core (lib result line):
+test result: ok. 201 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 159.41s


### PR DESCRIPTION
## Summary
`blendtutor new lesson` now scaffolds the lesson AND its `eval_<id>.yaml` grading suite — the eval_ sibling convention becomes first-class end to end. The sibling name derives through a single source (`core::scaffold::eval_sibling_path` + `EVAL_SIBLING_PREFIX`; cli's `sibling_suite_path` delegates), written via the existing atomic `write_without_clobber` so a hand-edited suite is never clobbered. The retired top-level R `evals/` package is pruned: `/evals/` gitignore entry removed, doc references cleaned, and the untracked `evals/` tree (3 R scripts + logs/) deleted locally with `rm -rf evals/` in the main checkout — a PR cannot delete untracked files (documented per issue #228 P1).

## Issue
Closes #228

Plan ref: `.opencode/plans/user-friendliness/plan.md` slice AC-6

## ACs implemented
- [x] F1: `new lesson --lang python tally` creates lessons/tally.yaml AND lessons/eval_tally.yaml (language-aware minimal 1-case `eval_template`; single eval_ naming convention via `eval_sibling_path`/`EVAL_SIBLING_PREFIX` — no second hand-copied `format!("eval_...")` rule, absence-grepped)
- [x] F2: sibling written via `write_without_clobber` (atomic create_new) — re-run fails AlreadyExists, hand-edited sibling byte-identical after refusal
- [x] P1: `.gitignore` /evals/ entry + anchoring comment removed; zero active references to the R scripts across crates/*/src, .github/, scripts/, docs/book/src, README.md; local `rm -rf evals/` performed
- [x] P2: eval.rs retains zero uvx|smevals|SMEVALS_PIN; eval_report.rs keeps smevals==0.2.0 pin
- [x] P3–P7 + R1: EvalSummary boundary untouched; model default pinned (check-model-alignment OK); exactly 9 subcommands; readme/quarto/smevals/judge harnesses green; docs name the eval_ sibling convention (README:40 new-lesson claim now TRUE); auto-discovery regression pins pass

## Test plan
- [x] RED-first: `new_scaffolds_a_sibling_eval_suite` (integration, behavioral RED) + 5 scaffold.rs unit tests (eval_template parse round-trip both languages, eval_sibling_path 3-shape pin, add_lesson sibling + sibling no-clobber); negative control confirmed (bogus `expected:` token fails 3 tests)
- [x] Full gate green: new 4, eval 7, eval_report_cli 10, readme 2, cli 2, cutover 1, core 201, model-alignment OK, smevals-runner 12, judge-feedback 78, quarto-dist 9, demo-docs 5
- [x] E2E evidence: docs/evidence/228/ (real CLI init+new+ls+cat, eval --help sibling convention, missing-sibling negative arm, prune absence greps, gate log)
- [x] PR review findings resolved (pending first review)

## Notes
- The spec probe greps `crates/` wholesale; its one hit is the archival provenance comment in `crates/core/tests/fixtures/evals/eval_fireworks_vitals.yaml:2` — exempt per the spec's own P1 prose ("fixture header comments is archival and exempt"); AC scope (crates/*/src) is zero-hit. Documented in docs/evidence/228/prune-absence-greps.log.
- Local `rm -rf evals/` was performed in the main checkout (/Users/carbonite/Documents/coding/portfolio/blendtutor) — untracked files cannot be deleted by a PR.

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested (no-clobber re-run, pre-existing sibling, missing-sibling eval arm)
- [x] Verification medium satisfied (code + shell grep arms + harness scripts)
- [x] Design intent respected (derived path never in manifest; one pure emitter; single naming source; no command-surface change)
- [x] No scope creep