### PR TITLE
docs: README install section reflects published release v0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ curl -LsSf https://raw.githubusercontent.com/mcmullarkey/blendtutor/main/scripts
 ```
 
 Prebuilt binaries for Linux and macOS (x86_64 + aarch64) are on the
-[releases page](https://github.com/mcmullarkey/blendtutor/releases). To build
-from source instead:
+[releases page](https://github.com/mcmullarkey/blendtutor/releases); verify
+against `sha256sums.txt` in the same release. To build from source instead:
 
 ```bash
 cargo install --path crates/cli

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ to `~/.local/bin`, override with `BLENDTUTOR_INSTALL_DIR`):
 curl -LsSf https://raw.githubusercontent.com/mcmullarkey/blendtutor/main/scripts/install.sh | sh
 ```
 
-No release assets are published yet — until the next release, install from a clone:
+Prebuilt binaries for Linux and macOS (x86_64 + aarch64) are on the
+[releases page](https://github.com/mcmullarkey/blendtutor/releases). To build
+from source instead:
 
 ```bash
-git clone https://github.com/mcmullarkey/blendtutor.git
-cd blendtutor
 cargo install --path crates/cli
 ```
 


### PR DESCRIPTION
## Summary
Release v0.1.1 is published with 5 assets (4 tarballs + sha256sums.txt) and the `curl | sh` install one-liner was verified end-to-end (`blendtutor 0.1.1`). The README install section still carried the stale caveat "No release assets are published yet — until the next release, install from a clone". Replaced it with a link to the releases page (prebuilt binaries for Linux and macOS, x86_64 + aarch64); `cargo install --path crates/cli` kept as the build-from-source fallback.

## Context
Release v0.1.1 published — install caveat now stale. Fast-track docs change (no plan ref).

## Changes
- README.md install section: caveat → releases-page link + cargo fallback (3 insertions, 3 deletions, 150 lines total — within the ≤150 concision ceiling)

## Pin-test audit (before editing)
- `scripts/tests/test_quarto_distribution.sh` — no caveat/curl/releases pin
- `scripts/tests/test_demo_docs.sh` — c9 region band (60–149) and c12 ceiling (≤150) unaffected (same 7-for-7 line swap; demo-book URL stays at line 119)
- `crates/cli/tests/readme.rs` — pins `("binary install", "cargo install")`; `cargo install` retained

## Test plan
- [x] `bash scripts/tests/test_quarto_distribution.sh` — 91 passed
- [x] `bash scripts/tests/test_demo_docs.sh` — 22 passed
- [x] `cargo test -p blendtutor-cli --test readme` — 1 passed
- [x] `wc -l README.md` — 150 ≤ 150