### PR TITLE
[feature] eval --write-report: durable smevals-free eval-report.json at course root

### DIFF
--- a/.opencode/plans/user-friendliness/AC-8.md
+++ b/.opencode/plans/user-friendliness/AC-8.md
@@ -2,7 +2,7 @@
 ac: 8
 depends_on: AC-6, AC-7
 risk: medium
-status: spec
+status: complete
 ---
 
 **Verdicts (in-spec resolutions):**
@@ -74,13 +74,20 @@ status: spec
 **Disagreement level: moderate** (divergence on overwrite policy + shared const + refusal-arm enumeration; converged on surface, shape, fixture, verification medium). All needs-clarification resolved in-spec.
 
 ### Progress
-- (none yet)
+- [x] RED suite committed (5041599): 7 tests in crates/cli/tests/eval.rs — positive items 1-6 (incl. `--format json` byte-identity), N1-N4, build round-trip, `eval --help` flag pin. All failed on the absent flag (clap exit 2 / missing help entry).
+- [x] Implementation committed (0592438): `#[arg(long)] write_report: bool` on Eval variant + dispatch; canonicalize-before-course_root_for; refusals precede scoring; `write_report_artifact` (.tmp + rename, Windows remove-then-rename retry, no .tmp leftover on failure); confirmation on stderr (keeps `--format json` stdout byte-pure); doc comment names the side effect + filename.
+- [x] Docs committed (dc8a170): whole-game.md eval region, creating-lessons.md Step 8, README loop one-liner.
+- [x] Evidence: docs/evidence/230/ (test-suite.log 16/16 + real-binary cli-transcript.log covering positive, overwrite, build round-trip 67%, N1, N3).
+- [x] Full workspace `cargo test` green; clippy clean; 9-subcommand surface untouched (cli.rs pin unchanged).
 
 ### Decision Log
-- (none yet)
+- Confirmation + overwrite warning go to **stderr**, not stdout: the spec allows either, but `--format json --write-report` must keep stdout a single pure JSON document for the byte-identity pin (item 5) — a stdout confirmation would break it. Matches the repo's "stdout is the data stream" pattern (embed-key WARNING precedent).
+- Atomic write = rename fast-path with remove-then-rename **retry** on failure (Windows target-exists), not unconditional remove-first: keeps the unix rename atomic, satisfies the Windows caveat, and the failure path removes the `.tmp` so no leftover survives.
+- N4 `.tmp`-leftover guarantee is enforced by cleanup-on-rename-failure plus the fact that the read-only-dir failure hits at `fs::write(tmp)` (nothing created yet).
 
 ### Surprises & Discoveries
-- (none yet)
+- macOS tempdir paths are symlinked (`/var/folders/...` → `/private/var/folders/...`): the binary canonicalizes the lesson before walking ancestors, so paths it prints are `/private/...` while a naive test assertion on the raw tempdir path would mismatch. Fix: the test helper canonicalizes the course dir before returning it, so asserted and printed paths agree.
+- The `eval --help` flag pin (item 7) does not match the `eval_write_report` test filter, so it must be run under its own name (`eval_help_lists_write_report_flag`) — the spec's probe list filters by `eval_write_report*` and would silently skip it.
 
 ### Idempotence & Recovery
 - Safe retry: re-run builder on same branch; tests are idempotent

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ blendtutor new lesson --lang r greet              # add lessons/greet.yaml + eva
 blendtutor validate lessons/greet.yaml            # check a lesson (nonzero exit drops into CI)
 blendtutor run lessons/greet.yaml --code sub.R    # execute the submission, get an LLM verdict
 blendtutor eval lessons/greet.yaml                # score grading-prompt accuracy on the eval cases
+blendtutor eval lessons/greet.yaml --write-report # persist eval-report.json at the course root for build
 blendtutor eval-report lessons/greet.yaml         # LLM-judged report → docs/evals/<lesson>/
 blendtutor build my-course --target webr -o site  # static browser site (--target webr|pyodide)
 ```

--- a/crates/cli/src/commands/eval.rs
+++ b/crates/cli/src/commands/eval.rs
@@ -3,20 +3,31 @@
 //! A thin orchestration shell (§4.1, §5.1): it loads the lesson and its sibling
 //! `eval_<lesson>.yaml` suite, drives the pure-cored [`run_eval`] on a runtime —
 //! the *same* pipeline `run` uses, so the feedback scored is the feedback
-//! shipped (§3.2) — and renders the report through the [`output`] seam. No
-//! scoring, execution, or HTTP logic lives here; those are `core`'s.
+//! shipped (§3.2) — and renders the report through the [`output`] seam. With
+//! `--write-report` it additionally persists the full-shape report as
+//! `eval-report.json` at the course root — the durable artifact `build` folds
+//! into the site's eval-results page. No scoring, execution, or HTTP logic
+//! lives here; those are `core`'s.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-use anyhow::Context;
-use blendtutor_core::eval::{parse_eval_suite, run_eval};
+use anyhow::{Context, anyhow};
+use blendtutor_core::eval::{EvalReport, parse_eval_suite, run_eval};
 use blendtutor_core::lesson::read_lesson_file;
 use blendtutor_core::llm::ProviderChoice;
+use blendtutor_core::smevals_gen::course_root_for;
 
-use crate::commands::PROVIDER_URL_VAR;
-use crate::commands::sibling_suite_path;
+use crate::commands::{PROVIDER_URL_VAR, sibling_suite_path};
 use crate::output::{self, OutputFormat};
+
+/// The conventional name of the durable eval report `--write-report` writes at
+/// the course root — the same artifact `build` folds into the site's
+/// eval-results page. The consumer's copy of this name is `build.rs`'s
+/// `EVAL_REPORT_FILE` (the contract source); the duplication is deliberate —
+/// extraction would touch the frozen build/core boundary — and the build
+/// round-trip test fails on drift.
+const EVAL_REPORT_FILE: &str = "eval-report.json";
 
 /// Load the lesson and its sibling eval suite, score every case — or, with
 /// `case`, only the one 1-based case — through the run pipeline, and render the
@@ -30,13 +41,50 @@ use crate::output::{self, OutputFormat};
 /// measures feedback quality, it is not a pass/fail gate, so a low accuracy is
 /// still a successful run. The provider is driven on a current-thread runtime
 /// (the binary owns its async runtime; `core` stays a library).
+///
+/// With `write_report`, the full-shape report is additionally persisted as
+/// `eval-report.json` at the course root — the nearest `blendtutor.toml`
+/// ancestor of the lesson, found wherever the command runs from — after
+/// scoring and rendering, as the command's single extra effect. A pre-existing
+/// report is overwritten with a warning; `--case` combined with
+/// `--write-report` is refused (a single-case report would masquerade as
+/// course-level accuracy in the built site), and so is a missing course root.
+/// Both refusals precede any scoring side effect.
 pub fn run(
     lesson_path: &Path,
     format: OutputFormat,
     case: Option<usize>,
+    write_report: bool,
 ) -> anyhow::Result<ExitCode> {
-    let lesson = read_lesson_file(lesson_path)?;
-    let suite_path = sibling_suite_path(lesson_path);
+    // Canonicalize FIRST (mirrors eval_report.rs): course_root_for climbs the
+    // lesson's ancestor chain, and a relative path from a CWD outside the
+    // course would walk relative ancestors and miss the manifest.
+    let lesson_path = lesson_path
+        .canonicalize()
+        .with_context(|| format!("resolving {} to an absolute path", lesson_path.display()))?;
+
+    // Refusals precede any scoring side effect (§1.3.1): the durable artifact
+    // is opt-in, so both refusal arms are checked before the provider runs.
+    let course_root = if write_report {
+        if case.is_some() {
+            return Err(anyhow!(
+                "--case N and --write-report are incompatible: a single-case report would \
+                 render as the course-level accuracy in the built site; drop one of the flags"
+            ));
+        }
+        Some(course_root_for(&lesson_path).ok_or_else(|| {
+            anyhow!(
+                "--write-report: no blendtutor.toml course root found above {} — an eval \
+                 report is written at the course root",
+                lesson_path.display()
+            )
+        })?)
+    } else {
+        None
+    };
+
+    let lesson = read_lesson_file(&lesson_path)?;
+    let suite_path = sibling_suite_path(&lesson_path);
     let suite_yaml = std::fs::read_to_string(&suite_path)
         .with_context(|| format!("reading eval suite {}", suite_path.display()))?;
     let suite = parse_eval_suite(&suite_yaml)?;
@@ -54,5 +102,50 @@ pub fn run(
     ))?;
 
     output::emit_eval(&report, format)?;
+
+    if let Some(course_root) = course_root {
+        let written = write_report_artifact(&report, &course_root)?;
+        eprintln!("wrote eval-report.json to {}", written.display());
+    }
     Ok(ExitCode::SUCCESS)
+}
+
+/// Serialize `report` and atomically write it as `eval-report.json` at
+/// `course_root`, returning the written path.
+///
+/// The single effectful step of `--write-report` (§2.3): the bytes are exactly
+/// `serde_json::to_string(&report)` — the same serialization `--format json`
+/// stdout uses — so the file and the machine output cannot drift, and the file
+/// is always full-shape regardless of `--format` (which controls stdout only).
+/// The write is atomic in practice: the bytes land in a sibling `.tmp` file
+/// that is renamed into place, so a failed write never leaves a half-written
+/// report or a `.tmp` leftover. A pre-existing report is overwritten with a
+/// warning (re-running eval on one's own course is the common case; committed
+/// artifacts are git's concern, not exit codes').
+fn write_report_artifact(report: &EvalReport, course_root: &Path) -> anyhow::Result<PathBuf> {
+    let target = course_root.join(EVAL_REPORT_FILE);
+    if target.exists() {
+        eprintln!(
+            "WARNING: overwriting existing eval report at {}",
+            target.display()
+        );
+    }
+    let tmp = course_root.join(format!(".{EVAL_REPORT_FILE}.tmp"));
+    std::fs::write(
+        &tmp,
+        serde_json::to_string(report).expect("an EvalReport serializes to JSON infallibly"),
+    )
+    .with_context(|| format!("writing {}", tmp.display()))?;
+    let renamed = std::fs::rename(&tmp, &target).or_else(|_| {
+        // Windows: rename fails while the target exists — remove it and retry
+        // (a small non-atomic window, acceptable for a dev tool; the same
+        // remove-then-rename shape as eval_report.rs's replace_dir).
+        std::fs::remove_file(&target)?;
+        std::fs::rename(&tmp, &target)
+    });
+    if let Err(e) = renamed {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e).with_context(|| format!("writing {}", target.display()));
+    }
+    Ok(target)
 }

--- a/crates/cli/src/commands/eval.rs
+++ b/crates/cli/src/commands/eval.rs
@@ -136,12 +136,15 @@ fn write_report_artifact(report: &EvalReport, course_root: &Path) -> anyhow::Res
         serde_json::to_string(report).expect("an EvalReport serializes to JSON infallibly"),
     )
     .with_context(|| format!("writing {}", tmp.display()))?;
-    let renamed = std::fs::rename(&tmp, &target).or_else(|_| {
-        // Windows: rename fails while the target exists — remove it and retry
-        // (a small non-atomic window, acceptable for a dev tool; the same
-        // remove-then-rename shape as eval_report.rs's replace_dir).
-        std::fs::remove_file(&target)?;
-        std::fs::rename(&tmp, &target)
+    let renamed = std::fs::rename(&tmp, &target).or_else(|e| {
+        // Windows only: rename fails while target exists. Accepted-untested on
+        // unix CI (rename overwrites) — precedent: eval_report.rs replace_dir.
+        if cfg!(windows) && target.exists() {
+            std::fs::remove_file(&target)?;
+            std::fs::rename(&tmp, &target)
+        } else {
+            Err(e)
+        }
     });
     if let Err(e) = renamed {
         let _ = std::fs::remove_file(&tmp);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -78,6 +78,11 @@ enum Commands {
         /// Score only the 1-based case `N` instead of the whole suite.
         #[arg(long)]
         case: Option<usize>,
+        /// Also write the full-shape report as `eval-report.json` at the
+        /// course root (the nearest `blendtutor.toml` ancestor) — the durable
+        /// artifact `build` folds into the site's eval-results page.
+        #[arg(long)]
+        write_report: bool,
     },
     /// Generate a static smevals eval report for a lesson.
     EvalReport {
@@ -144,7 +149,8 @@ fn main() -> anyhow::Result<ExitCode> {
             lesson,
             format,
             case,
-        } => commands::eval::run(&lesson, format, case),
+            write_report,
+        } => commands::eval::run(&lesson, format, case, write_report),
         Commands::EvalReport { lesson } => commands::eval_report::run(&lesson),
         Commands::New { target } => match target {
             NewTarget::Lesson { lang, id } => commands::new::run(lang, &id),

--- a/crates/cli/tests/eval.rs
+++ b/crates/cli/tests/eval.rs
@@ -13,6 +13,9 @@
 
 mod common;
 
+use std::path::Path;
+
+use assert_cmd::Command as AssertCommand;
 use common::{blendtutor_output, mount_feedback_for, rscript_absent};
 use wiremock::MockServer;
 
@@ -20,6 +23,12 @@ use wiremock::MockServer;
 const EVAL_LESSON: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../core/tests/fixtures/eval_command/demo_lesson.yaml"
+);
+
+/// The demo lesson's sibling eval suite (three cases: alpha/beta/gamma).
+const EVAL_SUITE: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../core/tests/fixtures/eval_command/eval_demo_lesson.yaml"
 );
 
 /// Mount the three scripted verdicts that, against the suite's expected
@@ -33,15 +42,48 @@ async fn mount_three_case_provider(server: &MockServer) {
 }
 
 /// Run `blendtutor eval <lesson> [extra args]` against `server`, inside
-/// `spawn_blocking` so the test runtime keeps serving the mock while the child's
+/// spawn_blocking so the test runtime keeps serving the mock while the child's
 /// requests are in flight.
 async fn eval_against(server: &MockServer, extra: &[&str]) -> std::process::Output {
+    eval_lesson_against(server, EVAL_LESSON, extra).await
+}
+
+/// Like [`eval_against`], but for an arbitrary lesson path — the
+/// `--write-report` tests point at a lesson inside a tempdir course.
+async fn eval_lesson_against(
+    server: &MockServer,
+    lesson: &str,
+    extra: &[&str],
+) -> std::process::Output {
     let uri = server.uri();
-    let mut args = vec!["eval".to_string(), EVAL_LESSON.to_string()];
+    let mut args = vec!["eval".to_string(), lesson.to_string()];
     args.extend(extra.iter().map(|s| s.to_string()));
     tokio::task::spawn_blocking(move || blendtutor_output(args, uri))
         .await
         .expect("the blocking command task should join")
+}
+
+/// A tempdir course for the `--write-report` tests: a 3-line `blendtutor.toml`
+/// manifest plus the demo lesson and its sibling suite copied from the
+/// `eval_command` fixtures. `course_root_for` only checks manifest existence,
+/// so the minimal marker is a valid course. The course dir is canonicalized so
+/// paths the binary prints (which resolve symlinked tempdirs) match the paths
+/// the test asserts on. Returns the tempdir (the caller keeps it alive), the
+/// absolute lesson path, and the course root.
+fn write_report_course() -> (tempfile::TempDir, String, std::path::PathBuf) {
+    let tmp = tempfile::tempdir().expect("a tempdir for the course");
+    let course = tmp.path().join("course");
+    std::fs::create_dir_all(&course).expect("create the course dir");
+    std::fs::write(
+        course.join("blendtutor.toml"),
+        "[[lessons]]\nid = \"eval-demo\"\npath = \"demo_lesson.yaml\"\n",
+    )
+    .expect("write the manifest marker");
+    std::fs::copy(EVAL_LESSON, course.join("demo_lesson.yaml")).expect("copy the lesson");
+    std::fs::copy(EVAL_SUITE, course.join("eval_demo_lesson.yaml")).expect("copy the suite");
+    let course = course.canonicalize().expect("canonicalize the course dir");
+    let lesson = course.join("demo_lesson.yaml");
+    (tmp, lesson.to_string_lossy().into_owned(), course)
 }
 
 /// AC1 — `eval` scores each case match/mismatch and reports the aggregate
@@ -402,5 +444,357 @@ async fn eval_case_non_numeric_is_a_parse_error_exit_2() {
         requests.len(),
         0,
         "a parse failure makes no provider request"
+    );
+}
+
+// ── AC-8: `--write-report` — durable eval-report.json at the course root ──
+
+/// AC-8 positive — `eval <lesson> --write-report` (default human format, run
+/// from a CWD that is NOT the course root) exits 0, keeps the human accuracy
+/// render unchanged, and writes the full-shape report at the course root —
+/// never at the CWD — with a confirmation naming the artifact.
+///
+/// A second run with `--format json --write-report` pins the single
+/// serialization path: the file bytes must equal the JSON stdout modulo the
+/// trailing newline `writeln` adds, so no second serializer can drift.
+#[tokio::test]
+async fn eval_write_report_writes_full_shape_report_at_course_root() {
+    if rscript_absent() {
+        return;
+    }
+    let server = MockServer::start().await;
+    mount_three_case_provider(&server).await;
+    let (_tmp, lesson, course) = write_report_course();
+
+    let output = eval_lesson_against(&server, &lesson, &["--write-report"]).await;
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "--write-report should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    assert!(
+        stdout.contains("2/3"),
+        "--write-report must not change the human accuracy render, got: {stdout:?}"
+    );
+
+    let report_path = course.join("eval-report.json");
+    assert!(
+        report_path.exists(),
+        "the report must be written at the course root"
+    );
+    assert!(
+        !Path::new("eval-report.json").exists(),
+        "the report must NOT be written at the CWD"
+    );
+
+    let file = std::fs::read_to_string(&report_path).expect("read the written report");
+    let doc: serde_json::Value =
+        serde_json::from_str(&file).expect("the report should be one JSON document");
+    let cases = doc["cases"].as_array().expect("cases should be an array");
+    assert_eq!(
+        cases.len(),
+        3,
+        "the full suite's case count, not a partial one"
+    );
+    let accuracy = doc["accuracy"]
+        .as_f64()
+        .expect("accuracy should be a JSON number, not a string");
+    assert!(
+        (accuracy - 2.0 / 3.0).abs() < 1e-12,
+        "accuracy should be 2/3, got {accuracy}"
+    );
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("eval-report.json"),
+        "the confirmation must name the artifact, got: {combined:?}"
+    );
+
+    // Single serialization path: `--format json` stdout == file bytes (+ the
+    // newline `writeln` appends). A second serializer would drift here.
+    let json_output =
+        eval_lesson_against(&server, &lesson, &["--format", "json", "--write-report"]).await;
+    assert_eq!(
+        json_output.status.code(),
+        Some(0),
+        "the json-format run should succeed; stderr: {}",
+        String::from_utf8_lossy(&json_output.stderr)
+    );
+    let file_bytes = std::fs::read(&report_path).expect("read the re-written report");
+    assert_eq!(
+        Some(file_bytes.as_slice()),
+        json_output.stdout.strip_suffix(b"\n"),
+        "the file must be byte-identical to the --format json stdout (modulo the trailing newline)"
+    );
+}
+
+/// AC-8 N1 — a lesson with no `blendtutor.toml` ancestor refuses (exit 1)
+/// naming the missing course root, writes no file anywhere, and makes no
+/// provider request: the refusal precedes any scoring side effect.
+#[tokio::test]
+async fn eval_write_report_no_course_root() {
+    if rscript_absent() {
+        return;
+    }
+    let server = MockServer::start().await;
+    mount_three_case_provider(&server).await;
+    // A plain dir with the lesson + suite but NO manifest marker.
+    let tmp = tempfile::tempdir().expect("a tempdir for the manifest-less dir");
+    let dir = tmp.path().join("no-course");
+    std::fs::create_dir_all(&dir).expect("create the dir");
+    std::fs::copy(EVAL_LESSON, dir.join("demo_lesson.yaml")).expect("copy the lesson");
+    std::fs::copy(EVAL_SUITE, dir.join("eval_demo_lesson.yaml")).expect("copy the suite");
+    let lesson = dir
+        .canonicalize()
+        .expect("canonicalize the dir")
+        .join("demo_lesson.yaml")
+        .to_string_lossy()
+        .into_owned();
+
+    let output = eval_lesson_against(&server, &lesson, &["--write-report"]).await;
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "no course root must refuse; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        stderr.contains("blendtutor.toml"),
+        "stderr must name the missing manifest, got: {stderr:?}"
+    );
+    assert!(
+        !dir.join("eval-report.json").exists(),
+        "no report may be written at the lesson's dir"
+    );
+    assert!(
+        !Path::new("eval-report.json").exists(),
+        "no report may be written at the CWD"
+    );
+    let requests = server
+        .received_requests()
+        .await
+        .expect("the mock server should record requests");
+    assert_eq!(
+        requests.len(),
+        0,
+        "the refusal must precede any scoring side effect"
+    );
+}
+
+/// AC-8 N2 — a pre-existing report is overwritten with a warning, not a
+/// refusal: exit 0, stderr says "overwrit…" and names the path, and the file
+/// is replaced with the new full-shape content.
+#[tokio::test]
+async fn eval_write_report_overwrite_warns() {
+    if rscript_absent() {
+        return;
+    }
+    let server = MockServer::start().await;
+    mount_three_case_provider(&server).await;
+    let (_tmp, lesson, course) = write_report_course();
+    std::fs::write(course.join("eval-report.json"), r#"{"sentinel":true}"#)
+        .expect("pre-create the sentinel report");
+
+    let output = eval_lesson_against(&server, &lesson, &["--write-report"]).await;
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "overwriting one's own course report proceeds; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        stderr.contains("overwrit"),
+        "the warning must say the file is overwritten, got: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("eval-report.json"),
+        "the warning must name the overwritten path, got: {stderr:?}"
+    );
+    let doc: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(course.join("eval-report.json")).expect("read the replaced file"),
+    )
+    .expect("the replaced file should be one JSON document");
+    assert!(
+        doc["sentinel"].is_null(),
+        "the sentinel content must be gone, got: {doc}"
+    );
+    let accuracy = doc["accuracy"]
+        .as_f64()
+        .expect("the replacement carries a numeric accuracy");
+    assert!(
+        (accuracy - 2.0 / 3.0).abs() < 1e-12,
+        "the replacement is the new full-shape report, accuracy 2/3, got {accuracy}"
+    );
+}
+
+/// AC-8 N3 — `--case N --write-report` refuses (exit 1) naming both flags and
+/// writes nothing: a single-case report would render as the course-level
+/// accuracy in the built site — a misleading durable artifact.
+#[tokio::test]
+async fn eval_write_report_partial_refused() {
+    if rscript_absent() {
+        return;
+    }
+    let server = MockServer::start().await;
+    mount_three_case_provider(&server).await;
+    let (_tmp, lesson, course) = write_report_course();
+
+    let output = eval_lesson_against(&server, &lesson, &["--case", "1", "--write-report"]).await;
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "a partial report must be refused; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        stderr.contains("--case"),
+        "the error must name --case, got: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("--write-report"),
+        "the error must name --write-report, got: {stderr:?}"
+    );
+    assert!(
+        !course.join("eval-report.json").exists(),
+        "a refused partial report must write no file"
+    );
+}
+
+/// AC-8 N4 — an unwritable course root propagates the write failure (exit 1),
+/// names the error, and leaves no `.tmp` leftover. Skipped when the process
+/// can write despite `0o555` (root), where chmod is ineffective.
+#[cfg(unix)]
+#[tokio::test]
+async fn eval_write_report_failure_propagates() {
+    if rscript_absent() {
+        return;
+    }
+    let server = MockServer::start().await;
+    mount_three_case_provider(&server).await;
+    let (_tmp, lesson, course) = write_report_course();
+
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(&course, std::fs::Permissions::from_mode(0o555))
+        .expect("chmod the course dir read-only");
+    // Root ignores mode bits — probe before asserting, and skip when the
+    // write would succeed anyway.
+    let probe = course.join(".perm-probe");
+    if std::fs::write(&probe, b"x").is_ok() {
+        let _ = std::fs::remove_file(&probe);
+        let _ = std::fs::set_permissions(&course, std::fs::Permissions::from_mode(0o755));
+        eprintln!("SKIP: privileged user — chmod 0o555 ineffective, skipping write-failure test");
+        return;
+    }
+
+    let output = eval_lesson_against(&server, &lesson, &["--write-report"]).await;
+
+    // Restore before the tempdir drop, which needs to delete the dir.
+    let _ = std::fs::set_permissions(&course, std::fs::Permissions::from_mode(0o755));
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "a write failure must propagate, not be swallowed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        stderr.contains("eval-report"),
+        "stderr must name the write error, got: {stderr:?}"
+    );
+    assert!(
+        !course.join("eval-report.json").exists(),
+        "no report may be written"
+    );
+    assert!(
+        !course.join(".eval-report.json.tmp").exists(),
+        "no .tmp leftover may survive the failure"
+    );
+}
+
+/// AC-8 item 8 — the bidirectional contract: the file `--write-report` writes
+/// is exactly what `build` consumes. Build the same tempdir course and assert
+/// the eval-results page shows the accuracy derived from the written file
+/// (a wrong-schema write that eval exits 0 on would fail the build here).
+#[tokio::test]
+async fn eval_write_report_build_roundtrip() {
+    if rscript_absent() {
+        return;
+    }
+    let server = MockServer::start().await;
+    mount_three_case_provider(&server).await;
+    let (tmp, lesson, course) = write_report_course();
+
+    let output = eval_lesson_against(&server, &lesson, &["--write-report"]).await;
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "--write-report should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let out = tmp.path().join("site");
+    let build_output = AssertCommand::cargo_bin("blendtutor")
+        .expect("binary `blendtutor` should be built")
+        .args(["build", "--target", "webr"])
+        .arg(&course)
+        .arg("-o")
+        .arg(&out)
+        .output()
+        .expect("running `blendtutor build` should produce output");
+    assert!(
+        build_output.status.success(),
+        "build must consume the written report; stderr: {:?}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+
+    let page = std::fs::read_to_string(out.join("eval-results.html"))
+        .expect("the built site must include an eval-results.html page");
+    // The expected figure is derived from the written report, parsed
+    // independently here — a placeholder or constant cannot pass.
+    let report: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(course.join("eval-report.json")).expect("read the written report"),
+    )
+    .expect("the written report should be one JSON document");
+    let accuracy = report["accuracy"]
+        .as_f64()
+        .expect("the written report carries a numeric accuracy");
+    let pct = (accuracy * 100.0).round() as i64;
+    assert!(
+        page.contains(&format!("{pct}%")),
+        "eval-results.html must show the written report's accuracy ({pct}%); page={page}"
+    );
+}
+
+/// AC-8 item 7 — `eval --help` advertises `--write-report`. The flag lives on
+/// the existing Eval variant; the 9-subcommand surface stays pinned in cli.rs.
+#[test]
+fn eval_help_lists_write_report_flag() {
+    let output = AssertCommand::cargo_bin("blendtutor")
+        .expect("binary `blendtutor` should be built")
+        .args(["eval", "--help"])
+        .output()
+        .expect("running `blendtutor eval --help` should succeed");
+    assert!(
+        output.status.success(),
+        "`eval --help` should exit 0, got {:?}",
+        output.status
+    );
+    let stdout = String::from_utf8(output.stdout).expect("help output should be UTF-8");
+    assert!(
+        stdout.contains("--write-report"),
+        "`eval --help` must advertise --write-report, got:\n{stdout}"
     );
 }

--- a/docs/book/src/creating-lessons.md
+++ b/docs/book/src/creating-lessons.md
@@ -103,6 +103,8 @@ blendtutor eval lessons/seed-data.yaml
 
 Replays the eval cases through the run pipeline and reports how often the grader's verdict matches the expected label — regression-test grading accuracy before shipping. `--case N` for one case, `--format json` for structured output. Real paid calls: run against the provider your deployed site will use.
 
+To persist the score for `build` to fold into the site's eval-results page, add `--write-report`: it writes the full-shape `eval-report.json` next to the course's `blendtutor.toml` (found from the lesson's directory, wherever you run from), overwriting a previous report with a warning. `--case N` and `--write-report` are mutually exclusive — a single-case report would render as the course-level accuracy.
+
 ## Step 9 — Generate the eval report
 
 ```bash

--- a/docs/book/src/whole-game.md
+++ b/docs/book/src/whole-game.md
@@ -83,6 +83,19 @@ inspect one: blendtutor eval <lesson> --case N
 grading is shaped by the lesson's `llm_evaluation_prompt` and each exercise's reference `solution`
 ```
 
+To persist the result for `build` to fold into the site's eval-results page,
+write the report at the course root:
+
+```bash
+blendtutor eval lesson_hello.yaml --write-report
+```
+
+This writes `eval-report.json` next to the course's `blendtutor.toml` — found
+from the lesson's directory, wherever you run the command from — as the same
+full-shape JSON `--format json` prints, regardless of `--format`. Re-runs
+overwrite it with a warning. `--case N` and `--write-report` are mutually
+exclusive: a single-case report would render as the course-level accuracy.
+
 ## Eval report — grade with the LLM judge
 
 `eval-report` drives the pinned smevals runner, which grades each case with

--- a/docs/evidence/230/README.md
+++ b/docs/evidence/230/README.md
@@ -1,0 +1,22 @@
+# Evidence — issue #230: `eval --write-report`
+
+Captured after the final code state (commits 5041599 → 0592438 → dc8a170).
+
+- `test-suite.log` — `cargo test -p blendtutor-cli --test eval`: 16 passed
+  (9 pre-existing unchanged + 7 new AC-8 tests: positive items 1-6 incl. the
+  `--format json` byte-identity pin, N1 no-course-root refusal before scoring,
+  N2 overwrite warns-and-proceeds, N3 partial refused, N4 write failure
+  propagates with no `.tmp` leftover, build round-trip item 8, `eval --help`
+  advertises the flag item 7).
+- `cli-transcript.log` — real-binary E2E transcript against a local mock
+  provider (OpenAI chat-completions envelope on 127.0.0.1:8765): `eval --help`
+  grep; positive run from a non-course-root CWD (exit 0, human render
+  unchanged, `eval-report.json` at course root and NOT at CWD, full shape
+  `{cases: 3, accuracy: 2/3}`, confirmation line); overwrite second run
+  (WARNING + exit 0); `build --target webr` round-trip (`67%` in
+  `eval-results.html`); N1 refusal (exit 1, names `blendtutor.toml`, no file);
+  N3 refusal (exit 1, names both flags).
+
+The positive path in the transcript is the same wire shape the wiremock tests
+pin (`crates/cli/tests/common/mod.rs` `feedback_body`), so transcript and
+suite corroborate each other.

--- a/docs/evidence/230/cli-transcript.log
+++ b/docs/evidence/230/cli-transcript.log
@@ -1,0 +1,56 @@
+# E2E transcript — issue #230 eval --write-report (real binary, local mock provider)
+
+## eval --help advertises --write-report
+$ blendtutor eval --help | grep -- --write-report
+      --write-report
+
+## positive: eval --write-report from NON-course-root CWD (mock provider on 127.0.0.1:8765)
+$ cd /tmp-ish/other-cwd && blendtutor eval <course>/demo_lesson.yaml --write-report
+Accuracy: 2/3 (66.7%)
+
+case 1: expected correct, got correct [match]
+case 2: expected incorrect, got incorrect [match]
+case 3: expected correct, got incorrect [mismatch]
+  grader: gamma is off
+
+mismatched cases: 3
+inspect one: blendtutor eval <lesson> --case N
+grading is shaped by the lesson's `llm_evaluation_prompt` and each exercise's reference `solution`
+wrote eval-report.json to /private/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/opencode/evidence-230/course/eval-report.json
+exit=0
+
+## written artifact (at course root, NOT at CWD)
+$ ls course/eval-report.json . && cat course/eval-report.json
+/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/opencode/evidence-230/course/eval-report.json
+no eval-report.json at CWD: confirmed
+{"cases":[{"expected":"correct","actual":"correct","matched":true,"feedback_message":"alpha looks right"},{"expected":"incorrect","actual":"incorrect","matched":true,"feedback_message":"beta is off"},{"expected":"correct","actual":"incorrect","matched":false,"feedback_message":"gamma is off"}],"accuracy":0.6666666666666666}
+## overwrite warns and proceeds
+$ blendtutor eval <course>/demo_lesson.yaml --write-report (second run)
+Accuracy: 2/3 (66.7%)
+
+case 1: expected correct, got correct [match]
+case 2: expected incorrect, got incorrect [match]
+case 3: expected correct, got incorrect [mismatch]
+  grader: gamma is off
+
+mismatched cases: 3
+inspect one: blendtutor eval <lesson> --case N
+grading is shaped by the lesson's `llm_evaluation_prompt` and each exercise's reference `solution`
+WARNING: overwriting existing eval report at /private/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/opencode/evidence-230/course/eval-report.json
+wrote eval-report.json to /private/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/opencode/evidence-230/course/eval-report.json
+exit=0
+
+## build round-trip: build consumes the written report
+$ blendtutor build --target webr course -o site && grep accuracy site/eval-results.html
+built 1 lesson(s) for webr into /var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/opencode/evidence-230/site
+67%
+
+## N1: no blendtutor.toml ancestor refuses before scoring
+Error: --write-report: no blendtutor.toml course root found above /private/var/folders/np/n0s92vd91p597552_mh5tt6r0000gn/T/opencode/evidence-230/no-course/demo_lesson.yaml — an eval report is written at the course root
+exit=1
+no file written: confirmed
+
+## N3: --case 1 --write-report refused, names both flags
+Error: --case N and --write-report are incompatible: a single-case report would render as the course-level accuracy in the built site; drop one of the flags
+exit=1
+no .tmp leftover: confirmed

--- a/docs/evidence/230/test-suite.log
+++ b/docs/evidence/230/test-suite.log
@@ -1,0 +1,23 @@
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.52s
+     Running tests/eval.rs (target/debug/deps/eval-93ad8e799f24424c)
+
+running 16 tests
+test eval_help_lists_write_report_flag ... ok
+test eval_case_non_numeric_is_a_parse_error_exit_2 ... ok
+test eval_case_out_of_range_exits_1_naming_the_suite_size ... ok
+test eval_write_report_no_course_root ... ok
+test eval_case_selection_scores_only_the_requested_case ... ok
+test eval_case_mismatch_exit0 ... ok
+test eval_write_report_partial_refused ... ok
+test eval_case_selection_is_one_based ... ok
+test eval_json_emits_per_case_verdicts_and_aggregate ... ok
+test eval_human_full_match_emits_no_footer ... ok
+test eval_human_shows_grader_feedback_and_next_steps_footer ... ok
+test eval_reports_aggregate_accuracy_and_per_case_results ... ok
+test eval_write_report_failure_propagates ... ok
+test eval_write_report_overwrite_warns ... ok
+test eval_write_report_build_roundtrip ... ok
+test eval_write_report_writes_full_shape_report_at_course_root ... ok
+
+test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.91s
+


### PR DESCRIPTION
## Summary
`blendtutor eval <lesson> --write-report` persists the full-shape eval report as `eval-report.json` at the course root (nearest `blendtutor.toml` ancestor, found from the lesson's directory wherever the command runs from) — the durable artifact `build` folds into the site's eval-results page, with no smevals/uvx dependency. Bytes are exactly `serde_json::to_string(&report)`, the same serialization `--format json` stdout uses (single serialization path); `--format` controls stdout only. Overwrite warns and proceeds; `--case N` + `--write-report` and a missing course root are refused before any scoring side effect; write failures propagate with no `.tmp` leftover.

## Issue
Closes #230

## ACs implemented
- [x] Positive: exit 0, human accuracy render unchanged, `<course_root>/eval-report.json` written (NOT at CWD), full shape `{cases: 3, accuracy: 2/3}`, byte-identical to `serde_json::to_string(&report)`, confirmation names the artifact
- [x] N1 no course root → exit 1 naming `blendtutor.toml`, no file, zero provider requests (refusal precedes scoring)
- [x] N2 overwrite → exit 0, stderr "overwrit…" + path, file replaced
- [x] N3 `--case 1 --write-report` → exit 1 naming both flags, no file
- [x] N4 read-only course root → exit 1 naming the write error, no `.tmp` leftover
- [x] Item 7: `eval --help` advertises `--write-report`; 9-subcommand surface untouched (cli.rs pin unchanged)
- [x] Item 8 build round-trip: `build --target webr` consumes the written report; `eval-results.html` shows the derived accuracy (67%)

## Test plan
- [x] RED suite first (5041599): 7 new tests in `crates/cli/tests/eval.rs`, all failing on the absent flag; then green (0592438) — 16/16 in the eval suite, 0 existing tests changed
- [x] Full workspace `cargo test` green; clippy clean; `cargo fmt --check` clean
- [x] E2E evidence: `docs/evidence/230/` — real-binary transcript (local mock provider) covering positive, overwrite, build round-trip, N1, N3 + full test-suite log
- [x] Non-regression: no new subcommand, `OutputFormat`/`EvalReport`/`build.rs`/`eval_report.rs`/`scripts/smevals/` untouched

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec (items 1-8, N1-N4)
- [x] Negative case tested (all four refusal/warning arms)
- [x] Verification medium satisfied (`code` — cargo integration tests, built binary, real file I/O, real build consumer)
- [x] Design intent respected (§1-§5: no new types, single effectful step after emit_eval, existing course_root_for joint, write logic its own fn, doc comment names side effect + filename)
- [x] No scope creep

Plan ref: `.opencode/plans/user-friendliness/plan.md` slice AC-8.